### PR TITLE
fix(team/gps): mostrar hora en TZ del tenant (no del browser)

### DIFF
--- a/apps/web/src/app/(dashboard)/team/components/GpsActivityMap.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/GpsActivityMap.tsx
@@ -3,6 +3,7 @@
 import { MapContainer, TileLayer, Polyline, CircleMarker, Tooltip, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EventoGpsDelDia } from '@/services/api/teamLocation';
+import { useFormatters } from '@/hooks/useFormatters';
 
 interface GpsActivityMapProps {
   eventos: EventoGpsDelDia[];
@@ -36,6 +37,8 @@ const ICON_BY_TYPE: Record<string, string> = {
  * (Leaflet manipula `window` directamente — falla en server-render).
  */
 export default function GpsActivityMap({ eventos }: GpsActivityMapProps) {
+  const { formatDate } = useFormatters();
+
   if (eventos.length === 0) {
     return (
       <div className="flex items-center justify-center h-64 bg-surface-3 rounded-lg text-sm text-muted-foreground">
@@ -64,7 +67,7 @@ export default function GpsActivityMap({ eventos }: GpsActivityMapProps) {
         {eventos.map((ev, i) => {
           const color = COLOR_BY_TYPE[ev.tipo] ?? '#94a3b8';
           const icon = ICON_BY_TYPE[ev.tipo] ?? '📍';
-          const hora = new Date(ev.cuando).toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' });
+          const hora = formatDate(ev.cuando, { hour: '2-digit', minute: '2-digit' });
           return (
             <CircleMarker
               key={`${ev.tipo}-${ev.referenciaId ?? 'np'}-${i}`}

--- a/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
@@ -1419,8 +1419,7 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
               <GpsActivityMap eventos={gpsEventos} />
               <div className="space-y-3">
               {gpsEventos.map((ev, i) => {
-                const cuando = new Date(ev.cuando);
-                const hora = cuando.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' });
+                const hora = formatDate(ev.cuando, { hour: '2-digit', minute: '2-digit' });
                 const tipoIcon = ev.tipo === 'visita' ? '👥' : ev.tipo === 'parada' ? '🛣️' : ev.tipo === 'cobro' ? '💰' : ev.tipo === 'checkpoint' ? '📍' : '🛒';
                 const tipoLabel = ev.tipo === 'visita' ? t('gpsActivity.visitTo') : ev.tipo === 'parada' ? t('gpsActivity.arrivedAtStop') : ev.tipo === 'checkpoint' ? t('gpsActivity.checkpoint') : t('gpsActivity.orderCreated');
                 const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${ev.latitud},${ev.longitud}`;


### PR DESCRIPTION
Pings GPS se almacenan en UTC (correcto) pero el web los renderizaba con toLocaleTimeString('es-MX', ...) — eso usa la TZ del navegador, no la configurada por el tenant en /settings.

Resultado: vendedor en Mazatlán (UTC-7) reportaba "21:21" en lugar de "14:21" porque el server side render usaba UTC del container.

Fix: useFormatters ya lee timezone desde CompanyContext (reactivo a cambios en /settings sin reload). Reemplazar las dos llamadas raw a toLocaleTimeString con formatDate(date, { hour, minute }).

Componentes afectados:
- GpsActivityMap (tooltip + popup de marcadores en mapa Leaflet)
- MiembrosTab (timeline de eventos GPS en drawer del vendedor)