### PR TITLE
Feat/venta ux acelerada

### DIFF
--- a/apps/mobile-app/app/(tabs)/vender/crear/index.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/crear/index.tsx
@@ -1,14 +1,16 @@
-import { useState, useCallback, useEffect } from 'react';
-import { View, Text, FlatList, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { View, Text, FlatList, ScrollView, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useOfflineClients } from '@/hooks';
+import { useNearbyClients } from '@/hooks/useNearbyClients';
+import { useRecentClients } from '@/hooks/useRecentClients';
 import { useOrderDraftStore } from '@/stores';
 import { ProgressSteps } from '@/components/shared/ProgressSteps';
 import { withErrorBoundary } from '@/components/shared/withErrorBoundary';
 import { LoadingSpinner, EmptyState, Button } from '@/components/ui';
 import { COLORS } from '@/theme/colors';
-import { User, Search, Check, ChevronLeft } from 'lucide-react-native';
+import { User, Search, Check, ChevronLeft, MapPin, Clock } from 'lucide-react-native';
 import type Cliente from '@/db/models/Cliente';
 
 const STEPS = ['Cliente', 'Productos', 'Revisar'];
@@ -33,6 +35,11 @@ function CrearPedidoStep1() {
   }, []);
 
   const { data: clientes, isLoading } = useOfflineClients(busqueda || undefined);
+  // Cercanos por GPS (offline, Haversine local). Solo se ejecuta si el
+  // dispositivo tiene permiso GPS y los clientes tienen lat/lng poblados.
+  const { nearby } = useNearbyClients(0.5, 5);
+  // Recientes (clientes con pedidos del vendedor en últimos 7 días).
+  const { recents } = useRecentClients(7, 5);
 
   const handleSelect = useCallback(
     (cliente: Cliente) => {
@@ -41,11 +48,37 @@ function CrearPedidoStep1() {
     [setCliente]
   );
 
+  // Selecciona Y avanza inmediatamente — para cards de Cercanos/Recientes,
+  // el vendedor ya tiene confianza en el cliente (1 tap reemplaza el patrón
+  // "tap card + tap Continuar"). Acelera el flujo.
+  const handleSelectAndContinue = useCallback(
+    (cliente: Cliente) => {
+      setCliente(cliente.id, cliente.serverId, cliente.nombre, cliente.listaPreciosId);
+      router.push('/(tabs)/vender/crear/productos' as any);
+    },
+    [setCliente, router]
+  );
+
   const handleContinue = () => {
     if (clienteId) {
       router.push('/(tabs)/vender/crear/productos' as any);
     }
   };
+
+  // Set de IDs ya mostrados en secciones top para no duplicarlos en la lista
+  // alfabética principal.
+  const idsTop = useMemo(() => {
+    const s = new Set<string>();
+    nearby.forEach(n => s.add(n.cliente.id));
+    recents.forEach(r => s.add(r.cliente.id));
+    return s;
+  }, [nearby, recents]);
+
+  const clientesFiltrados = useMemo(() => {
+    if (!clientes) return [];
+    if (busqueda) return clientes; // si está buscando, no filtramos por dedup
+    return clientes.filter(c => !idsTop.has(c.id));
+  }, [clientes, busqueda, idsTop]);
 
   const renderItem = useCallback(
     ({ item }: { item: Cliente }) => {
@@ -121,7 +154,7 @@ function CrearPedidoStep1() {
         <LoadingSpinner message="Cargando clientes..." />
       ) : (
         <FlatList
-          data={clientes ?? []}
+          data={clientesFiltrados}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={styles.listContent}
@@ -130,6 +163,92 @@ function CrearPedidoStep1() {
           windowSize={5}
           removeClippedSubviews
           keyboardShouldPersistTaps="handled"
+          ListHeaderComponent={
+            // Solo mostrar secciones especiales si NO hay búsqueda activa.
+            // Cuando vendedor escribe en el buscador, esperar resultados sobre
+            // toda la lista, no atascar con cercanos/recientes irrelevantes.
+            busqueda ? null : (
+              <View>
+                {nearby.length > 0 && (
+                  <View style={styles.section}>
+                    <View style={styles.sectionHeader}>
+                      <MapPin size={14} color={COLORS.button} />
+                      <Text style={styles.sectionTitle}>Cercanos a ti</Text>
+                    </View>
+                    <ScrollView
+                      horizontal
+                      showsHorizontalScrollIndicator={false}
+                      contentContainerStyle={styles.nearbyScroll}
+                    >
+                      {nearby.map(({ cliente, distanciaM }) => {
+                        const isSelected = clienteId === cliente.id;
+                        return (
+                          <TouchableOpacity
+                            key={cliente.id}
+                            style={[styles.nearbyCard, isSelected && styles.nearbyCardSelected]}
+                            onPress={() => handleSelectAndContinue(cliente)}
+                            activeOpacity={0.85}
+                            accessibilityLabel={`Vender a ${cliente.nombre}, a ${Math.round(distanciaM)} metros`}
+                            accessibilityRole="button"
+                          >
+                            <View style={styles.nearbyAvatar}>
+                              <MapPin size={16} color="#ffffff" />
+                            </View>
+                            <Text style={styles.nearbyName} numberOfLines={1}>
+                              {cliente.nombre}
+                            </Text>
+                            <Text style={styles.nearbyDistance}>
+                              {distanciaM < 1000
+                                ? `${Math.round(distanciaM)} m`
+                                : `${(distanciaM / 1000).toFixed(1)} km`}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </ScrollView>
+                  </View>
+                )}
+                {recents.length > 0 && (
+                  <View style={styles.section}>
+                    <View style={styles.sectionHeader}>
+                      <Clock size={14} color="#64748b" />
+                      <Text style={styles.sectionTitle}>Recientes</Text>
+                    </View>
+                    {recents.map(({ cliente }) => {
+                      const isSelected = clienteId === cliente.id;
+                      return (
+                        <TouchableOpacity
+                          key={cliente.id}
+                          style={[styles.clientItem, isSelected && styles.clientItemSelected]}
+                          onPress={() => handleSelectAndContinue(cliente)}
+                          activeOpacity={0.7}
+                          accessibilityLabel={`Cliente reciente ${cliente.nombre}`}
+                          accessibilityRole="button"
+                        >
+                          <View style={[styles.clientAvatar, isSelected && styles.clientAvatarSelected]}>
+                            <Clock size={18} color={isSelected ? '#ffffff' : '#64748b'} />
+                          </View>
+                          <View style={styles.clientInfo}>
+                            <Text style={[styles.clientName, isSelected && styles.clientNameSelected]}>
+                              {cliente.nombre}
+                            </Text>
+                            {cliente.telefono && (
+                              <Text style={styles.clientPhone}>{cliente.telefono}</Text>
+                            )}
+                          </View>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                )}
+                {(nearby.length > 0 || recents.length > 0) && (
+                  <View style={styles.sectionHeader}>
+                    <Text style={[styles.sectionTitle, { color: '#94a3b8' }]}>Todos los clientes</Text>
+                  </View>
+                )}
+              </View>
+            )
+          }
           ListEmptyComponent={
             <EmptyState
               icon={<User size={48} color="#cbd5e1" />}
@@ -215,6 +334,52 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     borderTopWidth: 1,
     borderTopColor: '#f1f5f9',
+  },
+  // Secciones "Cercanos" y "Recientes" en el header del FlatList
+  section: { marginTop: 8 },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  sectionTitle: { fontSize: 12, fontWeight: '700', color: '#475569', textTransform: 'uppercase', letterSpacing: 0.5 },
+  nearbyScroll: { paddingHorizontal: 16, gap: 10, paddingBottom: 4 },
+  nearbyCard: {
+    width: 140,
+    padding: 12,
+    backgroundColor: '#ffffff',
+    borderRadius: 14,
+    borderWidth: 2,
+    borderColor: '#dcfce7',
+    marginRight: 10,
+    alignItems: 'center',
+  },
+  nearbyCardSelected: {
+    borderColor: COLORS.button,
+    backgroundColor: COLORS.buttonLight,
+  },
+  nearbyAvatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    backgroundColor: '#16a34a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+  },
+  nearbyName: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#1e293b',
+    textAlign: 'center',
+    marginBottom: 2,
+  },
+  nearbyDistance: {
+    fontSize: 11,
+    color: '#16a34a',
+    fontWeight: '600',
   },
 });
 

--- a/apps/mobile-app/app/(tabs)/vender/crear/modo.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/crear/modo.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, BackHandler } from 'react-nat
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useOrderDraftStore } from '@/stores';
+import { useEmpresa } from '@/hooks/useEmpresa';
 import { ClipboardList, Truck, ChevronLeft } from 'lucide-react-native';
 import { COLORS } from '@/theme/colors';
 import Animated, { FadeInDown } from 'react-native-reanimated';
@@ -13,6 +14,8 @@ export default function ModoVentaScreen() {
   const { setTipoVenta, reset, clienteId } = useOrderDraftStore();
   const { fromParada } = useLocalSearchParams<{ fromParada?: string }>();
   const [selected, setSelected] = useState<number | null>(null);
+  const { data: empresa } = useEmpresa();
+  const modoDefault = empresa?.modoVentaDefault ?? 'Preguntar';
 
   const handleBack = useCallback(() => {
     if (fromParada) {
@@ -32,7 +35,7 @@ export default function ModoVentaScreen() {
     return () => handler.remove();
   }, [fromParada, handleBack]);
 
-  const handleSelect = (tipo: number) => {
+  const handleSelect = useCallback((tipo: number) => {
     setSelected(tipo);
     // If coming from parada, DON'T reset — client is already set
     if (!fromParada) {
@@ -45,7 +48,19 @@ export default function ModoVentaScreen() {
     } else {
       router.replace('/(tabs)/vender/crear' as any);
     }
-  };
+  }, [fromParada, reset, setTipoVenta, clienteId, router]);
+
+  // Auto-skip cuando admin configuró un modo default (Preventa o VentaDirecta).
+  // Saltamos esta pantalla totalmente y avanzamos al siguiente paso. Solo si
+  // el dato ya cargó del backend (empresa != null).
+  useEffect(() => {
+    if (!empresa) return;
+    if (modoDefault === 'Preventa') {
+      handleSelect(0);
+    } else if (modoDefault === 'VentaDirecta') {
+      handleSelect(1);
+    }
+  }, [empresa, modoDefault, handleSelect]);
 
   return (
     <View style={styles.container}>

--- a/apps/mobile-app/app/(tabs)/vender/crear/productos.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/crear/productos.tsx
@@ -7,6 +7,7 @@ import { useOrderDraftStore, useOrderItemCount } from '@/stores';
 import { usePricingMap } from '@/hooks/usePricing';
 import { ProgressSteps } from '@/components/shared/ProgressSteps';
 import { QuantityStepper } from '@/components/shared/QuantityStepper';
+import { QuantityNumericSheet } from '@/components/shared/QuantityNumericSheet';
 import { CartBar } from '@/components/shared/CartBar';
 import { EmptyState } from '@/components/ui';
 import { COLORS } from '@/theme/colors';
@@ -49,6 +50,10 @@ function CrearPedidoStep2() {
   const addItem = useOrderDraftStore(s => s.addItem);
   const updateQuantity = useOrderDraftStore(s => s.updateQuantity);
   const removeItem = useOrderDraftStore(s => s.removeItem);
+
+  // Producto seleccionado para abrir el sheet de cantidad numérica.
+  // null = sheet cerrado. Setear con un Producto = abrir.
+  const [qtyProduct, setQtyProduct] = useState<Producto | null>(null);
   const tipoVenta = useOrderDraftStore(s => s.tipoVenta);
   const itemCount = useOrderItemCount();
   const isDirecta = tipoVenta === 1;
@@ -122,7 +127,21 @@ function CrearPedidoStep2() {
       const pricing = getPricing(item.serverId ?? 0, item.precio, qty || 1);
 
       return (
-        <View style={[styles.productCard, blocked && { opacity: 0.5 }]}>
+        <TouchableOpacity
+          style={[styles.productCard, blocked && { opacity: 0.5 }]}
+          onPress={() => {
+            // Tap en el card abre el sheet con teclado numérico para
+            // capturar cantidad rápidamente (1 tap → escribir → confirmar
+            // vs N taps en stepper). El stepper visible sigue disponible
+            // para ajustes finos (+1/-1) cuando ya hay qty.
+            if (blocked) return;
+            setQtyProduct(item);
+          }}
+          activeOpacity={blocked ? 1 : 0.85}
+          disabled={blocked}
+          accessibilityLabel={`Capturar cantidad de ${item.nombre}`}
+          accessibilityRole="button"
+        >
           <View style={styles.productRow}>
             {item.imagenUrl ? (
               <Image source={{ uri: item.imagenUrl }} style={styles.productImage} resizeMode="cover" />
@@ -174,7 +193,10 @@ function CrearPedidoStep2() {
               ) : (
                 <TouchableOpacity
                   style={styles.addButton}
-                  onPress={() => addItem(item, 1, pricing.precioFinal)}
+                  onPress={(e) => {
+                    e.stopPropagation();
+                    setQtyProduct(item);
+                  }}
                   activeOpacity={0.7}
                   accessibilityLabel={`Agregar ${item.nombre}`}
                   accessibilityRole="button"
@@ -185,10 +207,10 @@ function CrearPedidoStep2() {
               )}
             </View>
           </View>
-        </View>
+        </TouchableOpacity>
       );
     },
-    [items, addItem, updateQuantity, removeItem, isDirecta, getPricing]
+    [items, updateQuantity, removeItem, isDirecta, getPricing]
   );
 
   return (
@@ -275,6 +297,30 @@ function CrearPedidoStep2() {
         onPress={() => router.push('/(tabs)/vender/crear/revision' as any)}
         label="Revisar pedido"
       />
+
+      {qtyProduct && (
+        <QuantityNumericSheet
+          visible={!!qtyProduct}
+          productoNombre={qtyProduct.nombre}
+          precioUnitario={getPricing(qtyProduct.serverId ?? 0, qtyProduct.precio, getItemQuantity(qtyProduct.id) || 1).precioFinal}
+          formatCurrency={formatCurrency}
+          initialQty={getItemQuantity(qtyProduct.id) || 1}
+          maxQty={qtyProduct.stockDisponible ?? 9999}
+          onClose={() => setQtyProduct(null)}
+          onConfirm={(qty) => {
+            const existingQty = getItemQuantity(qtyProduct.id);
+            const pricing = getPricing(qtyProduct.serverId ?? 0, qtyProduct.precio, qty);
+            if (qty <= 0) {
+              if (existingQty > 0) removeItem(qtyProduct.id);
+            } else if (existingQty > 0) {
+              updateQuantity(qtyProduct.id, qty);
+            } else {
+              addItem(qtyProduct, qty, pricing.precioFinal);
+            }
+            setQtyProduct(null);
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/apps/mobile-app/app/(tabs)/vender/crear/revision.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/crear/revision.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { View, Text, ScrollView, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -55,6 +56,26 @@ function CrearPedidoStep3() {
   } = useOrderDraftStore();
 
   const subtotalRaw = useOrderSubtotal();
+
+  // Recordar último método de pago del vendedor en AsyncStorage. Al abrir
+  // revisión, pre-seleccionamos el último que usó (ahorra 1 tap del modal de
+  // pago en 90% de los casos donde el vendedor cobra siempre del mismo modo).
+  const lastMetodoKey = `last_metodo_pago_${user?.id ?? 'default'}`;
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(lastMetodoKey);
+        if (!cancelled && stored != null) {
+          const parsed = parseInt(stored, 10);
+          if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 5) {
+            setMetodoPago(parsed);
+          }
+        }
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [lastMetodoKey, setMetodoPago]);
 
   const isDirecta = tipoVenta === 1;
   const clienteListaPreciosId = useOrderDraftStore(s => s.clienteListaPreciosId);
@@ -145,6 +166,8 @@ function CrearPedidoStep3() {
       if (isDirecta) {
         const montoTotal = total;
         const metodo = metodoPago ?? 0;
+        // Persistir último método para próxima venta del mismo vendedor.
+        AsyncStorage.setItem(lastMetodoKey, String(metodo)).catch(() => {});
         const nombre = clienteNombre || 'Cliente';
         const paradaId = useOrderDraftStore.getState().fromParadaId;
         // Pedido + Cobro + parada.Completada en una sola transacción WDB:

--- a/apps/mobile-app/app/(tabs)/vender/index.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/index.tsx
@@ -7,6 +7,7 @@ import { View, Text, FlatList, RefreshControl, ScrollView, TouchableOpacity, Sty
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useOfflineOrders, useClientNameMap } from '@/hooks';
+import { useEmpresa } from '@/hooks/useEmpresa';
 import { useAuthStore, useOrderDraftStore } from '@/stores';
 import { Card, LoadingSpinner, EmptyState, BottomSheet } from '@/components/ui';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -36,6 +37,11 @@ function VenderListScreenContent() {
   const router = useRouter();
   const role = useAuthStore(s => s.user?.role);
   const { setTipoVenta, reset: resetDraft } = useOrderDraftStore();
+  const { data: empresa } = useEmpresa();
+  // Modo default configurado por el admin del tenant. Si != "Preguntar",
+  // saltamos el BottomSheet y vamos directo al picker de cliente con el
+  // modo pre-seleccionado. Acelera el flujo de venta.
+  const modoDefault = empresa?.modoVentaDefault ?? 'Preguntar';
 
   const _role = role; // kept for future role-based filtering
 
@@ -55,6 +61,16 @@ function VenderListScreenContent() {
   const total = orders.length;
 
   const handleFabPress = () => {
+    // Si admin configuró un modo default (no "Preguntar"), saltamos el sheet
+    // de selección y vamos directo al picker de cliente con el modo seteado.
+    if (modoDefault === 'Preventa') {
+      handleOrderTypeSelect(0);
+      return;
+    }
+    if (modoDefault === 'VentaDirecta') {
+      handleOrderTypeSelect(1);
+      return;
+    }
     setShowOrderTypeSheet(true);
   };
 

--- a/apps/mobile-app/app/_layout.tsx
+++ b/apps/mobile-app/app/_layout.tsx
@@ -87,6 +87,11 @@ function LocationTrackingBridge() {
   useEffect(() => {
     if (isAuthenticated && !hidratada) {
       hidratarDesdeStorage();
+      // Tomar la última config de empresa persistida (horario laboral, modo
+      // venta default). Si la app está sin red al startup, esto evita que
+      // recordPing decida con valores nulos y haga auto-start spam fuera de
+      // horario. El useEmpresa la sobrescribirá con datos frescos al fetch.
+      import('@/utils/empresaConfigSnapshot').then(m => m.hydrateEmpresaConfigSnapshot()).catch(() => {});
     }
   }, [isAuthenticated, hidratada, hidratarDesdeStorage]);
 

--- a/apps/mobile-app/src/components/shared/QuantityNumericSheet.tsx
+++ b/apps/mobile-app/src/components/shared/QuantityNumericSheet.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { BottomSheet } from '@/components/ui';
+import { COLORS } from '@/theme/colors';
+import { Delete } from 'lucide-react-native';
+
+interface QuantityNumericSheetProps {
+  visible: boolean;
+  productoNombre: string;
+  precioUnitario: number;
+  formatCurrency: (n: number) => string;
+  initialQty?: number;
+  maxQty?: number;
+  onClose: () => void;
+  onConfirm: (qty: number) => void;
+}
+
+const KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '⌫', '0', '✓'];
+
+/**
+ * Sheet con teclado numérico grande para capturar cantidad de un producto.
+ * Reemplaza el patrón "tap +1 cinco veces" por "1 tap → escribir → confirmar".
+ *
+ * Reduce friction principal del flujo de venta cuando vendedor tiene que
+ * ingresar cantidades grandes (ej: 24 sodas) que con stepper +/- toma 24 taps.
+ */
+export function QuantityNumericSheet({
+  visible,
+  productoNombre,
+  precioUnitario,
+  formatCurrency,
+  initialQty = 1,
+  maxQty = 9999,
+  onClose,
+  onConfirm,
+}: QuantityNumericSheetProps) {
+  const [value, setValue] = useState(String(initialQty));
+  const [isFresh, setIsFresh] = useState(true);
+
+  // Re-sincronizar al abrir el sheet con un nuevo producto
+  useEffect(() => {
+    if (visible) {
+      setValue(String(initialQty));
+      setIsFresh(true);
+    }
+  }, [visible, initialQty]);
+
+  const numericValue = Math.max(0, parseInt(value || '0', 10) || 0);
+  const totalLine = numericValue * precioUnitario;
+  const exceedsMax = numericValue > maxQty;
+
+  const press = (k: string) => {
+    if (k === '⌫') {
+      setValue(prev => (prev.length <= 1 ? '0' : prev.slice(0, -1)));
+      setIsFresh(false);
+      return;
+    }
+    if (k === '✓') {
+      if (numericValue > 0 && !exceedsMax) {
+        onConfirm(numericValue);
+      }
+      return;
+    }
+    // Tap de un dígito: si es la primera interacción tras abrir, sustituye
+    // el initial qty (más natural — vendedor no quiere borrar y empezar).
+    if (isFresh) {
+      setValue(k);
+      setIsFresh(false);
+      return;
+    }
+    if (value === '0') {
+      setValue(k);
+      return;
+    }
+    if (value.length >= 5) return; // cap a 99999
+    setValue(prev => prev + k);
+  };
+
+  return (
+    <BottomSheet
+      visible={visible}
+      title={productoNombre}
+      subtitle={`${formatCurrency(precioUnitario)} c/u`}
+      onClose={onClose}
+    >
+      <View style={styles.body}>
+        <View style={styles.displayBox}>
+          <Text style={[styles.displayValue, exceedsMax && styles.displayError]}>
+            {numericValue}
+          </Text>
+          <Text style={styles.displayTotal}>
+            {formatCurrency(totalLine)}
+          </Text>
+          {exceedsMax && (
+            <Text style={styles.errorText}>Excede stock disponible ({maxQty})</Text>
+          )}
+        </View>
+
+        <View style={styles.keypad}>
+          {KEYS.map((k) => {
+            const isConfirm = k === '✓';
+            const isDelete = k === '⌫';
+            const disabled = isConfirm && (numericValue <= 0 || exceedsMax);
+            return (
+              <TouchableOpacity
+                key={k}
+                style={[
+                  styles.key,
+                  isConfirm && styles.keyConfirm,
+                  isDelete && styles.keyDelete,
+                  disabled && styles.keyDisabled,
+                ]}
+                onPress={() => press(k)}
+                disabled={disabled}
+                activeOpacity={0.7}
+                accessibilityLabel={
+                  isConfirm ? 'Confirmar cantidad' : isDelete ? 'Borrar' : `Tecla ${k}`
+                }
+                accessibilityRole="button"
+              >
+                {isDelete ? (
+                  <Delete size={22} color={COLORS.foreground} />
+                ) : (
+                  <Text
+                    style={[
+                      styles.keyText,
+                      isConfirm && styles.keyConfirmText,
+                    ]}
+                  >
+                    {k}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: { paddingHorizontal: 16, paddingBottom: 12 },
+  displayBox: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 14,
+    paddingVertical: 18,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  displayValue: {
+    fontSize: 48,
+    fontWeight: '800',
+    color: COLORS.foreground,
+    lineHeight: 52,
+  },
+  displayError: { color: '#dc2626' },
+  displayTotal: {
+    fontSize: 14,
+    color: COLORS.textSecondary,
+    marginTop: 4,
+    fontWeight: '600',
+  },
+  errorText: { fontSize: 12, color: '#dc2626', marginTop: 4 },
+  keypad: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    rowGap: 10,
+  },
+  key: {
+    width: '31%',
+    aspectRatio: 1.3,
+    backgroundColor: '#f1f5f9',
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  keyText: { fontSize: 24, fontWeight: '700', color: COLORS.foreground },
+  keyConfirm: { backgroundColor: '#16a34a' },
+  keyConfirmText: { color: '#ffffff', fontSize: 26 },
+  keyDelete: { backgroundColor: '#fee2e2' },
+  keyDisabled: { opacity: 0.4 },
+});

--- a/apps/mobile-app/src/hooks/useEmpresa.ts
+++ b/apps/mobile-app/src/hooks/useEmpresa.ts
@@ -27,6 +27,10 @@ export interface DatosEmpresa {
   horaInicioJornada?: string | null;  // formato "HH:mm"
   horaFinJornada?: string | null;     // formato "HH:mm"
   diasLaborables?: string | null;     // CSV "1,2,3,4,5" (1=Lun..7=Dom)
+  // Modo default de venta. "Preventa" | "VentaDirecta" | "Preguntar".
+  // El mobile usa esto para saltar la pantalla de selección de modo y
+  // acelerar el flujo del vendedor cuando el tenant tiene un modo dominante.
+  modoVentaDefault?: string | null;
 }
 
 export function useEmpresa() {

--- a/apps/mobile-app/src/hooks/useEmpresa.ts
+++ b/apps/mobile-app/src/hooks/useEmpresa.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/api/client';
 import { Image } from 'react-native';
+import { setEmpresaConfigSnapshot } from '@/utils/empresaConfigSnapshot';
 
 export interface DatosEmpresa {
   razonSocial: string | null;
@@ -46,6 +47,18 @@ export function useEmpresa() {
       // Prefetch logo into RN image cache so it renders instantly
       if (data?.logoUrl) {
         Image.prefetch(data.logoUrl).catch(() => {});
+      }
+
+      // Snapshot síncrono para que services no-React (recordPing, watchers
+      // que viven fuera del árbol React) puedan leer la config sin estar
+      // suscritos al query.
+      if (data) {
+        setEmpresaConfigSnapshot({
+          horaInicioJornada: data.horaInicioJornada ?? null,
+          horaFinJornada: data.horaFinJornada ?? null,
+          diasLaborables: data.diasLaborables ?? null,
+          modoVentaDefault: data.modoVentaDefault ?? null,
+        }).catch(() => {});
       }
 
       return data;

--- a/apps/mobile-app/src/hooks/useHorarioLaboralWatcher.ts
+++ b/apps/mobile-app/src/hooks/useHorarioLaboralWatcher.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import Toast from 'react-native-toast-message';
 import { useEmpresa } from './useEmpresa';
 import { useJornadaStore } from '@/stores';
+import { enHorarioLaboral } from '@/utils/horarioLaboral';
 
 const CHECK_INTERVAL_MS = 60_000; // 1 min
 
@@ -49,42 +50,5 @@ export function useHorarioLaboralWatcher() {
   }, [empresa, jornadaActiva, finalizarJornada]);
 }
 
-/**
- * Devuelve true si "ahora" cae dentro del horario configurado.
- * - Sin horaInicio ni horaFin → permitido (no hay rango horario).
- * - Sin diasLaborables → permitido cualquier día.
- * - Con uno o ambos → respeta lo que esté configurado.
- *
- * Day mapping: 1=Lun, 2=Mar, ..., 7=Dom (ISO).
- * `Date.getDay()` retorna 0=Dom, 1=Lun..6=Sáb → convertir a ISO.
- */
-function enHorarioLaboral(
-  horaInicio: string | null | undefined,
-  horaFin: string | null | undefined,
-  diasLaborables: string | null | undefined,
-): boolean {
-  const ahora = new Date();
-  const dowJs = ahora.getDay();              // 0=Dom..6=Sáb
-  const dowIso = dowJs === 0 ? 7 : dowJs;    // 1=Lun..7=Dom
-
-  if (diasLaborables) {
-    const setDias = new Set(diasLaborables.split(',').map(s => s.trim()));
-    if (setDias.size > 0 && !setDias.has(String(dowIso))) {
-      return false;
-    }
-  }
-
-  if (horaInicio || horaFin) {
-    const minutosAhora = ahora.getHours() * 60 + ahora.getMinutes();
-    const inicioMin = horaInicio ? toMin(horaInicio) : 0;
-    const finMin = horaFin ? toMin(horaFin) : 24 * 60;
-    if (minutosAhora < inicioMin || minutosAhora >= finMin) return false;
-  }
-
-  return true;
-}
-
-function toMin(hhmm: string): number {
-  const [h, m] = hhmm.split(':').map(n => parseInt(n, 10));
-  return (h || 0) * 60 + (m || 0);
-}
+// Helper `enHorarioLaboral` extraído a `@/utils/horarioLaboral` para que
+// `recordPing` también pueda evaluarlo sin acoplarse a React.

--- a/apps/mobile-app/src/hooks/useNearbyClients.ts
+++ b/apps/mobile-app/src/hooks/useNearbyClients.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { Q } from '@nozbe/watermelondb';
+import { database } from '@/db/database';
+import Cliente from '@/db/models/Cliente';
+import { useObservable } from './useObservable';
+import { useUserLocation } from './useLocation';
+import { haversineMeters } from '@/utils/haversine';
+
+export interface NearbyCliente {
+  cliente: Cliente;
+  distanciaM: number;
+}
+
+const DEFAULT_RADIUS_KM = 0.5; // 500m por default
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Devuelve clientes con coords dentro del radio dado, ordenados por distancia
+ * ascendente. Reactivo: re-evalúa cuando cambia la ubicación del vendedor o
+ * el observable de WatermelonDB. SIN red — Haversine puro JS sobre records
+ * sincronizados localmente.
+ *
+ * Si el GPS no está disponible o no hay clientes con coords, retorna lista
+ * vacía silenciosamente (graceful degradation).
+ */
+export function useNearbyClients(radiusKm: number = DEFAULT_RADIUS_KM, limit: number = DEFAULT_LIMIT) {
+  const { location, loading: gpsLoading, error: gpsError } = useUserLocation();
+
+  // Observa todos los clientes activos. Filtramos por coords presentes en JS
+  // porque WDB no soporta Q.notEq(null) sobre @field number consistentemente.
+  const observable = useMemo(
+    () => database.get<Cliente>('clientes').query(Q.where('activo', true)).observe(),
+    [],
+  );
+  const { data: clientes, isLoading: dbLoading } = useObservable(observable);
+
+  const nearby = useMemo<NearbyCliente[]>(() => {
+    if (!location || !clientes) return [];
+    const center = { latitud: location.latitude, longitud: location.longitude };
+    const radiusM = radiusKm * 1000;
+
+    return clientes
+      .filter(c => c.latitud != null && c.longitud != null)
+      .map(c => ({
+        cliente: c,
+        distanciaM: haversineMeters(center, { latitud: c.latitud as number, longitud: c.longitud as number }),
+      }))
+      .filter(x => x.distanciaM <= radiusM)
+      .sort((a, b) => a.distanciaM - b.distanciaM)
+      .slice(0, limit);
+  }, [location, clientes, radiusKm, limit]);
+
+  return {
+    nearby,
+    isLoading: gpsLoading || dbLoading,
+    hasGps: !!location,
+    gpsError,
+  };
+}

--- a/apps/mobile-app/src/hooks/useRecentClients.ts
+++ b/apps/mobile-app/src/hooks/useRecentClients.ts
@@ -1,0 +1,101 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Q } from '@nozbe/watermelondb';
+import { database } from '@/db/database';
+import Cliente from '@/db/models/Cliente';
+import Pedido from '@/db/models/Pedido';
+import { useAuthStore } from '@/stores';
+
+export interface RecentCliente {
+  cliente: Cliente;
+  ultimaActividad: Date;
+}
+
+const DEFAULT_DAYS_BACK = 7;
+const DEFAULT_LIMIT = 5;
+
+/**
+ * Devuelve los últimos N clientes con los que el vendedor ha tenido actividad
+ * (pedidos) en los últimos `daysBack` días, ordenados por fecha descendente.
+ *
+ * Offline-first: lee desde WatermelonDB local (Pedido + Cliente). Sin red.
+ *
+ * Acelera el flow del vendedor: en lugar de buscar con lupa al mismo cliente
+ * frecuente, lo ve en el tope.
+ */
+export function useRecentClients(daysBack: number = DEFAULT_DAYS_BACK, limit: number = DEFAULT_LIMIT) {
+  const userId = Number(useAuthStore(s => s.user?.id) ?? 0);
+  const [recents, setRecents] = useState<RecentCliente[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const since = useMemo(() => Date.now() - daysBack * 24 * 60 * 60 * 1000, [daysBack]);
+
+  useEffect(() => {
+    if (!userId) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        // Fetch pedidos del vendedor en el rango. Usamos `created_at` (siempre
+        // poblado) en lugar de `fecha_pedido` que puede ser null en drafts.
+        const pedidos = await database
+          .get<Pedido>('pedidos')
+          .query(
+            Q.where('usuario_id', userId),
+            Q.where('created_at', Q.gte(since)),
+            Q.where('activo', true),
+            Q.sortBy('created_at', Q.desc),
+          )
+          .fetch();
+
+        // Dedup por clienteServerId (preferido) o clienteId local
+        const seen = new Set<string>();
+        const ordered: { key: string; pedido: Pedido }[] = [];
+        for (const p of pedidos) {
+          const key = p.clienteServerId != null ? `s:${p.clienteServerId}` : `l:${p.clienteId}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          ordered.push({ key, pedido: p });
+          if (ordered.length >= limit) break;
+        }
+
+        // Lookup Cliente para cada uno. Buscamos por serverId si está, sino por id local.
+        const clientesCol = database.get<Cliente>('clientes');
+        const result: RecentCliente[] = [];
+        for (const item of ordered) {
+          let cliente: Cliente | null = null;
+          if (item.pedido.clienteServerId != null) {
+            const matches = await clientesCol
+              .query(Q.where('server_id', item.pedido.clienteServerId), Q.take(1))
+              .fetch();
+            cliente = matches[0] ?? null;
+          }
+          if (!cliente && item.pedido.clienteId) {
+            try {
+              cliente = await clientesCol.find(item.pedido.clienteId);
+            } catch { /* no encontrado */ }
+          }
+          if (cliente && cliente.activo) {
+            result.push({ cliente, ultimaActividad: item.pedido.createdAt });
+          }
+        }
+
+        if (!cancelled) {
+          setRecents(result);
+          setIsLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setRecents([]);
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [userId, since, limit]);
+
+  return { recents, isLoading };
+}

--- a/apps/mobile-app/src/services/locationCheckpoint.ts
+++ b/apps/mobile-app/src/services/locationCheckpoint.ts
@@ -92,25 +92,44 @@ export async function recordPing(
   // visita SIN jornada activa, arrancamos automáticamente. Es el flujo principal
   // (no hay botón "Iniciar jornada" en home — esto reemplaza ese gesture).
   // No aplica para tipos que ya son de inicio/fin/checkpoint para evitar loops.
+  //
+  // FIX 2026-05-02: si el día/hora actual NO está en el horario laboral
+  // configurado por el admin, NO auto-iniciar. Antes el watcher cerraba la
+  // jornada inmediato después del auto-start, generando spam de 3 pings
+  // (Venta + InicioJornada + StopAutomatico) en el mismo timestamp. Reportado
+  // en Jeyma sábado 2026-05-02 con `dias_laborables='1,2,3,4,5'` (sin sábado).
   const esEventoNegocio = tipo === TipoPing.Venta || tipo === TipoPing.Cobro || tipo === TipoPing.Visita;
   if (esEventoNegocio) {
     try {
-      const { useJornadaStore } = await import('@/stores/jornadaStore');
-      const jornada = useJornadaStore.getState();
-      if (!jornada.activa) {
-        await jornada.iniciarJornada('manual');
-        // Toast informativo — el vendedor ve por qué arrancó el indicador
-        // "Tracking activo" en home.
-        try {
-          const ToastModule = await import('react-native-toast-message');
-          ToastModule.default.show({
-            type: 'info',
-            text1: 'Jornada iniciada',
-            text2: 'Tu ubicación se registra mientras tu jornada esté activa.',
-            visibilityTime: 4000,
-          });
-        } catch { /* ignore */ }
+      const { getEmpresaConfigSnapshot } = await import('@/utils/empresaConfigSnapshot');
+      const { enHorarioLaboral } = await import('@/utils/horarioLaboral');
+      const cfg = getEmpresaConfigSnapshot();
+      const enHorario = !cfg
+        ? true // sin snapshot → no podemos validar, mejor permitir (caso primer login)
+        : enHorarioLaboral(cfg.horaInicioJornada, cfg.horaFinJornada, cfg.diasLaborables);
+
+      if (enHorario) {
+        const { useJornadaStore } = await import('@/stores/jornadaStore');
+        const jornada = useJornadaStore.getState();
+        if (!jornada.activa) {
+          await jornada.iniciarJornada('manual');
+          // Toast informativo — el vendedor ve por qué arrancó el indicador
+          // "Tracking activo" en home.
+          try {
+            const ToastModule = await import('react-native-toast-message');
+            ToastModule.default.show({
+              type: 'info',
+              text1: 'Jornada iniciada',
+              text2: 'Tu ubicación se registra mientras tu jornada esté activa.',
+              visibilityTime: 4000,
+            });
+          } catch { /* ignore */ }
+        }
       }
+      // Si NO está en horario laboral: no auto-iniciar jornada. La venta/
+      // cobro/visita se registra normalmente; solo no se trackea ubicación
+      // GPS continua. Admin puede agregar el día actual a `diasLaborables`
+      // desde /settings si quiere capturar la actividad de hoy.
     } catch { /* ignore */ }
   }
 

--- a/apps/mobile-app/src/utils/empresaConfigSnapshot.ts
+++ b/apps/mobile-app/src/utils/empresaConfigSnapshot.ts
@@ -1,0 +1,56 @@
+// Snapshot síncrono de la configuración del tenant (subset de useEmpresa).
+//
+// Motivación: services NO React (locationCheckpoint.ts) necesitan leer
+// `horaInicioJornada/horaFinJornada/diasLaborables/modoVentaDefault` para
+// decidir si auto-iniciar jornada o no. No pueden usar el hook useEmpresa
+// porque corren fuera del árbol React.
+//
+// Pattern: el componente _layout.tsx (que sí usa useEmpresa) llama a
+// `setEmpresaConfigSnapshot` cada vez que el query data cambia. El service
+// llama a `getEmpresaConfigSnapshot()` síncrono para tomar la última versión
+// vista. Persistimos en AsyncStorage para sobrevivir restarts (la primera
+// venta del día post-restart aún puede tomar el snapshot del día anterior).
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface EmpresaConfigSnapshot {
+  horaInicioJornada: string | null;
+  horaFinJornada: string | null;
+  diasLaborables: string | null;
+  modoVentaDefault: string | null;
+}
+
+const STORAGE_KEY = 'empresa_config_snapshot_v1';
+
+let inMemorySnapshot: EmpresaConfigSnapshot | null = null;
+
+export function getEmpresaConfigSnapshot(): EmpresaConfigSnapshot | null {
+  return inMemorySnapshot;
+}
+
+export async function setEmpresaConfigSnapshot(snapshot: EmpresaConfigSnapshot): Promise<void> {
+  inMemorySnapshot = snapshot;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    // ignore — fallar la persistencia no debe bloquear el flujo
+  }
+}
+
+/**
+ * Re-hidrata el snapshot desde AsyncStorage al primer mount post-restart.
+ * Después el `useEmpresa` lo refresca cuando llega la respuesta del backend.
+ */
+export async function hydrateEmpresaConfigSnapshot(): Promise<EmpresaConfigSnapshot | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as EmpresaConfigSnapshot;
+      inMemorySnapshot = parsed;
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/apps/mobile-app/src/utils/haversine.ts
+++ b/apps/mobile-app/src/utils/haversine.ts
@@ -1,0 +1,43 @@
+// Distancia Haversine entre 2 puntos lat/lng en metros. Radio tierra 6371000m.
+// Usado offline para ordenar clientes por proximidad sin tocar el backend.
+
+const EARTH_RADIUS_METERS = 6371000;
+
+export interface LatLng {
+  latitud: number;
+  longitud: number;
+}
+
+export function haversineMeters(a: LatLng, b: LatLng): number {
+  const lat1 = toRad(a.latitud);
+  const lat2 = toRad(b.latitud);
+  const dLat = toRad(b.latitud - a.latitud);
+  const dLng = toRad(b.longitud - a.longitud);
+
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+
+  const h = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+
+  return EARTH_RADIUS_METERS * c;
+}
+
+/**
+ * Pre-filtro bounding-box: descarta puntos que claramente NO están en el radio
+ * antes de hacer Haversine. ~10x más rápido para tablas grandes (>2000 records).
+ *
+ * 1° latitud ≈ 111km, 1° longitud ≈ 111km · cos(lat).
+ */
+export function withinBoundingBox(center: LatLng, target: LatLng, radiusMeters: number): boolean {
+  const latDeg = radiusMeters / 111000;
+  const lngDeg = radiusMeters / (111000 * Math.cos(toRad(center.latitud)));
+  return (
+    Math.abs(target.latitud - center.latitud) <= latDeg &&
+    Math.abs(target.longitud - center.longitud) <= lngDeg
+  );
+}
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}

--- a/apps/mobile-app/src/utils/horarioLaboral.ts
+++ b/apps/mobile-app/src/utils/horarioLaboral.ts
@@ -1,0 +1,49 @@
+// Helper puro reusable para evaluar si "ahora" cae dentro del horario
+// laboral configurado por el admin (CompanySetting.horaInicioJornada,
+// horaFinJornada, diasLaborables). Sin red. Independiente de React.
+//
+// Usado por:
+//  - useHorarioLaboralWatcher (cierra jornada al salir del rango)
+//  - recordPing (evita auto-start de jornada en día/hora no laborable
+//    para no spam'ear pings InicioJornada+StopAutomatico simultáneos
+//    que reportó Jeyma sábado 2026-05-02)
+
+/**
+ * Devuelve true si "ahora" cae dentro del horario configurado.
+ * - Sin horaInicio ni horaFin → permitido (no hay rango horario).
+ * - Sin diasLaborables → permitido cualquier día.
+ * - Con uno o ambos → respeta lo que esté configurado.
+ *
+ * Day mapping: 1=Lun..7=Dom (ISO).
+ * `Date.getDay()` retorna 0=Dom..6=Sáb → convertir a ISO.
+ */
+export function enHorarioLaboral(
+  horaInicio: string | null | undefined,
+  horaFin: string | null | undefined,
+  diasLaborables: string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  const dowJs = now.getDay();              // 0=Dom..6=Sáb
+  const dowIso = dowJs === 0 ? 7 : dowJs;  // 1=Lun..7=Dom
+
+  if (diasLaborables) {
+    const setDias = new Set(diasLaborables.split(',').map(s => s.trim()));
+    if (setDias.size > 0 && !setDias.has(String(dowIso))) {
+      return false;
+    }
+  }
+
+  if (horaInicio || horaFin) {
+    const minutosAhora = now.getHours() * 60 + now.getMinutes();
+    const inicioMin = horaInicio ? toMin(horaInicio) : 0;
+    const finMin = horaFin ? toMin(horaFin) : 24 * 60;
+    if (minutosAhora < inicioMin || minutosAhora >= finMin) return false;
+  }
+
+  return true;
+}
+
+function toMin(hhmm: string): number {
+  const [h, m] = hhmm.split(':').map(n => parseInt(n, 10));
+  return (h || 0) * 60 + (m || 0);
+}

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileEmpresaEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileEmpresaEndpoints.cs
@@ -65,6 +65,8 @@ public static class MobileEmpresaEndpoints
                     horaInicioJornada = (settings?.HoraInicioJornada ?? new TimeOnly(8, 0)).ToString("HH:mm"),
                     horaFinJornada = (settings?.HoraFinJornada ?? new TimeOnly(18, 0)).ToString("HH:mm"),
                     diasLaborables = settings?.DiasLaborables ?? "1,2,3,4,5", // CSV "1,2,3,4,5"
+                    // Modo default para acelerar UX en mobile. "Preguntar" preserva el flow actual.
+                    modoVentaDefault = settings?.ModoVentaDefault ?? "Preguntar",
                 }
             });
         })

--- a/apps/web/e2e/test-modo-venta-default.spec.ts
+++ b/apps/web/e2e/test-modo-venta-default.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+test.setTimeout(90_000);
+
+/**
+ * Smoke /settings tab Apariencia → ModoVentaDefaultSection
+ * Verifica que las 3 opciones aparecen + guardar persiste.
+ */
+test.describe('Settings — Modo de venta default', () => {
+  test('3 opciones visibles + guardar persiste tras reload', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/settings');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(1500);
+
+    const tabApariencia = page.getByRole('tab', { name: /apariencia/i });
+    if (await tabApariencia.count() > 0) {
+      await tabApariencia.click();
+      await page.waitForTimeout(800);
+    }
+
+    const titulo = page.getByText(/modo de venta default/i).first();
+    await expect(titulo).toBeVisible({ timeout: 8000 });
+
+    await page.screenshot({ path: 'test-results/modo-venta-default-initial.png', fullPage: false });
+
+    // Verifica que las 3 opciones existen
+    await expect(page.getByText(/^Preventa$/i).first()).toBeVisible();
+    await expect(page.getByText(/^Venta directa$/i).first()).toBeVisible();
+    await expect(page.getByText(/preguntar al vendedor/i).first()).toBeVisible();
+
+    // Click "Preventa"
+    await page.getByText(/^Preventa$/i).first().click();
+    await page.waitForTimeout(300);
+
+    // Capturar PATCH del save
+    const patchPromise = page.waitForResponse(
+      r => /\/api\/company\/settings/.test(r.url()) && (r.request().method() === 'PUT' || r.request().method() === 'PATCH'),
+      { timeout: 8000 }
+    ).catch(() => null);
+
+    // Click "Guardar" del modo venta (puede haber varios botones Guardar en la página)
+    const guardarBtns = page.getByRole('button', { name: /^Guardar$/i });
+    const count = await guardarBtns.count();
+    // Tomar el último (debería ser el de modo venta porque es la última sección)
+    if (count > 0) {
+      await guardarBtns.nth(count - 1).click();
+    }
+
+    const resp = await patchPromise;
+    if (resp) {
+      console.log(`Save status: ${resp.status()}`);
+      expect(resp.status()).toBeLessThan(400);
+    }
+
+    await page.waitForTimeout(1500);
+
+    // Reload
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(1500);
+    await tabApariencia.click().catch(() => {});
+    await page.waitForTimeout(800);
+
+    // Verifica que la opción Preventa está marcada (aria-pressed)
+    const preventaBtn = page.locator('button[aria-pressed="true"]').filter({ hasText: /Preventa/ }).first();
+    await expect(preventaBtn).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({ path: 'test-results/modo-venta-default-saved.png', fullPage: false });
+
+    // Restaurar a "Preguntar" para no afectar otros tests
+    await page.getByText(/preguntar al vendedor/i).first().click();
+    await page.waitForTimeout(300);
+    const guardarBtns2 = page.getByRole('button', { name: /^Guardar$/i });
+    const count2 = await guardarBtns2.count();
+    if (count2 > 0) {
+      await guardarBtns2.nth(count2 - 1).click();
+      await page.waitForTimeout(1500);
+    }
+  });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2447,6 +2447,20 @@
         "sun": "Sun"
       }
     },
+    "salesMode": {
+      "title": "Default sales mode",
+      "description": "Defines which mode is auto-selected when starting a sale on mobile. Speeds up the seller flow by skipping one step.",
+      "modoPreventa": "Pre-order",
+      "modoPreventaDesc": "Seller takes the order and delivers/collects later. Recommended for orders for future delivery.",
+      "modoVentaDirecta": "Direct sale",
+      "modoVentaDirectaDesc": "Seller delivers and collects on the spot. Recommended for self-sale with product on board.",
+      "modoPreguntar": "Ask the seller",
+      "modoPreguntarDesc": "Keeps the current screen with both options. Useful if your team combines both schemes.",
+      "hint": "The seller can always switch mode from the sale screen if needed. This only defines what appears first.",
+      "save": "Save",
+      "saving": "Saving...",
+      "saved": "Saved"
+    },
     "appearance": {
       "title": "Appearance",
       "theme": "Theme",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2447,6 +2447,20 @@
         "sun": "Dom"
       }
     },
+    "salesMode": {
+      "title": "Modo de venta default",
+      "description": "Define qué modo se selecciona automáticamente al iniciar una venta en mobile. Acelera el flujo del vendedor saltando un paso.",
+      "modoPreventa": "Preventa",
+      "modoPreventaDesc": "El vendedor toma el pedido y se entrega/cobra después. Recomendado si tu equipo levanta pedidos para entrega futura.",
+      "modoVentaDirecta": "Venta directa",
+      "modoVentaDirectaDesc": "El vendedor entrega y cobra en el momento. Recomendado si tu equipo opera en autoventa con producto a bordo.",
+      "modoPreguntar": "Preguntar al vendedor",
+      "modoPreguntarDesc": "Mantiene la pantalla actual con ambas opciones. Útil si tu equipo combina ambos esquemas.",
+      "hint": "El vendedor siempre puede cambiar el modo desde la pantalla de venta si lo necesita. Esto solo define qué se muestra primero.",
+      "save": "Guardar",
+      "saving": "Guardando...",
+      "saved": "Guardado"
+    },
     "appearance": {
       "title": "Apariencia",
       "theme": "Tema",

--- a/apps/web/src/app/(dashboard)/settings/components/AppearanceTab.tsx
+++ b/apps/web/src/app/(dashboard)/settings/components/AppearanceTab.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '@/stores/useUIStore';
 import { useCompany } from '@/contexts/CompanyContext';
 import { useTranslations } from 'next-intl';
 import { HorarioLaboralSection } from './HorarioLaboralSection';
+import { ModoVentaDefaultSection } from './ModoVentaDefaultSection';
 
 // Value keys for dropdowns — labels resolved via i18n in component
 const TIMEZONE_KEYS = [
@@ -191,6 +192,7 @@ export const AppearanceTab: React.FC = () => {
       </CardContent>
     </Card>
     <HorarioLaboralSection />
+    <ModoVentaDefaultSection />
     </div>
   );
 };

--- a/apps/web/src/app/(dashboard)/settings/components/ModoVentaDefaultSection.tsx
+++ b/apps/web/src/app/(dashboard)/settings/components/ModoVentaDefaultSection.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Save, Check, Loader2, ShoppingCart, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useCompany } from '@/contexts/CompanyContext';
+import { useTranslations } from 'next-intl';
+
+type ModoVentaDefault = 'Preventa' | 'VentaDirecta' | 'Preguntar';
+
+const MODOS: { value: ModoVentaDefault; labelKey: string; descriptionKey: string }[] = [
+  { value: 'Preventa', labelKey: 'modoPreventa', descriptionKey: 'modoPreventaDesc' },
+  { value: 'VentaDirecta', labelKey: 'modoVentaDirecta', descriptionKey: 'modoVentaDirectaDesc' },
+  { value: 'Preguntar', labelKey: 'modoPreguntar', descriptionKey: 'modoPreguntarDesc' },
+];
+
+/**
+ * Modo de venta default que el mobile mostrará al iniciar una venta. Acelera
+ * UX al saltar la pantalla de selección Preventa vs VentaDirecta cuando el
+ * tenant tiene un modo dominante. "Preguntar" preserva el flow actual.
+ */
+export const ModoVentaDefaultSection: React.FC = () => {
+  const t = useTranslations('settings.salesMode');
+  const { settings, updateSettings, isUpdating } = useCompany();
+
+  const [modo, setModo] = useState<ModoVentaDefault>('Preguntar');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!settings) return;
+    const current = (settings.modoVentaDefault as ModoVentaDefault) || 'Preguntar';
+    setModo(current);
+  }, [settings]);
+
+  const handleSave = async () => {
+    const success = await updateSettings({ modoVentaDefault: modo });
+    if (success) {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <ShoppingCart className="w-5 h-5 text-primary" />
+          <CardTitle>{t('title')}</CardTitle>
+        </div>
+        <CardDescription>{t('description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          {MODOS.map((m) => {
+            const selected = modo === m.value;
+            return (
+              <button
+                key={m.value}
+                type="button"
+                onClick={() => setModo(m.value)}
+                className={cn(
+                  'w-full text-left p-4 rounded-lg border transition-colors',
+                  selected
+                    ? 'bg-primary/10 border-primary'
+                    : 'bg-surface-2 border-border hover:bg-surface-3'
+                )}
+                aria-pressed={selected}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className={cn(
+                      'w-4 h-4 mt-0.5 rounded-full border-2 shrink-0 transition-colors',
+                      selected ? 'bg-primary border-primary' : 'bg-transparent border-border'
+                    )}
+                  />
+                  <div className="flex-1">
+                    <p className="font-semibold text-foreground text-[14px]">{t(m.labelKey)}</p>
+                    <p className="text-[12px] text-foreground/70 mt-1">{t(m.descriptionKey)}</p>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex items-start gap-2 p-3 bg-blue-50 dark:bg-blue-950/30 rounded-md">
+          <Info className="w-4 h-4 text-blue-600 mt-0.5 shrink-0" />
+          <p className="text-[12px] text-blue-900 dark:text-blue-200">{t('hint')}</p>
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <Button type="button" onClick={handleSave} disabled={isUpdating}>
+            {isUpdating ? (
+              <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> {t('saving')}</>
+            ) : saved ? (
+              <><Check className="w-4 h-4 mr-2" /> {t('saved')}</>
+            ) : (
+              <><Save className="w-4 h-4 mr-2" /> {t('save')}</>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/services/api/companyService.ts
+++ b/apps/web/src/services/api/companyService.ts
@@ -48,6 +48,8 @@ export interface CompanySettings {
   horaInicioJornada?: string | null;
   horaFinJornada?: string | null;
   diasLaborables?: string | null; // CSV "1,2,3,4,5" (1=Lun..7=Dom)
+  // Modo default de venta para mobile. "Preventa" | "VentaDirecta" | "Preguntar".
+  modoVentaDefault?: string | null;
 }
 
 export interface UpdateGlobalSettingsRequest {
@@ -78,6 +80,7 @@ export interface UpdateCompanyRequest {
   horaInicioJornada?: string;
   horaFinJornada?: string;
   diasLaborables?: string;
+  modoVentaDefault?: string;
 }
 
 export interface ApiResponse<T> {

--- a/libs/HandySuites.Application/CompanySettings/DTOs/CompanySettingsDto.cs
+++ b/libs/HandySuites.Application/CompanySettings/DTOs/CompanySettingsDto.cs
@@ -78,6 +78,10 @@ namespace HandySuites.Application.CompanySettings.DTOs
         // CSV con días laborables (1=Lun..7=Dom).
         [JsonPropertyName("diasLaborables")]
         public string DiasLaborables { get; set; } = "1,2,3,4,5";
+
+        // Modo default de venta para mobile. "Preventa" | "VentaDirecta" | "Preguntar".
+        [JsonPropertyName("modoVentaDefault")]
+        public string ModoVentaDefault { get; set; } = "Preguntar";
     }
 
     public class UpdateCompanySettingsRequest
@@ -105,6 +109,8 @@ namespace HandySuites.Application.CompanySettings.DTOs
         public string? HoraFinJornada { get; set; }
         [JsonPropertyName("diasLaborables")]
         public string? DiasLaborables { get; set; }
+        [JsonPropertyName("modoVentaDefault")]
+        public string? ModoVentaDefault { get; set; }
     }
 
     public class UploadLogoResponse

--- a/libs/HandySuites.Application/CompanySettings/Services/CompanySettingsService.cs
+++ b/libs/HandySuites.Application/CompanySettings/Services/CompanySettingsService.cs
@@ -94,6 +94,7 @@ namespace HandySuites.Application.CompanySettings.Services
                     HoraInicioJornada = settings.HoraInicioJornada.ToString("HH:mm"),
                     HoraFinJornada = settings.HoraFinJornada.ToString("HH:mm"),
                     DiasLaborables = settings.DiasLaborables,
+                    ModoVentaDefault = settings.ModoVentaDefault,
                 };
             }
             catch (Exception ex)
@@ -162,6 +163,15 @@ namespace HandySuites.Application.CompanySettings.Services
                 {
                     settings.DiasLaborables = request.DiasLaborables;
                 }
+                if (!string.IsNullOrWhiteSpace(request.ModoVentaDefault))
+                {
+                    // Whitelist — solo aceptar los 3 valores válidos.
+                    var valid = new[] { "Preventa", "VentaDirecta", "Preguntar" };
+                    if (Array.IndexOf(valid, request.ModoVentaDefault) >= 0)
+                    {
+                        settings.ModoVentaDefault = request.ModoVentaDefault;
+                    }
+                }
 
                 settings.ActualizadoPor = userId.ToString();
 
@@ -183,6 +193,7 @@ namespace HandySuites.Application.CompanySettings.Services
                     HoraInicioJornada = updatedSettings.HoraInicioJornada.ToString("HH:mm"),
                     HoraFinJornada = updatedSettings.HoraFinJornada.ToString("HH:mm"),
                     DiasLaborables = updatedSettings.DiasLaborables,
+                    ModoVentaDefault = updatedSettings.ModoVentaDefault,
                     UpdatedAt = updatedSettings.ActualizadoEn ?? updatedSettings.CreadoEn
                 };
             }

--- a/libs/HandySuites.Domain/Entities/CompanySetting.cs
+++ b/libs/HandySuites.Domain/Entities/CompanySetting.cs
@@ -91,6 +91,15 @@ public class CompanySetting : AuditableEntity
     [MaxLength(20)]
     public string DiasLaborables { get; set; } = "1,2,3,4,5";
 
+    /// <summary>
+    /// Modo default para el flujo de venta en mobile. Acelera UX al saltar la
+    /// pantalla de selección Preventa vs VentaDirecta cuando el tenant tiene
+    /// uno claramente dominante. Valores: "Preventa", "VentaDirecta", "Preguntar".
+    /// </summary>
+    [Column("modo_venta_default")]
+    [MaxLength(20)]
+    public string ModoVentaDefault { get; set; } = "Preguntar";
+
     // Navigation properties
     public Tenant Tenant { get; set; } = null!;
     public Company? Company { get; set; }

--- a/libs/HandySuites.Infrastructure/Migrations/20260502140943_AddModoVentaDefaultToCompanySetting.Designer.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260502140943_AddModoVentaDefaultToCompanySetting.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace HandySuites.Infrastructure.Migrations
 {
     [DbContext(typeof(HandySuitesDbContext))]
-    partial class HandySuitesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502140943_AddModoVentaDefaultToCompanySetting")]
+    partial class AddModoVentaDefaultToCompanySetting
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/HandySuites.Infrastructure/Migrations/20260502140943_AddModoVentaDefaultToCompanySetting.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260502140943_AddModoVentaDefaultToCompanySetting.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HandySuites.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddModoVentaDefaultToCompanySetting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Default "Preguntar" para preservar comportamiento actual: el vendedor
+            // sigue viendo la pantalla de Preventa vs VentaDirecta. Admin puede
+            // cambiarlo desde /settings (web) cuando quiera acelerar el flujo.
+            migrationBuilder.AddColumn<string>(
+                name: "modo_venta_default",
+                table: "company_settings",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Preguntar");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "modo_venta_default",
+                table: "company_settings");
+        }
+    }
+}


### PR DESCRIPTION
## Highlights de esta release

### Features nuevos (esta semana)
- **Jornada vendedor redesign** (`2fc5c134` y previos): inicio 100% automático en primera Venta/Cobro/Visita, horario laboral obligatorio en `/settings` (08:00-18:00 L-V default), auto-stop por inactividad >4h, chip discreto en home reemplaza card grande, banner Reanudar con TTL 4h
- **Catálogos comerciales real-time** (`7c7e49cf` + `d8f4b468`): backend emite SignalR en CRUD/toggle de 8 catálogos (promociones, descuentos, listas precios, productos, categorías cliente/producto, familias, zonas) → mobile invalida cache + dispara sync → UI refleja cambios en <2s sin re-login
- **UX acelerada flujo de venta** (`1e7f92ca` + `c9b0ce31`):
  - `CompanySetting.modoVentaDefault` configurable por tenant en `/settings` (Preventa | VentaDirecta | Preguntar) → mobile salta pantalla de modo
  - Hooks offline-first `useNearbyClients` (Haversine local) + `useRecentClients` (últimos 7 días)
  - Picker de cliente con secciones "Cercanos a ti" + "Recientes" arriba
  - `QuantityNumericSheet` reemplaza N taps de stepper por 3 (escribir + ✓)
  - Recuerda último método de pago en AsyncStorage
  - **Reduce 11 taps → ~5-6 taps** sin agregar botones nuevos
- **Fix horario laboral sábado** (`d2babf24`): `recordPing(Venta|Cobro|Visita)` valida `enHorarioLaboral` antes de auto-iniciar jornada. Resuelve spam de 3 pings por venta reportado en Jeyma sábado 2026-05-02 (jornada se cerraba inmediato por sábado fuera de `dias_laborables='1,2,3,4,5'`)

### Acumulado previo de staging (~283 commits adicionales)
- Tracking GPS vendedores (Fase A + B) — UbicacionesVendedor + endpoints + mapa Leaflet web
- Multi-zona en rutas
- Sync offline catálogos completos en WatermelonDB
- Bug fixes: IVA en pedidos, `$` doble, cliente cap, TZ, CSP, activity-logs loader
- Drop columnas legacy `es_admin`/`es_super_admin`
- Setup ambientes staging/prod separados en Railway
- Subscription enforcement + cross-API sync DatosEmpresa
- Cupón redeem UI + security whitelist
- RLS deployment

## Pre-Deploy Checklist

- ✅ Migrations auto-aplican en CI prod (incluyendo `BackfillAndRequireHorarioLaboral` con default 08:00-18:00 L-V + `AddModoVentaDefaultToCompanySetting` con default "Preguntar")
- ✅ Sin nuevos env vars
- ✅ Sin breaking API changes
- ⚠️ Mobile: requiere EAS update post-merge para distribuir feature de jornada + catálogos real-time + UX acelerada + fix horario. **Pendiente (usuario sigue trabajando)** — se enviará al final del día.
- ✅ Backwards compatible: tenants sin config → defaults seguros (Preguntar, 08:00-18:00 L-V)

## Test plan
- [x] Backend xUnit 453/454 pass
- [x] Web Playwright smoke (jornada, horario laboral, modo venta default, promo realtime)
- [x] Mobile type-check 0 errores
- [x] Smoke real-time E2E (toggle web → sync mobile <2s)
- [x] Investigación prod confirma fix de horario sábado
- [ ] Verificar Railway prod deploy post-merge
- [ ] EAS update post-merge cuando equipo termine día
