### PR TITLE
fix(web): normalizar DateTimes sin Z a UTC (chip GPS atascado en "hac…

### DIFF
--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -29,7 +29,14 @@ export function formatDate(
   if (!date) return '';
   const tz = settings?.timezone || 'America/Mexico_City';
   const locale = getLocale(settings);
-  const d = typeof date === 'string' ? new Date(date) : date;
+  // Defensa: backend a veces serializa DateTime sin sufijo 'Z' (Npgsql legacy
+  // mode con Kind=Unspecified). new Date() los interpreta como local → la
+  // conversión a TZ del tenant queda mal. Forzamos UTC si falta marker.
+  const normalized = typeof date === 'string'
+    && !/[Zz]$|[+-]\d{2}:?\d{2}$/.test(date)
+    ? date + 'Z'
+    : date;
+  const d = typeof normalized === 'string' ? new Date(normalized) : normalized;
   if (isNaN(d.getTime())) return '';
   return d.toLocaleString(locale, { timeZone: tz, ...options });
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -72,10 +72,17 @@ export function formatTimeAgo(dateStr: string): string {
   try { const s = JSON.parse(localStorage.getItem('company_settings') || '{}'); lang = s.language || 'es'; } catch { /* */ }
   const en = lang === 'en'
 
+  // Defensa: si el backend manda DateTime con Kind=Unspecified queda sin sufijo
+  // 'Z' y `new Date(str)` lo interpreta como hora LOCAL → diff negativo →
+  // chip atascado en "hace unos segundos". Forzamos UTC si no hay marker de TZ.
+  const normalized = dateStr && !/[Zz]$|[+-]\d{2}:?\d{2}$/.test(dateStr)
+    ? dateStr + 'Z'
+    : dateStr;
+
   const now = new Date()
-  const date = new Date(dateStr)
+  const date = new Date(normalized)
   const diffMs = now.getTime() - date.getTime()
-  const diffSec = Math.floor(diffMs / 1000)
+  const diffSec = Math.max(0, Math.floor(diffMs / 1000))
   const diffMin = Math.floor(diffSec / 60)
   const diffHr = Math.floor(diffMin / 60)
   const diffDays = Math.floor(diffHr / 24)

--- a/apps/web/src/services/api/teamLocation.ts
+++ b/apps/web/src/services/api/teamLocation.ts
@@ -1,5 +1,18 @@
 import { api, handleApiError } from '@/lib/api';
 
+/**
+ * Backend serializa DateTimes (Kind=Unspecified por Npgsql legacy mode) sin
+ * sufijo 'Z'. Sin Z, `new Date(str)` los interpreta como hora LOCAL del browser
+ * → diff negativo → formatTimeAgo se queda en "hace unos segundos" eterno.
+ * Normalizamos a UTC explícito en el client API.
+ */
+function ensureUtc(value: string): string {
+  if (!value) return value;
+  // Ya tiene Z u offset (+/-HH:MM): respetar
+  if (/[Zz]$|[+-]\d{2}:?\d{2}$/.test(value)) return value;
+  return value + 'Z';
+}
+
 export type FuenteUbicacion = 'visita' | 'parada' | 'pedido' | 'cobro' | 'checkpoint' | 'inicio_ruta' | 'fin_ruta' | 'tracking';
 
 export interface UltimaUbicacionVendedor {
@@ -37,7 +50,7 @@ class TeamLocationService {
   async getUltimasUbicaciones(): Promise<UltimaUbicacionVendedor[]> {
     try {
       const response = await api.get<UltimaUbicacionVendedor[]>(`${this.basePath}/ubicaciones-recientes`);
-      return response.data;
+      return response.data.map(u => ({ ...u, ultimaActividad: ensureUtc(u.ultimaActividad) }));
     } catch (error) {
       throw handleApiError(error);
     }
@@ -47,7 +60,10 @@ class TeamLocationService {
     try {
       const params = dia ? `?dia=${encodeURIComponent(dia)}` : '';
       const response = await api.get<ActividadGpsDelDia>(`${this.basePath}/usuarios/${usuarioId}/actividad-gps${params}`);
-      return response.data;
+      return {
+        ...response.data,
+        eventos: response.data.eventos.map(ev => ({ ...ev, cuando: ensureUtc(ev.cuando) })),
+      };
     } catch (error) {
       throw handleApiError(error);
     }


### PR DESCRIPTION
…e unos segundos")

Bug: backend serializa DateTime con Kind=Unspecified (Npgsql legacy mode) sin sufijo 'Z'. `new Date(str)` sin Z interpreta como hora LOCAL del browser → fecha queda en el "futuro" UTC → diff negativo en formatTimeAgo → condición `diffSec < 60` matchea siempre → "hace unos segundos" eterno.

Mismo síntoma en formatDate: el toLocaleString con timeZone shift produce hora incorrecta porque parte de un parse local-misconstrued.

Fix en 3 capas defensivas:
1. teamLocation.ts: ensureUtc() en respuestas del API antes de devolverlas.
2. formatTimeAgo: normaliza el string si no tiene Z u offset; clamp a 0 con Math.max para futuros parseos negativos.
3. formatDate: misma normalización.

Resultado: chip ahora envejece correctamente (hace 5 min, hace 25 min, etc) y la hora absoluta en el drawer respeta TZ del tenant.