### PR TITLE
fix(web): eliminar 401 race condition en bootstrap endpoints

### DIFF
--- a/apps/web/e2e/test-auth-no-401-race.spec.ts
+++ b/apps/web/e2e/test-auth-no-401-race.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * Regression — admin@jeyma.com 2026-05-03:
+ * En prod la consola del browser mostraba 401 al navegar a /team/{id}/gps:
+ *   GET /api/global-settings → 401
+ *   GET /api/company/settings → 401
+ *   GET /api/profile → 401
+ *
+ * Causa: race condition por orden de useEffect en React (child-first → parent-last).
+ * GlobalSettings/Company/Profile providers (children) disparaban sus fetch en
+ * useEffect ANTES de que HydrationProvider (parent) ejecutara su useEffect que
+ * seteaba `_cachedAccessToken` en api.ts. Resultado: requests salían sin
+ * Authorization header → 401 → response interceptor refresh + retry (transparente
+ * para el user pero contaminaba la consola).
+ *
+ * Fix: setApiAccessToken movido al cuerpo del hook useAuthSession (sync durante
+ * render). Por mount/render order (parent-first), HydrationProvider llena el
+ * cache antes de que cualquier child renderee.
+ */
+test.setTimeout(60_000);
+
+test.describe('Auth race condition — 401s en initial load', () => {
+  test('navegar a /team/{id}/gps no produce 401 en endpoints de bootstrap', async ({ page }) => {
+    const reqs401: Array<{ url: string; status: number }> = [];
+
+    page.on('response', (resp) => {
+      if (resp.status() === 401) {
+        reqs401.push({ url: resp.url(), status: 401 });
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto('/team/3/gps?dia=2026-05-02', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(2500);
+
+    const bootstrap401s = reqs401.filter((r) =>
+      /\/api\/(global-settings|company\/settings|profile)(\?|$)/.test(r.url)
+    );
+
+    if (bootstrap401s.length > 0) {
+      console.log('401s en bootstrap endpoints:');
+      bootstrap401s.forEach((r, i) => console.log(`  [${i}]`, r.url));
+    }
+    expect(bootstrap401s, 'No debe haber 401 en bootstrap endpoints (race condition fix)').toHaveLength(0);
+  });
+
+  test('navegar a /dashboard como admin tampoco produce 401 en bootstrap endpoints', async ({ page }) => {
+    const reqs401: Array<{ url: string; status: number }> = [];
+
+    page.on('response', (resp) => {
+      if (resp.status() === 401) {
+        reqs401.push({ url: resp.url(), status: 401 });
+      }
+    });
+
+    await loginAsAdmin(page);
+    await page.goto('/dashboard', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(2000);
+
+    const bootstrap401s = reqs401.filter((r) =>
+      /\/api\/(global-settings|company\/settings|profile)(\?|$)/.test(r.url)
+    );
+
+    expect(bootstrap401s, 'Dashboard tampoco debe disparar 401 en bootstrap').toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/useAuthSession.ts
+++ b/apps/web/src/hooks/useAuthSession.ts
@@ -11,6 +11,20 @@ export function useAuthSession() {
   const { setUser, setLoading } = useAppStore();
   const isSigningOut = useRef(false);
 
+  // SYNC durante render (NO en useEffect): React corre useEffects child-first →
+  // parent-last. Si seteamos el token en useEffect aquí (parent — HydrationProvider),
+  // los providers hijos (GlobalSettings/Company/Profile) ya dispararon sus fetches
+  // en su propio useEffect SIN el header Authorization → 401 silencioso (que el
+  // response interceptor reintenta, pero queda en consola). Escribir al cache
+  // módulo-level durante render es safe: no triggea re-renders.
+  if (typeof window !== 'undefined') {
+    if (status === 'authenticated' && session?.accessToken) {
+      setApiAccessToken(session.accessToken);
+    } else if (status === 'unauthenticated') {
+      setApiAccessToken(null);
+    }
+  }
+
   useEffect(() => {
     if (status === 'loading') {
       setLoading('auth', true);
@@ -40,10 +54,9 @@ export function useAuthSession() {
           createdAt: new Date(),
           updatedAt: new Date(),
         });
-        setApiAccessToken(session.accessToken || null);
+        // Token cache ya seteado arriba en el sync render path.
       } else {
         setUser(null);
-        setApiAccessToken(null);
       }
     }
   }, [session, status, setUser, setLoading]);


### PR DESCRIPTION
Reportado por admin@jeyma.com (2026-05-03): consola del browser mostraba 401 en /api/global-settings, /api/company/settings y /api/profile al navegar a paginas autenticadas. La pagina renderizaba bien (response interceptor reintenta con refresh), pero los 401 contaminaban la consola.

Causa raiz: React corre useEffects child-first -> parent-last. En ClientProviders.tsx, HydrationProvider (parent) llamaba setApiAccessToken en su useEffect, pero los 3 contexts hijos (GlobalSettings/Company/Profile) ya habian disparado sus fetches en sus propios useEffects, por lo tanto sin el header Authorization -> 401.

Fix: mover setApiAccessToken al cuerpo del hook useAuthSession (sync durante render). Por mount/render order (parent renders BEFORE children), el cache se llena antes de que cualquier child renderee o ejecute useEffects.

Tests:
- e2e/test-auth-no-401-race.spec.ts (2 tests, todos pasan):
  * /team/{id}/gps no dispara 401 en bootstrap endpoints
  * /dashboard tampoco dispara 401