### PR TITLE
Promote staging → main: tracking GPS + IVA backend + UI fixes

### DIFF
--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -361,14 +361,23 @@ export default function OrdersPage() {
       });
 
       const clientFromCatalog = clients.find(c => c.id === detail.clienteId.toString());
+      const resolvedClient = clientFromCatalog ?? {
+        ...listOrder.client,
+        id: detail.clienteId.toString(),
+        name: detail.clienteNombre,
+        address: detail.clienteDireccion ?? '',
+      };
+
+      // Sin esto, si el cliente del pedido no está en `clients` (cache de 100
+      // primeros), el SearchableSelect del drawer se ve vacío. Inyectamos el
+      // cliente del pedido al array para que el dropdown lo muestre.
+      if (!clientFromCatalog) {
+        setClients(prev => [...prev, resolvedClient as Client]);
+      }
+
       const fullOrder: Order = {
         ...listOrder,
-        client: clientFromCatalog ?? {
-          ...listOrder.client,
-          id: detail.clienteId.toString(),
-          name: detail.clienteNombre,
-          address: detail.clienteDireccion ?? '',
-        },
+        client: resolvedClient,
         clientId: detail.clienteId.toString(),
         items: detalleItems,
         subtotal: detail.subtotal,


### PR DESCRIPTION
## Summary
Promoción staging→prod (commits acumulados desde el último merge a main).

**Fixes principales**
- 4f9fc335 drawer detalle de pedido muestra cliente fuera del cap de 100 (Jeyma 167 clientes)
- 6f4c142d doble dollar-dollar en /orders mobile card (literal antes de formatCurrency)
- 6cebe82b backend SyncRepository.UpsertPedidoAsync respeta PrecioIncluyeIva + tasa por producto (resuelve doble-IVA en pedidos pusheados desde mobile)
- 03b68a18 DateTimes sin Z parseados como UTC (chip GPS atascado en hace unos segundos)
- 415adc1b hora GPS en TZ del tenant (no del browser) — useFormatters reactivo
- 046e25a1 CSP permite Google Maps + Leaflet tiles

## Pre-Push Deployment Checklist
- DB prod: migrations tracking-vendedor + flag PRO + Jeyma linkeado (aplicado earlier today)
- DB prod: IVA fix de pedidos abril aplicado
- Pedidos mayo (IDs 10-16) en prod siguen con doble-IVA en total — backfill SQL manual post-merge
- APK nuevo: distribución a vendedores cuando el usuario lo confirme
- Sin nuevos env vars
- xUnit tests passing (104 sync+pedido)
- Playwright pasa: GPS chip aging, doble dollar-dollar resuelto, maps cargan, drawer cliente OK

## Test Plan post-merge
- CI workflow aplica build .NET sin errores
- Verificar app.handysuites.com/orders (mobile DevTools): no aparece dollar-dollar
- Verificar /team chip: muestra hace X min no hace unos segundos
- Crear pedido prueba desde web admin: total = subtotal (sin doble-IVA)
- Click en pedido cuyo cliente está fuera del top 100 → drawer muestra el cliente
- Backfill manual de pedidos mayo IDs 10-16 (cuando confirmes el deploy completo)