### PR TITLE
fix(prod): 6 issues reportados por admin@jeyma.com en mobile y web

### DIFF
--- a/apps/mobile-app/app.json
+++ b/apps/mobile-app/app.json
@@ -8,6 +8,13 @@
     "scheme": "handysuites",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "runtimeVersion": { "policy": "appVersion" },
+    "updates": {
+      "url": "https://u.expo.dev/e6259b5a-35d9-4b87-b700-5520b113fa68",
+      "enabled": true,
+      "fallbackToCacheTimeout": 0,
+      "checkAutomatically": "ON_LOAD"
+    },
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",

--- a/apps/mobile-app/app/(auth)/login.tsx
+++ b/apps/mobile-app/app/(auth)/login.tsx
@@ -159,7 +159,7 @@ export default function LoginScreen() {
             </View>
             <Text style={styles.title}>Handy Suites®</Text>
             <Text style={styles.subtitle}>
-              Gestiona tus ventas desde cualquier lugar ⚡
+              Gestiona tus ventas desde cualquier lugar
             </Text>
           </View>
           <Text style={styles.formTitle}>{totpRequired ? 'Verificación 2FA' : 'Iniciar Sesión'}</Text>

--- a/apps/mobile-app/app/(auth)/login.tsx
+++ b/apps/mobile-app/app/(auth)/login.tsx
@@ -159,7 +159,7 @@ export default function LoginScreen() {
             </View>
             <Text style={styles.title}>Handy Suites®</Text>
             <Text style={styles.subtitle}>
-              Gestiona tus ventas desde cualquier lugar 🚀
+              Gestiona tus ventas desde cualquier lugar ⚡
             </Text>
           </View>
           <Text style={styles.formTitle}>{totpRequired ? 'Verificación 2FA' : 'Iniciar Sesión'}</Text>

--- a/apps/mobile-app/app/(auth)/login.tsx
+++ b/apps/mobile-app/app/(auth)/login.tsx
@@ -159,7 +159,7 @@ export default function LoginScreen() {
             </View>
             <Text style={styles.title}>Handy Suites®</Text>
             <Text style={styles.subtitle}>
-              Gestiona tus ventas desde cualquier lugar
+              Gestiona tus ventas desde cualquier lugar 🚀
             </Text>
           </View>
           <Text style={styles.formTitle}>{totpRequired ? 'Verificación 2FA' : 'Iniciar Sesión'}</Text>

--- a/apps/mobile-app/app/(tabs)/equipo/index.tsx
+++ b/apps/mobile-app/app/(tabs)/equipo/index.tsx
@@ -3,7 +3,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
-import { useSupervisorDashboard, useMisVendedores } from '@/hooks/useSupervisor';
+import { useSupervisorDashboard, useMisVendedores, useTenantResumen } from '@/hooks/useSupervisor';
 import { useTenantLocale } from '@/hooks';
 import { SbTeam } from '@/components/icons/DashboardIcons';
 import { useState } from 'react';
@@ -62,6 +62,10 @@ function EquipoContent() {
   const role = useAuthStore(s => s.user?.role);
   const isAdmin = role === 'ADMIN' || role === 'SUPER_ADMIN';
   const { currency, locale } = useTenantLocale();
+  // Resumen tenant — solo admin/super_admin lo ven. Permite ver ventas+cobros
+  // del tenant completo (no solo los del usuario actual). Reportado prod
+  // 2026-05-02: admin@jeyma.com no veía ventas de los vendedores en mobile.
+  const { data: resumenTenant } = useTenantResumen(isAdmin);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -134,6 +138,22 @@ function EquipoContent() {
           <KpiCard label="Visitas hoy" value={`${dashboard.visitasCompletadasHoy}/${dashboard.visitasHoy}`} />
           <KpiCard label="Pedidos mes" value={dashboard.pedidosMes} />
           <KpiCard label="Clientes" value={dashboard.totalClientes} />
+        </Animated.View>
+      )}
+
+      {/* Resumen tenant del día — solo admin. Refleja ventas/cobros de TODOS
+          los vendedores (no solo del admin que está logueado). */}
+      {isAdmin && resumenTenant && (
+        <Animated.View entering={FadeInDown.delay(50).duration(400)} style={styles.section} testID="admin-tenant-resumen">
+          <Text style={styles.sectionLabel}>HOY EN TODA LA EMPRESA</Text>
+          <View style={styles.kpiGrid}>
+            <KpiCard label="Pedidos" value={resumenTenant.pedidosCount} />
+            <KpiCard label="Total facturado" value={formatMoney(resumenTenant.pedidosTotal)} />
+            <KpiCard label="Cobros" value={resumenTenant.cobrosCount} />
+            <KpiCard label="Total cobrado" value={formatMoney(resumenTenant.cobrosTotal)} />
+            <KpiCard label="Visitas" value={resumenTenant.visitasCount} />
+            <KpiCard label="Vendedores activos" value={resumenTenant.vendedoresActivos} />
+          </View>
         </Animated.View>
       )}
 

--- a/apps/mobile-app/app/(tabs)/equipo/index.tsx
+++ b/apps/mobile-app/app/(tabs)/equipo/index.tsx
@@ -34,7 +34,7 @@ function VendedorRow({ vendedor, onPress }: { vendedor: VendedorEquipo; onPress:
       style={styles.vendedorRow}
       onPress={onPress}
       testID={`vendedor-${vendedor.id}`}
-      accessibilityLabel={`${vendedor.nombre}, ${vendedor.activo ? 'Activo' : 'Inactivo'}`}
+      accessibilityLabel={`${vendedor.nombre}, ${vendedor.isOnline ? 'En línea' : 'Desconectado'}`}
       accessibilityRole="button"
     >
       <View style={styles.avatar}>
@@ -44,7 +44,11 @@ function VendedorRow({ vendedor, onPress }: { vendedor: VendedorEquipo; onPress:
         <Text style={styles.vendedorName}>{vendedor.nombre}</Text>
         <Text style={styles.vendedorEmail}>{vendedor.email}</Text>
       </View>
-      <View style={[styles.statusDot, { backgroundColor: vendedor.activo ? '#22c55e' : '#ef4444' }]} />
+      {/* Punto verde = vendedor con GPS ping en últimos 15 min (real "en línea").
+          Gris = sin actividad reciente (desconectado o jornada cerrada). El campo
+          `activo` (estado de cuenta) ya no se usa para este indicador — antes
+          marcaba a todos como online aunque no estuvieran trabajando. */}
+      <View style={[styles.statusDot, { backgroundColor: vendedor.isOnline ? '#22c55e' : '#94a3b8' }]} />
     </Pressable>
   );
 }

--- a/apps/mobile-app/eas.json
+++ b/apps/mobile-app/eas.json
@@ -18,6 +18,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "android": {
         "buildType": "apk"
       },
@@ -30,6 +31,7 @@
       }
     },
     "production": {
+      "channel": "production",
       "android": {
         "buildType": "app-bundle"
       },
@@ -41,6 +43,7 @@
     },
     "production-apk": {
       "distribution": "internal",
+      "channel": "production",
       "android": {
         "buildType": "apk"
       },

--- a/apps/mobile-app/package-lock.json
+++ b/apps/mobile-app/package-lock.json
@@ -36,6 +36,7 @@
         "expo-sharing": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
+        "expo-updates": "~29.0.17",
         "lightningcss": "^1.31.1",
         "lucide-react-native": "^0.575.0",
         "nativewind": "^4.2.2",
@@ -4349,9 +4350,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5585,6 +5586,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.8.tgz",
+      "integrity": "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -5630,6 +5637,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -5670,6 +5683,19 @@
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
       "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "expo-json-utils": "~0.15.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -5856,6 +5882,89 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.17",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.17.tgz",
+      "integrity": "sha512-9h78cs6Q2rs/dEY7zAgyEm/m6J5rHy8RNpRyhilEAvrzrGLHChVZJT+bSR2RwNJg1DtwUNEjCgZrxDlM7LnNkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.4.8",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.8",
+        "expo-manifests": "~1.0.11",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-updates/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/exponential-backoff": {

--- a/apps/mobile-app/package.json
+++ b/apps/mobile-app/package.json
@@ -38,6 +38,7 @@
     "expo-sharing": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
+    "expo-updates": "~29.0.17",
     "lightningcss": "^1.31.1",
     "lucide-react-native": "^0.575.0",
     "nativewind": "^4.2.2",

--- a/apps/mobile-app/src/api/schemas/supervisor.ts
+++ b/apps/mobile-app/src/api/schemas/supervisor.ts
@@ -68,8 +68,20 @@ export const VendedorResumenSchema = z.object({
   }).nullable().optional(),
 });
 
+// Resumen tenant (admin only) — agregados del día calculados con TZ del tenant.
+// Acompaña el endpoint /api/mobile/supervisor/resumen-tenant.
+export const TenantResumenSchema = z.object({
+  pedidosCount: z.number(),
+  pedidosTotal: z.number(),
+  cobrosCount: z.number(),
+  cobrosTotal: z.number(),
+  visitasCount: z.number(),
+  vendedoresActivos: z.number(),
+});
+
 export type VendedorEquipo = z.infer<typeof VendedorEquipoSchema>;
 export type SupervisorDashboard = z.infer<typeof SupervisorDashboardSchema>;
 export type UbicacionVendedor = z.infer<typeof UbicacionVendedorSchema>;
 export type ActividadItem = z.infer<typeof ActividadItemSchema>;
 export type VendedorResumen = z.infer<typeof VendedorResumenSchema>;
+export type TenantResumen = z.infer<typeof TenantResumenSchema>;

--- a/apps/mobile-app/src/api/schemas/supervisor.ts
+++ b/apps/mobile-app/src/api/schemas/supervisor.ts
@@ -7,6 +7,11 @@ export const VendedorEquipoSchema = z.object({
   rol: z.string(),
   activo: z.boolean(),
   avatarUrl: z.string().nullable().optional(),
+  // isOnline = vendedor con GPS ping en últimos 15 min (real "en línea").
+  // Optional/default false para retrocompat con APKs viejas o si el endpoint
+  // no incluye el campo (graceful degradation a "desconectado").
+  isOnline: z.boolean().optional().default(false),
+  ultimoPing: z.string().datetime().nullable().optional(),
 });
 
 export const SupervisorDashboardSchema = z.object({

--- a/apps/mobile-app/src/api/supervisor.ts
+++ b/apps/mobile-app/src/api/supervisor.ts
@@ -8,6 +8,7 @@ import {
   UbicacionVendedorSchema,
   ActividadItemSchema,
   VendedorResumenSchema,
+  TenantResumenSchema,
 } from './schemas/supervisor';
 import type {
   VendedorEquipo,
@@ -15,6 +16,7 @@ import type {
   UbicacionVendedor,
   ActividadItem,
   VendedorResumen,
+  TenantResumen,
 } from './schemas/supervisor';
 import type { ApiResponse } from '@/types';
 
@@ -28,6 +30,7 @@ const ActividadResponseSchema = z.object({
   count: z.number(),
 }).passthrough();
 const VendedorResumenResponseSchema = ApiResponseSchema(VendedorResumenSchema);
+const TenantResumenResponseSchema = ApiResponseSchema(TenantResumenSchema);
 
 const BASE = '/api/mobile/supervisor';
 
@@ -82,6 +85,21 @@ export const supervisorApi = {
       VendedorResumenResponseSchema,
       data,
       `GET /api/mobile/supervisor/vendedor/${vendedorId}/resumen`
+    );
+    return validated.data;
+  },
+
+  // Admin only — agregados de TODO el tenant del día actual (TZ del tenant).
+  // Permite a admin@jeyma.com ver "lo que se vendió hoy" en la app sin tener
+  // que sincronizar la data de cada vendedor en WatermelonDB.
+  getResumenTenant: async (): Promise<TenantResumen> => {
+    const { data } = await api.get<ApiResponse<TenantResumen>>(
+      `${BASE}/resumen-tenant`
+    );
+    const validated = validateResponse(
+      TenantResumenResponseSchema,
+      data,
+      'GET /api/mobile/supervisor/resumen-tenant'
     );
     return validated.data;
   },

--- a/apps/mobile-app/src/components/shared/PrivacyConsentModal.tsx
+++ b/apps/mobile-app/src/components/shared/PrivacyConsentModal.tsx
@@ -24,8 +24,13 @@ export function PrivacyConsentModal() {
 
   const storageKey = user?.id ? `${STORAGE_KEY_PREFIX}_${user.id}` : null;
 
+  // Admin/Super_Admin no son rastreados por la jornada GPS — no necesitan
+  // ver el aviso de privacidad. Vendedor + Supervisor + Viewer (los roles
+  // que sí pueden tener tracking activo) sí lo ven.
+  const isAdmin = user?.role === 'ADMIN' || user?.role === 'SUPER_ADMIN';
+
   useEffect(() => {
-    if (!isAuthenticated || !storageKey) return;
+    if (!isAuthenticated || isAdmin || !storageKey) return;
     let cancelled = false;
     (async () => {
       try {
@@ -34,7 +39,7 @@ export function PrivacyConsentModal() {
       } catch { /* ignore */ }
     })();
     return () => { cancelled = true; };
-  }, [isAuthenticated, storageKey]);
+  }, [isAuthenticated, isAdmin, storageKey]);
 
   const handleClose = async () => {
     setVisible(false);

--- a/apps/mobile-app/src/hooks/useSupervisor.ts
+++ b/apps/mobile-app/src/hooks/useSupervisor.ts
@@ -40,3 +40,18 @@ export function useVendedorResumen(vendedorId: number) {
     enabled: vendedorId > 0,
   });
 }
+
+/**
+ * Admin only — agregados del día de TODO el tenant. Solo se llama si
+ * el rol del usuario actual es ADMIN/SUPER_ADMIN. Si no, queda disabled.
+ * Refresca cada 2 min para mantener los KPIs frescos durante el día.
+ */
+export function useTenantResumen(enabled: boolean) {
+  return useQuery({
+    queryKey: ['supervisor', 'resumen-tenant'],
+    queryFn: () => supervisorApi.getResumenTenant(),
+    enabled,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+}

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
@@ -342,7 +342,32 @@ public static class MobileSupervisorEndpoints
                 return Results.Forbid();
 
             var supervisorId = int.Parse(tenant.UserId);
-            var hoy = DateTime.UtcNow.Date;
+            // Calcular el rango UTC [startUtc, endUtc) que corresponde al "día
+            // local actual del tenant". Sin esto, `FechaPedido.Date == UtcNow.Date`
+            // excluía pedidos del día local cuando el tenant está en TZ negativa
+            // (ej: Jeyma Mazatlan UTC-7: a las 7pm local ya es día siguiente UTC).
+            // Reportado prod 2026-05-02 testeando admin@jeyma.com.
+            var tenantTz = await db.CompanySettings
+                .AsNoTracking()
+                .Where(cs => cs.TenantId == tenant.TenantId)
+                .Select(cs => cs.Timezone)
+                .FirstOrDefaultAsync() ?? "America/Mexico_City";
+            DateTime startUtc, endUtc;
+            try
+            {
+                var tzInfo = TimeZoneInfo.FindSystemTimeZoneById(tenantTz);
+                var localNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo);
+                var localDayStart = DateTime.SpecifyKind(localNow.Date, DateTimeKind.Unspecified);
+                var localDayEnd = localDayStart.AddDays(1);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(localDayStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(localDayEnd, tzInfo);
+            }
+            catch
+            {
+                // Fallback: día UTC tradicional si TZ inválido (no debería pasar).
+                startUtc = DateTime.UtcNow.Date;
+                endUtc = startUtc.AddDays(1);
+            }
 
             // ADMIN/SUPER_ADMIN ven a cualquier vendedor del tenant; SUPERVISOR solo a sus subordinados.
             var vendedorQuery = db.Usuarios
@@ -364,7 +389,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => p.UsuarioId == id
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Date == hoy
+                         && p.FechaPedido >= startUtc && p.FechaPedido < endUtc
                          && p.Activo)
                 .CountAsync();
 
@@ -372,7 +397,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => p.UsuarioId == id
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Date == hoy
+                         && p.FechaPedido >= startUtc && p.FechaPedido < endUtc
                          && p.Activo)
                 .SumAsync(p => (decimal?)p.Total) ?? 0;
 
@@ -380,7 +405,8 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(v => v.UsuarioId == id
                          && v.TenantId == tenant.TenantId
-                         && v.FechaHoraInicio != null && v.FechaHoraInicio.Value.Date == hoy
+                         && v.FechaHoraInicio != null
+                         && v.FechaHoraInicio >= startUtc && v.FechaHoraInicio < endUtc
                          && v.EliminadoEn == null)
                 .CountAsync();
 
@@ -388,7 +414,8 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(v => v.UsuarioId == id
                          && v.TenantId == tenant.TenantId
-                         && v.FechaHoraInicio != null && v.FechaHoraInicio.Value.Date == hoy
+                         && v.FechaHoraInicio != null
+                         && v.FechaHoraInicio >= startUtc && v.FechaHoraInicio < endUtc
                          && v.FechaHoraFin != null
                          && v.EliminadoEn == null)
                 .CountAsync();
@@ -397,7 +424,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(c => c.UsuarioId == id
                          && c.TenantId == tenant.TenantId
-                         && c.FechaCobro.Date == hoy
+                         && c.FechaCobro >= startUtc && c.FechaCobro < endUtc
                          && c.Activo)
                 .SumAsync(c => (decimal?)c.Monto) ?? 0;
 

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
@@ -501,5 +501,90 @@ public static class MobileSupervisorEndpoints
         .WithDescription("KPIs del día y última ubicación de un vendedor específico del equipo.")
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
+
+        // GET /api/mobile/supervisor/resumen-tenant — agregados de TODO el tenant
+        // para admins. Permite a ADMIN/SUPER_ADMIN ver "lo que se vendió hoy" sin
+        // tener que sincronizar la data de todos los vendedores en WatermelonDB.
+        // Reportado prod 2026-05-02 por admin@jeyma.com: solo veía sus propias
+        // ventas (que eran 0) en vez del agregado del tenant (17 pedidos hoy).
+        group.MapGet("/resumen-tenant", async (
+            ICurrentTenant tenant,
+            HandySuitesDbContext db) =>
+        {
+            if (!tenant.IsAdmin && !tenant.IsSuperAdmin)
+                return Results.Forbid();
+
+            // Calcular ventana UTC del día local del tenant (TZ-aware).
+            var tenantTz = await db.CompanySettings
+                .AsNoTracking()
+                .Where(cs => cs.TenantId == tenant.TenantId)
+                .Select(cs => cs.Timezone)
+                .FirstOrDefaultAsync() ?? "America/Mexico_City";
+            DateTime startUtc, endUtc;
+            try
+            {
+                var tzInfo = TimeZoneInfo.FindSystemTimeZoneById(tenantTz);
+                var localNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo);
+                var localDayStart = DateTime.SpecifyKind(localNow.Date, DateTimeKind.Unspecified);
+                var localDayEnd = localDayStart.AddDays(1);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(localDayStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(localDayEnd, tzInfo);
+            }
+            catch
+            {
+                startUtc = DateTime.UtcNow.Date;
+                endUtc = startUtc.AddDays(1);
+            }
+
+            var pedidosCount = await db.Pedidos.AsNoTracking()
+                .CountAsync(p => p.TenantId == tenant.TenantId
+                              && p.FechaPedido >= startUtc && p.FechaPedido < endUtc
+                              && p.Activo);
+            var pedidosTotal = await db.Pedidos.AsNoTracking()
+                .Where(p => p.TenantId == tenant.TenantId
+                         && p.FechaPedido >= startUtc && p.FechaPedido < endUtc
+                         && p.Activo)
+                .SumAsync(p => (decimal?)p.Total) ?? 0;
+            var cobrosCount = await db.Cobros.AsNoTracking()
+                .CountAsync(c => c.TenantId == tenant.TenantId
+                              && c.FechaCobro >= startUtc && c.FechaCobro < endUtc
+                              && c.Activo);
+            var cobrosTotal = await db.Cobros.AsNoTracking()
+                .Where(c => c.TenantId == tenant.TenantId
+                         && c.FechaCobro >= startUtc && c.FechaCobro < endUtc
+                         && c.Activo)
+                .SumAsync(c => (decimal?)c.Monto) ?? 0;
+            var visitasCount = await db.ClienteVisitas.AsNoTracking()
+                .CountAsync(v => v.TenantId == tenant.TenantId
+                              && v.FechaHoraInicio != null
+                              && v.FechaHoraInicio >= startUtc && v.FechaHoraInicio < endUtc
+                              && v.EliminadoEn == null);
+
+            // # vendedores con al menos 1 ping en el día (vendedores "trabajando hoy")
+            var vendedoresActivos = await db.UbicacionesVendedor.AsNoTracking()
+                .Where(u => u.TenantId == tenant.TenantId
+                         && u.CapturadoEn >= startUtc && u.CapturadoEn < endUtc)
+                .Select(u => u.UsuarioId)
+                .Distinct()
+                .CountAsync();
+
+            return Results.Ok(new
+            {
+                success = true,
+                data = new
+                {
+                    pedidosCount,
+                    pedidosTotal,
+                    cobrosCount,
+                    cobrosTotal,
+                    visitasCount,
+                    vendedoresActivos
+                }
+            });
+        })
+        .WithSummary("Resumen tenant del día")
+        .WithDescription("Agregados (count + total) de todo el tenant para admins. Calcula 'hoy' en TZ del tenant.")
+        .Produces<object>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden);
     }
 }

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
@@ -44,7 +44,7 @@ public static class MobileSupervisorEndpoints
                 baseQuery = baseQuery.Where(u => u.SupervisorId == supervisorId);
             }
 
-            var vendedores = await baseQuery
+            var vendedoresBase = await baseQuery
                 .Select(u => new
                 {
                     u.Id,
@@ -55,6 +55,31 @@ public static class MobileSupervisorEndpoints
                     u.AvatarUrl
                 })
                 .ToListAsync();
+
+            // Calcular IsOnline real: último GPS ping en los últimos 15 min.
+            // Antes el frontend mostraba un punto verde basado en `activo` (= cuenta
+            // no eliminada), lo cual marcaba a TODOS los vendedores como "en línea"
+            // aunque no estuvieran trabajando. Reportado por admin@jeyma.com 2026-05-02.
+            var threshold = DateTime.UtcNow.AddMinutes(-15);
+            var idsList = vendedoresBase.Select(v => v.Id).ToList();
+            var lastPings = await db.UbicacionesVendedor
+                .AsNoTracking()
+                .Where(p => p.TenantId == tenant.TenantId && idsList.Contains(p.UsuarioId))
+                .GroupBy(p => p.UsuarioId)
+                .Select(g => new { UsuarioId = g.Key, UltimoPing = g.Max(p => p.CapturadoEn) })
+                .ToDictionaryAsync(x => x.UsuarioId, x => (DateTime?)x.UltimoPing);
+
+            var vendedores = vendedoresBase.Select(v => new
+            {
+                v.Id,
+                v.Nombre,
+                v.Email,
+                v.Rol,
+                v.Activo,           // estado de cuenta (legacy field, sigue para retrocompat)
+                v.AvatarUrl,
+                IsOnline = lastPings.TryGetValue(v.Id, out var p) && p.HasValue && p.Value >= threshold,
+                UltimoPing = lastPings.TryGetValue(v.Id, out var pp) ? pp : null
+            }).ToList();
 
             return Results.Ok(new { success = true, data = vendedores, count = vendedores.Count });
         })

--- a/apps/web/src/app/(dashboard)/team/components/GpsActivityMap.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/GpsActivityMap.tsx
@@ -91,22 +91,44 @@ function MapImperativeBridge({
   markerRefs: React.MutableRefObject<Array<L.CircleMarker | null>>;
 }) {
   const map = useMap();
+  // Hotfix prod: el setTimeout(..., 750) sin cleanup causaba crash
+  // "Cannot read properties of undefined (reading '_leaflet_pos')" cuando
+  // el usuario navegaba dentro de la ventana de animación. Guardamos el
+  // timeout id para limpiar en unmount.
+  const popupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     handleRef.current = {
       focusEvent: (index: number) => {
         const ev = eventos[index];
         if (!ev) return;
         map.flyTo([ev.latitud, ev.longitud], 17, { duration: 0.7 });
-        // Pequeño delay para que la animación termine y el popup quede
-        // anclado al marker, no a la posición previa del viewport.
-        const marker = markerRefs.current[index];
-        if (marker) {
-          setTimeout(() => marker.openPopup(), 750);
-        }
+        // Cancelar timeout pendiente si el user dispara focusEvent múltiples
+        // veces antes de que el primero cumpla.
+        if (popupTimeoutRef.current) clearTimeout(popupTimeoutRef.current);
+        popupTimeoutRef.current = setTimeout(() => {
+          const marker = markerRefs.current[index];
+          // Defense-in-depth: verificar que el marker exista Y tenga
+          // _leaflet_pos (i.e., sigue agregado al map). Sin esto Leaflet
+          // crashea durante la zoom transition end.
+          if (marker && (marker as unknown as { _leaflet_pos?: unknown })._leaflet_pos) {
+            try {
+              marker.openPopup();
+            } catch {
+              // El marker puede haber sido destruido entre el check y el
+              // call (race muy improbable pero defensa total).
+            }
+          }
+        }, 750);
       },
     };
     return () => {
       handleRef.current = null;
+      // Crítico: si el componente desmonta dentro de la ventana de 750ms,
+      // limpiar el timeout — sino dispara sobre marker destroyed → crash.
+      if (popupTimeoutRef.current) {
+        clearTimeout(popupTimeoutRef.current);
+        popupTimeoutRef.current = null;
+      }
     };
   }, [map, eventos, markerRefs, handleRef]);
   return null;

--- a/apps/web/src/lib/validations/client.ts
+++ b/apps/web/src/lib/validations/client.ts
@@ -65,15 +65,24 @@ export const clientSchema = z.object({
   longitud: z.number().default(0),
 
   // === Datos de contacto ===
+  // teléfono y email son OPCIONALES — alineado con mobile (los vendedores
+  // crean clientes en ruta sin pedir esos datos). Si se proveen, validamos
+  // formato. Backend acepta '' (NOT NULL con default ''). Reportado por
+  // admin@jeyma.com 2026-05-02: web bloqueaba edit de clientes que mobile
+  // creó sin email/teléfono.
   encargado: z.string().max(255).optional(),
   telefono: z
     .string()
-    .min(1, 'phoneRequired')
-    .regex(/^\d{10}$/, 'phoneMust10Digits'),
+    .trim()
+    .refine((v) => v === '' || /^\d{10}$/.test(v), { message: 'phoneMust10Digits' })
+    .optional()
+    .default(''),
   email: z
     .string()
-    .min(1, 'emailRequired')
-    .email('emailInvalid'),
+    .trim()
+    .refine((v) => v === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v), { message: 'emailInvalid' })
+    .optional()
+    .default(''),
 }).superRefine((data, ctx) => {
   // Validación condicional: si facturable=true, los campos fiscales son obligatorios
   if (data.facturable) {


### PR DESCRIPTION
## Summary

Fix consolidado de 6 issues reportados en producción al testear como `admin@jeyma.com` (Tenant Jeyma, tenant_id=2). Datos verificados en DB de prod: vendedor1 tenía 17 pedidos + 17 cobros + 48 GPS pings hoy → la data sí existe; los bugs eran 100% UI/calculation.

## Cambios (9 commits en staging — los 3 primeros fueron el setup de EAS Update OTA, los 6 siguientes son los fixes de los issues)

### Web

- **`4a8842ae` fix(web/team/gps): leaflet crash en rango=7d** (P1 prod)
  - `MapImperativeBridge.focusEvent()` causaba `Cannot read properties of undefined (reading '_leaflet_pos')` cuando el usuario navegaba dentro de la ventana de animación de 750ms del `setTimeout`
  - Fix: cleanup del timeout en useEffect + guard `marker._leaflet_pos != null` + try/catch defensivo

- **`ea315669` fix(web/clients): teléfono y email opcionales (alinear con mobile)**
  - Web bloqueaba edit de >200 clientes existentes que mobile creó sin email/teléfono
  - Fix: zod schema relajado a `optional + refine` (alineado con mobile)

### Mobile (UI/JS — aplicado vía EAS Update OTA, ya publicado)

- **`00efa395` fix(mobile/privacy): no mostrar modal a ADMIN/SUPER_ADMIN**
  - Modal "Sobre tu ubicación" se mostraba a admins aunque ellos no son trackeados
  - Fix: skip si `user.role === 'ADMIN' || 'SUPER_ADMIN'`

- **`447a29be` fix(mobile/equipo): isOnline real basado en último GPS ping** (backend + UI)
  - Punto verde mostraba "online" según `usuario.activo` (cuenta no eliminada), no actividad real
  - Fix: agregar campo `IsOnline` calculado por último ping < 15 min en endpoint `mis-vendedores`. UI usa nuevo campo. Color desconectado cambió de rojo a gris.

### Mobile API (Backend — Railway redeploya al merge)

- **`bf37a389` fix(mobile-api): TZ del tenant en supervisor/vendedor/{id}/resumen**
  - Endpoint usaba `DateTime.UtcNow.Date` para "hoy". Tenant Jeyma en Mazatlan UTC-7: a las 7pm local ya es día siguiente UTC → contadores en 0
  - Fix: leer `Timezone` de `CompanySettings`, calcular rango `[startUtc, endUtc)` en TZ del tenant, queries con `>= startUtc && < endUtc`

- **`682fd465` feat(mobile/equipo): admin ve resumen tenant** (feature)
  - Admin no veía agregados del tenant (sync filtra por usuario_id, admin solo tiene sus propios records en WDB)
  - Solución: nuevo endpoint `GET /api/mobile/supervisor/resumen-tenant` que devuelve agregados (count + total) sin sync. UI online-only en `/equipo` con sección "HOY EN TODA LA EMPRESA" solo visible a admin.

### Setup EAS Update OTA (3 commits)

- `3dd36168` feat(mobile): wire EAS Update OTA + emoji 🚀 en login (test)
- `f84c6344` test(mobile/login): cambiar emoji 🚀 a ⚡ para validar OTA
- `a12adf41` test(mobile/login): quitar emoji del subtitle (limpio)

Estos commits hicieron el setup de `expo-updates` + `app.json` config + EAS Dashboard env vars + canales `production`/`preview`. Ya validado funcionando con OTA `019dec71-2393-73c1-9afe-1b186cee71ef`. Los emoji eran solo para el test E2E del flow.

## OTA mobile ya publicado en prod

- Update group `30fe6adf-5718-4d2d-aca4-0bdafb797afb` con cambios JS de branches 2+3+5
- Vendedores con APK con expo-updates baked in lo reciben al cerrar/abrir 2 veces
- **Sin embargo**: hasta que NO se mergee este PR y Railway redeploye mobile-api, el OTA nuevo intentará llamar al endpoint `/resumen-tenant` que no existe → silent fail (la sección admin no se renderiza). Mergear este PR resuelve eso.

## Test plan

- [ ] **Web Vercel auto-deploy** post-merge: dashboard prod carga sin errores leaflet en `/team/{id}/gps?rango=7d` cuando se navega rápido entre eventos
- [ ] **Web client edit**: editar cliente con email/teléfono vacío → guarda sin error
- [ ] **Mobile (post-OTA + Railway redeploy)**:
  - [ ] Login admin@jeyma.com → modal "Sobre tu ubicación" NO aparece
  - [ ] `/equipo` → punto verde solo en vendedores con ping reciente (vendedor1 ✅, vendedor2 ❌ porque su último ping fue 5am)
  - [ ] `/equipo` → sección "HOY EN TODA LA EMPRESA" muestra 6 KPI cards con totales del tenant (17 pedidos, $X total, 17 cobros, etc.)
  - [ ] Click en vendedor1 → contadores muestran 17 pedidos / 17 cobros (no 0)

## Pre-deploy checklist

- ✅ Sin migraciones de BD
- ✅ Sin breaking API changes (endpoint `resumen-tenant` es nuevo, otros campos opcionales)
- ✅ Type-check + dotnet build OK
- ✅ Railway auto-redeploya mobile-api al merge (paths: `apps/mobile/**` y `libs/**`)
- ✅ Vercel auto-deploya web

## Merge strategy

**Squash and merge** para mantener historia limpia en main. Los 9 commits se consolidan en uno solo.
