### PR TITLE
hotfix: zod datetime rechaza formato .NET en /mis-vendedores

### DIFF
--- a/apps/mobile-app/src/api/schemas/supervisor.ts
+++ b/apps/mobile-app/src/api/schemas/supervisor.ts
@@ -11,7 +11,13 @@ export const VendedorEquipoSchema = z.object({
   // Optional/default false para retrocompat con APKs viejas o si el endpoint
   // no incluye el campo (graceful degradation a "desconectado").
   isOnline: z.boolean().optional().default(false),
-  ultimoPing: z.string().datetime().nullable().optional(),
+  // Backend serializa con .NET DateTime ToString("o"): formato
+  // "2026-05-04T00:59:18.3231698+00:00" (7 decimales, offset, sin Z).
+  // zod `.datetime()` por defecto rechaza offsets y +7 decimales — causaba
+  // "Invalid ISO datetime" en prod (admin@jeyma.com 2026-05-04 reportó tab
+  // Equipo cargando infinito). No validamos el formato — el backend es la
+  // fuente de verdad y el frontend solo lo muestra/parsea con new Date().
+  ultimoPing: z.string().nullable().optional(),
 });
 
 export const SupervisorDashboardSchema = z.object({


### PR DESCRIPTION
…o .NET

Reportado por admin@jeyma.com (2026-05-04 prod): tab Equipo se queda cargando infinitamente. Crash log:
  API validation failed: GET /api/mobile/supervisor/mis-vendedores
    - Invalid ISO datetime

Causa: zod `z.string().datetime()` por defecto exige formato Z (UTC) sin offset y maximo 3 decimales. El backend .NET serializa DateTime con ToString("o"): "2026-05-04T00:59:18.3231698+00:00" (7 decimales + offset). zod rechaza el response → frontend explota → tab Equipo no renderiza ninguna data → loading infinito.

Fix: cambiar a `z.string()` sin validacion de formato. El frontend ya no parsea el datetime con strict regex; solo lo muestra (formatTimeAgo usa new Date(string) que acepta cualquier ISO razonable).

Hotfix produccion — requiere EAS Update OTA tras el merge.