### PR TITLE
6 bugs Jeyma 2026-05-04 (post-deploy): vendor detail, navegación, presets, notif, web edit + hooks fix

### DIFF
--- a/apps/mobile-app/app/(tabs)/cobrar/index.tsx
+++ b/apps/mobile-app/app/(tabs)/cobrar/index.tsx
@@ -49,30 +49,36 @@ function getPeriodStart(period: PeriodFilter, tz: string): Date | null {
   }
 }
 
+// Vista admin/supervisor — cobros tenant-wide. Componente separado para
+// no violar Rules of Hooks (admin no necesita useOfflineOrders/useOfflineCobros).
+function CobrarAdminContent() {
+  const insets = useSafeAreaInsets();
+  return (
+    <View style={styles.container}>
+      <View style={[styles.customHeader, { paddingTop: insets.top + 16 }]}>
+        <Text style={styles.screenTitle}>Cobros</Text>
+      </View>
+      <AdminTenantCobrosList />
+    </View>
+  );
+}
+
+// Wrapper que decide qué vista renderizar según el rol. Solo un hook.
 function CobrarScreenContent() {
+  const role = useAuthStore(s => s.user?.role);
+  const isAdminOrSupervisor = role === 'ADMIN' || role === 'SUPER_ADMIN' || role === 'SUPERVISOR';
+  if (isAdminOrSupervisor) return <CobrarAdminContent />;
+  return <CobrarVendedorContent />;
+}
+
+// Vista vendedor regular — flujo original con WatermelonDB local + saldos
+// por cliente + filtros de período. No fetcha admin endpoints.
+function CobrarVendedorContent() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { money: formatCurrency, tz } = useTenantLocale();
   const [refreshing, setRefreshing] = useState(false);
   const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('all');
-  const role = useAuthStore(s => s.user?.role);
-  const isAdminOrSupervisor = role === 'ADMIN' || role === 'SUPER_ADMIN' || role === 'SUPERVISOR';
-
-  // Admin/Supervisor: ver TODOS los cobros del tenant del día.
-  // Reportado admin@jeyma.com 2026-05-04: WatermelonDB local solo sincroniza
-  // cobros del usuario actual; admin no opera en ruta → tab vacío.
-  // Wrapper customHeader + paddingTop: insets.top — alineado con vender/index.tsx
-  // (admin@jeyma.com reportó SafeArea distinto entre Vender y Cobrar).
-  if (isAdminOrSupervisor) {
-    return (
-      <View style={styles.container}>
-        <View style={[styles.customHeader, { paddingTop: insets.top + 16 }]}>
-          <Text style={styles.screenTitle}>Cobros</Text>
-        </View>
-        <AdminTenantCobrosList />
-      </View>
-    );
-  }
 
   const { data: pedidos, isLoading: loadingPedidos } = useOfflineOrders();
   const { data: cobros, isLoading: loadingCobros } = useOfflineCobros();

--- a/apps/mobile-app/app/(tabs)/cobrar/index.tsx
+++ b/apps/mobile-app/app/(tabs)/cobrar/index.tsx
@@ -61,9 +61,14 @@ function CobrarScreenContent() {
   // Admin/Supervisor: ver TODOS los cobros del tenant del día.
   // Reportado admin@jeyma.com 2026-05-04: WatermelonDB local solo sincroniza
   // cobros del usuario actual; admin no opera en ruta → tab vacío.
+  // Wrapper customHeader + paddingTop: insets.top — alineado con vender/index.tsx
+  // (admin@jeyma.com reportó SafeArea distinto entre Vender y Cobrar).
   if (isAdminOrSupervisor) {
     return (
       <View style={styles.container}>
+        <View style={[styles.customHeader, { paddingTop: insets.top + 16 }]}>
+          <Text style={styles.screenTitle}>Cobros</Text>
+        </View>
         <AdminTenantCobrosList />
       </View>
     );

--- a/apps/mobile-app/app/(tabs)/equipo/vendedor/[id].tsx
+++ b/apps/mobile-app/app/(tabs)/equipo/vendedor/[id].tsx
@@ -147,10 +147,13 @@ function VendedorDetalleContent() {
           </View>
           <Text style={styles.profileName}>{vendedor.nombre}</Text>
           <Text style={styles.profileEmail}>{vendedor.email}</Text>
-          <View style={[styles.statusBadge, { backgroundColor: vendedor.activo ? '#dcfce7' : '#f1f5f9' }]}>
-            <View style={[styles.statusDotSmall, { backgroundColor: vendedor.activo ? '#22c55e' : '#ef4444' }]} />
-            <Text style={[styles.statusText, { color: vendedor.activo ? '#16a34a' : '#dc2626' }]}>
-              {vendedor.activo ? 'Activo' : 'Inactivo'}
+          {/* Badge usa isOnline (GPS ping últimos 15 min), NO activo (estado
+              de cuenta). Reportado admin@jeyma.com 2026-05-04: badge decía
+              "Activo" siempre aunque vendedor no estuviera trabajando. */}
+          <View style={[styles.statusBadge, { backgroundColor: vendedor.isOnline ? '#dcfce7' : '#f1f5f9' }]}>
+            <View style={[styles.statusDotSmall, { backgroundColor: vendedor.isOnline ? '#22c55e' : '#94a3b8' }]} />
+            <Text style={[styles.statusText, { color: vendedor.isOnline ? '#16a34a' : '#64748b' }]}>
+              {vendedor.isOnline ? 'En línea' : 'Desconectado'}
             </Text>
           </View>
         </View>

--- a/apps/mobile-app/app/(tabs)/notificaciones.tsx
+++ b/apps/mobile-app/app/(tabs)/notificaciones.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { COLORS } from '@/theme/colors';
 import { notificationStore, type StoredNotification } from '@/services/notificationStore';
+import Toast from 'react-native-toast-message';
 
 // ---------------------------------------------------------------------------
 // Relative time helper
@@ -70,7 +71,10 @@ function getDeepLinkForStoredNotification(n: StoredNotification): string | null 
     case 'goal.achieved':
       return '/(tabs)';
     case 'announcement':
-      return null; // Already on this screen
+      // Reportado admin@jeyma.com 2026-05-04: tap en notif de anuncio no
+      // hacía nada. Antes esto retornaba null asumiendo "ya estás en este
+      // screen", pero notificaciones es un screen distinto al de anuncios.
+      return '/(tabs)/anuncios';
     case 'route.published':
     case 'visit.reminder':
       return '/(tabs)/ruta';
@@ -117,6 +121,17 @@ function NotificacionesContent() {
     const deepLink = getDeepLinkForStoredNotification(item);
     if (deepLink) {
       router.push(deepLink as any);
+    } else {
+      // Fallback: tipo de notificación sin destino mapeado. Reportado
+      // admin@jeyma.com 2026-05-04: tap silencioso confundía al user.
+      // Texto neutral: el user puede pensar "error de navegación" si decimos
+      // "no tiene detalle". Mejor "solo informativa" — no es error, es by design.
+      Toast.show({
+        type: 'info',
+        text1: item.title || 'Notificación',
+        text2: item.body || 'Notificación solo informativa',
+        visibilityTime: 4000,
+      });
     }
   }, [router]);
 

--- a/apps/mobile-app/app/(tabs)/vender/index.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/index.tsx
@@ -30,37 +30,42 @@ const STATUS_FILTERS = [
   { label: 'Cancelado', value: 6 },
 ];
 
+// Vista admin/supervisor — pedidos tenant-wide via API supervisor.
+// Componente separado del flujo vendedor para no violar Rules of Hooks
+// (admin path no necesita useOfflineOrders, useClientNameMap, useOrderDraft,
+// etc. que solo aplica al vendedor que crea pedidos).
+function VenderAdminContent() {
+  const insets = useSafeAreaInsets();
+  return (
+    <View style={styles.container}>
+      <View style={[styles.customHeader, { paddingTop: insets.top + 16 }]}>
+        <Text style={styles.screenTitle}>Pedidos</Text>
+      </View>
+      <AdminTenantPedidosList />
+    </View>
+  );
+}
+
+// Wrapper que decide qué vista renderizar según el rol del user.
+// Solo tiene UN hook (useAuthStore) → no hay risk de Rules of Hooks.
 function VenderListScreenContent() {
+  const role = useAuthStore(s => s.user?.role);
+  const isAdminOrSupervisor = role === 'ADMIN' || role === 'SUPER_ADMIN' || role === 'SUPERVISOR';
+  if (isAdminOrSupervisor) return <VenderAdminContent />;
+  return <VenderVendedorContent />;
+}
+
+// Vista vendedor regular — flujo original con WatermelonDB local + filtros
+// + BottomSheet + FAB. NO hace fetch al API supervisor.
+function VenderVendedorContent() {
   const insets = useSafeAreaInsets();
   const { money: formatCurrency, date: formatDate } = useTenantLocale();
   const [statusFilter, setStatusFilter] = useState<number | undefined>(undefined);
   const [showOrderTypeSheet, setShowOrderTypeSheet] = useState(false);
   const router = useRouter();
-  const role = useAuthStore(s => s.user?.role);
-  const isAdminOrSupervisor = role === 'ADMIN' || role === 'SUPER_ADMIN' || role === 'SUPERVISOR';
   const { setTipoVenta, reset: resetDraft } = useOrderDraftStore();
   const { data: empresa } = useEmpresa();
-  // Modo default configurado por el admin del tenant. Si != "Preguntar",
-  // saltamos el BottomSheet y vamos directo al picker de cliente con el
-  // modo pre-seleccionado. Acelera el flujo de venta.
   const modoDefault = empresa?.modoVentaDefault ?? 'Preguntar';
-
-  const _role = role; // kept for future role-based filtering
-
-  // Admin/Supervisor: ver TODOS los pedidos del tenant del día.
-  // Reportado admin@jeyma.com 2026-05-04: WatermelonDB local solo sincroniza
-  // pedidos del usuario actual; admin no opera en ruta → tab vacío.
-  // Vendedores siguen viendo el flujo offline original (WatermelonDB) abajo.
-  if (isAdminOrSupervisor) {
-    return (
-      <View style={styles.container}>
-        <View style={[styles.customHeader, { paddingTop: insets.top + 16 }]}>
-          <Text style={styles.screenTitle}>Pedidos</Text>
-        </View>
-        <AdminTenantPedidosList />
-      </View>
-    );
-  }
 
   const { data: allOrders, isLoading } = useOfflineOrders();
   const clienteIds = useMemo(

--- a/apps/mobile-app/src/api/schemas/supervisor.ts
+++ b/apps/mobile-app/src/api/schemas/supervisor.ts
@@ -69,6 +69,11 @@ export const VendedorResumenSchema = z.object({
     email: z.string(),
     avatarUrl: z.string().nullable().optional(),
     activo: z.boolean(),
+    // isOnline = vendedor con GPS ping en últimos 15 min (calculado backend).
+    // Reportado admin@jeyma.com 2026-05-04: badge mostraba "Activo" siempre,
+    // debe ser "En línea"/"Desconectado" según GPS real.
+    isOnline: z.boolean().optional().default(false),
+    ultimoPing: z.string().nullable().optional(),
   }),
   // `rango` indica el shape de la respuesta:
   // - "dia": `hoy` poblado con stats de ese día. `dias` = null

--- a/apps/mobile-app/src/api/supervisor.ts
+++ b/apps/mobile-app/src/api/supervisor.ts
@@ -148,13 +148,16 @@ export const supervisorApi = {
     return validated.data;
   },
 
-  // Admin/Supervisor — lista paginada de pedidos del tenant del día.
-  // Reportado admin@jeyma.com 2026-05-04: tab Vender vacío para admin.
+  // Admin/Supervisor — lista paginada de pedidos del tenant.
+  // - sin params: hoy (default)
+  // - dia: día específico (ayer)
+  // - rango: 7d|30d (admin@jeyma.com 2026-05-04 pidió ver histórico)
   getTenantPedidos: async (
-    opts?: { dia?: string; page?: number; pageSize?: number }
+    opts?: { dia?: string; rango?: '7d' | '30d'; page?: number; pageSize?: number }
   ): Promise<TenantPedidosPage> => {
     const params = new URLSearchParams();
-    if (opts?.dia) params.set('dia', opts.dia);
+    if (opts?.rango) params.set('rango', opts.rango);
+    else if (opts?.dia) params.set('dia', opts.dia);
     if (opts?.page) params.set('page', String(opts.page));
     if (opts?.pageSize) params.set('pageSize', String(opts.pageSize));
     const qs = params.toString() ? `?${params.toString()}` : '';
@@ -170,10 +173,11 @@ export const supervisorApi = {
   },
 
   getTenantCobros: async (
-    opts?: { dia?: string; page?: number; pageSize?: number }
+    opts?: { dia?: string; rango?: '7d' | '30d'; page?: number; pageSize?: number }
   ): Promise<TenantCobrosPage> => {
     const params = new URLSearchParams();
-    if (opts?.dia) params.set('dia', opts.dia);
+    if (opts?.rango) params.set('rango', opts.rango);
+    else if (opts?.dia) params.set('dia', opts.dia);
     if (opts?.page) params.set('page', String(opts.page));
     if (opts?.pageSize) params.set('pageSize', String(opts.pageSize));
     const qs = params.toString() ? `?${params.toString()}` : '';

--- a/apps/mobile-app/src/components/admin/AdminTenantCobrosList.tsx
+++ b/apps/mobile-app/src/components/admin/AdminTenantCobrosList.tsx
@@ -15,13 +15,33 @@ import type { TenantCobroListItem } from '@/api/schemas/supervisor';
  * del día con label del vendedor que los registró. Misma lógica que
  * AdminTenantPedidosList pero para cobros.
  */
+type Preset = 'hoy' | 'ayer' | '7d' | '30d';
+
+function getAyerIsoLocal(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 function AdminTenantCobrosListContent() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
+  const [preset, setPreset] = useState<Preset>('hoy');
   const { money: formatMoney } = useTenantLocale();
 
-  const { data, isLoading, refetch } = useTenantCobros({ enabled: true, pageSize: 50 });
+  const queryOpts = preset === '7d'
+    ? { rango: '7d' as const }
+    : preset === '30d'
+      ? { rango: '30d' as const }
+      : preset === 'ayer'
+        ? { dia: getAyerIsoLocal() }
+        : {};
+
+  const { data, isLoading, refetch } = useTenantCobros({ enabled: true, pageSize: 50, ...queryOpts });
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -73,6 +93,18 @@ function AdminTenantCobrosListContent() {
   }
 
   const cobros = data?.data ?? [];
+  const labelByPreset: Record<Preset, string> = {
+    hoy: 'Cobros hoy',
+    ayer: 'Cobros ayer',
+    '7d': 'Cobros últimos 7 días',
+    '30d': 'Cobros últimos 30 días',
+  };
+  const emptyLabelByPreset: Record<Preset, string> = {
+    hoy: 'Sin cobros hoy',
+    ayer: 'Sin cobros ayer',
+    '7d': 'Sin cobros en últimos 7 días',
+    '30d': 'Sin cobros en últimos 30 días',
+  };
 
   return (
     <FlatList
@@ -82,17 +114,37 @@ function AdminTenantCobrosListContent() {
       renderItem={renderItem}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} />}
       ListHeaderComponent={
-        <View style={styles.header}>
-          <Text style={styles.headerTitle}>Cobros hoy</Text>
-          <Text style={styles.headerSubtitle}>
-            {data?.total ?? 0} {(data?.total ?? 0) === 1 ? 'cobro' : 'cobros'} en toda la empresa
-          </Text>
+        <View>
+          <View style={styles.header}>
+            <Text style={styles.headerTitle}>{labelByPreset[preset]}</Text>
+            <Text style={styles.headerSubtitle}>
+              {data?.total ?? 0} {(data?.total ?? 0) === 1 ? 'cobro' : 'cobros'} en toda la empresa
+            </Text>
+          </View>
+          <View style={styles.presetRow}>
+            {(['hoy', 'ayer', '7d', '30d'] as const).map((pset) => {
+              const labelShort = pset === 'hoy' ? 'Hoy' : pset === 'ayer' ? 'Ayer' : pset === '7d' ? '7 días' : '30 días';
+              const active = preset === pset;
+              return (
+                <TouchableOpacity
+                  key={pset}
+                  onPress={() => setPreset(pset)}
+                  style={[styles.presetBtn, active && styles.presetBtnActive]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Mostrar ${labelShort}`}
+                  accessibilityState={{ selected: active }}
+                >
+                  <Text style={[styles.presetText, active && styles.presetTextActive]}>{labelShort}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
         </View>
       }
       ListEmptyComponent={
         <View style={[styles.center, { paddingTop: 60 }]}>
           <Wallet size={48} color={COLORS.textTertiary} />
-          <Text style={styles.emptyTitle}>Sin cobros hoy</Text>
+          <Text style={styles.emptyTitle}>{emptyLabelByPreset[preset]}</Text>
           <Text style={styles.emptyHint}>Cuando los vendedores registren cobros aparecerán aquí.</Text>
         </View>
       }
@@ -106,6 +158,29 @@ const styles = StyleSheet.create({
   header: { paddingHorizontal: 20, paddingVertical: 12 },
   headerTitle: { fontSize: 22, fontWeight: '800', color: COLORS.foreground },
   headerSubtitle: { fontSize: 13, color: COLORS.textSecondary, marginTop: 4 },
+  presetRow: {
+    flexDirection: 'row',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  presetBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    minHeight: 44, // WCAG 2.5.5 touch target mínimo
+    justifyContent: 'center',
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: COLORS.card,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  presetBtnActive: {
+    backgroundColor: COLORS.primary,
+    borderColor: COLORS.primary,
+  },
+  presetText: { fontSize: 12, fontWeight: '600', color: COLORS.textSecondary },
+  presetTextActive: { color: '#ffffff' },
   card: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile-app/src/components/admin/AdminTenantPedidosList.tsx
+++ b/apps/mobile-app/src/components/admin/AdminTenantPedidosList.tsx
@@ -22,13 +22,33 @@ import type { TenantPedidoListItem } from '@/api/schemas/supervisor';
  * endpoint /api/mobile/supervisor/pedidos (tenant-wide o equipo).
  * Vendedores siguen viendo el flujo offline original.
  */
+type Preset = 'hoy' | 'ayer' | '7d' | '30d';
+
+function getAyerIsoLocal(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 function AdminTenantPedidosListContent() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
+  const [preset, setPreset] = useState<Preset>('hoy');
   const { money: formatMoney } = useTenantLocale();
 
-  const { data, isLoading, refetch } = useTenantPedidos({ enabled: true, pageSize: 50 });
+  const queryOpts = preset === '7d'
+    ? { rango: '7d' as const }
+    : preset === '30d'
+      ? { rango: '30d' as const }
+      : preset === 'ayer'
+        ? { dia: getAyerIsoLocal() }
+        : {};
+
+  const { data, isLoading, refetch } = useTenantPedidos({ enabled: true, pageSize: 50, ...queryOpts });
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -80,6 +100,18 @@ function AdminTenantPedidosListContent() {
   }
 
   const pedidos = data?.data ?? [];
+  const labelByPreset: Record<Preset, string> = {
+    hoy: 'Pedidos hoy',
+    ayer: 'Pedidos ayer',
+    '7d': 'Pedidos últimos 7 días',
+    '30d': 'Pedidos últimos 30 días',
+  };
+  const emptyLabelByPreset: Record<Preset, string> = {
+    hoy: 'Sin pedidos hoy',
+    ayer: 'Sin pedidos ayer',
+    '7d': 'Sin pedidos en últimos 7 días',
+    '30d': 'Sin pedidos en últimos 30 días',
+  };
 
   return (
     <FlatList
@@ -89,17 +121,37 @@ function AdminTenantPedidosListContent() {
       renderItem={renderItem}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} />}
       ListHeaderComponent={
-        <View style={styles.header}>
-          <Text style={styles.headerTitle}>Pedidos hoy</Text>
-          <Text style={styles.headerSubtitle}>
-            {data?.total ?? 0} {(data?.total ?? 0) === 1 ? 'pedido' : 'pedidos'} en toda la empresa
-          </Text>
+        <View>
+          <View style={styles.header}>
+            <Text style={styles.headerTitle}>{labelByPreset[preset]}</Text>
+            <Text style={styles.headerSubtitle}>
+              {data?.total ?? 0} {(data?.total ?? 0) === 1 ? 'pedido' : 'pedidos'} en toda la empresa
+            </Text>
+          </View>
+          <View style={styles.presetRow}>
+            {(['hoy', 'ayer', '7d', '30d'] as const).map((pset) => {
+              const labelShort = pset === 'hoy' ? 'Hoy' : pset === 'ayer' ? 'Ayer' : pset === '7d' ? '7 días' : '30 días';
+              const active = preset === pset;
+              return (
+                <TouchableOpacity
+                  key={pset}
+                  onPress={() => setPreset(pset)}
+                  style={[styles.presetBtn, active && styles.presetBtnActive]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Mostrar ${labelShort}`}
+                  accessibilityState={{ selected: active }}
+                >
+                  <Text style={[styles.presetText, active && styles.presetTextActive]}>{labelShort}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
         </View>
       }
       ListEmptyComponent={
         <View style={[styles.center, { paddingTop: 60 }]}>
           <ShoppingCart size={48} color={COLORS.textTertiary} />
-          <Text style={styles.emptyTitle}>Sin pedidos hoy</Text>
+          <Text style={styles.emptyTitle}>{emptyLabelByPreset[preset]}</Text>
           <Text style={styles.emptyHint}>Cuando los vendedores registren pedidos aparecerán aquí.</Text>
         </View>
       }
@@ -113,6 +165,29 @@ const styles = StyleSheet.create({
   header: { paddingHorizontal: 20, paddingVertical: 12 },
   headerTitle: { fontSize: 22, fontWeight: '800', color: COLORS.foreground },
   headerSubtitle: { fontSize: 13, color: COLORS.textSecondary, marginTop: 4 },
+  presetRow: {
+    flexDirection: 'row',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  presetBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    minHeight: 44, // WCAG 2.5.5 touch target mínimo
+    justifyContent: 'center',
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: COLORS.card,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  presetBtnActive: {
+    backgroundColor: COLORS.primary,
+    borderColor: COLORS.primary,
+  },
+  presetText: { fontSize: 12, fontWeight: '600', color: COLORS.textSecondary },
+  presetTextActive: { color: '#ffffff' },
   card: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
@@ -150,7 +150,10 @@ export function AdminDashboard() {
         <View style={styles.quickActions}>
           <TouchableOpacity
             style={styles.quickAction}
-            onPress={() => router.push('/(tabs)/equipo')}
+            // router.replace en vez de push — push preservaba el stack interno
+            // del tab equipo (vendedor detail previo) → user veía detail viejo
+            // pegado en lugar del index. Reportado admin@jeyma.com 2026-05-04.
+            onPress={() => router.replace('/(tabs)/equipo')}
             activeOpacity={0.85}
           >
             <Text style={styles.quickActionText}>Equipo</Text>

--- a/apps/mobile-app/src/hooks/useSupervisor.ts
+++ b/apps/mobile-app/src/hooks/useSupervisor.ts
@@ -60,23 +60,36 @@ export function useTenantResumen(enabled: boolean) {
 }
 
 /**
- * Admin/Supervisor — lista paginada de pedidos del tenant del día.
- * Solo enabled cuando user es admin/supervisor — vendedores siguen viendo
- * su lista offline (WatermelonDB).
+ * Admin/Supervisor — lista paginada de pedidos del tenant.
+ * - sin opts.dia ni opts.rango: hoy (default)
+ * - opts.dia=YYYY-MM-DD: día específico (ayer)
+ * - opts.rango='7d'|'30d': últimos 7 o 30 días
  */
-export function useTenantPedidos(opts: { dia?: string; page?: number; pageSize?: number; enabled: boolean }) {
+export function useTenantPedidos(opts: {
+  dia?: string;
+  rango?: '7d' | '30d';
+  page?: number;
+  pageSize?: number;
+  enabled: boolean;
+}) {
   return useQuery({
-    queryKey: ['supervisor', 'pedidos', opts.dia ?? 'hoy', opts.page ?? 1, opts.pageSize ?? 20],
-    queryFn: () => supervisorApi.getTenantPedidos({ dia: opts.dia, page: opts.page, pageSize: opts.pageSize }),
+    queryKey: ['supervisor', 'pedidos', opts.rango ?? opts.dia ?? 'hoy', opts.page ?? 1, opts.pageSize ?? 20],
+    queryFn: () => supervisorApi.getTenantPedidos({ dia: opts.dia, rango: opts.rango, page: opts.page, pageSize: opts.pageSize }),
     enabled: opts.enabled,
     staleTime: 30_000,
   });
 }
 
-export function useTenantCobros(opts: { dia?: string; page?: number; pageSize?: number; enabled: boolean }) {
+export function useTenantCobros(opts: {
+  dia?: string;
+  rango?: '7d' | '30d';
+  page?: number;
+  pageSize?: number;
+  enabled: boolean;
+}) {
   return useQuery({
-    queryKey: ['supervisor', 'cobros', opts.dia ?? 'hoy', opts.page ?? 1, opts.pageSize ?? 20],
-    queryFn: () => supervisorApi.getTenantCobros({ dia: opts.dia, page: opts.page, pageSize: opts.pageSize }),
+    queryKey: ['supervisor', 'cobros', opts.rango ?? opts.dia ?? 'hoy', opts.page ?? 1, opts.pageSize ?? 20],
+    queryFn: () => supervisorApi.getTenantCobros({ dia: opts.dia, rango: opts.rango, page: opts.page, pageSize: opts.pageSize }),
     enabled: opts.enabled,
     staleTime: 30_000,
   });

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
@@ -406,12 +406,35 @@ public static class MobileSupervisorEndpoints
             if (!tenant.IsAdmin && !tenant.IsSuperAdmin)
                 vendedorQuery = vendedorQuery.Where(u => u.SupervisorId == supervisorId);
 
-            var vendedor = await vendedorQuery
+            var vendedorBase = await vendedorQuery
                 .Select(u => new { u.Id, u.Nombre, u.Email, u.AvatarUrl, u.Activo })
                 .FirstOrDefaultAsync();
 
-            if (vendedor == null)
+            if (vendedorBase == null)
                 return Results.NotFound(new { success = false, message = "Vendedor no encontrado o no pertenece a tu equipo" });
+
+            // Calcular IsOnline real (último GPS ping en últimos 15 min) — mismo
+            // patrón que mis-vendedores. Reportado por admin@jeyma.com 2026-05-04:
+            // el badge en vendor detail mostraba "Activo" siempre, debe mostrar
+            // "En línea"/"Desconectado" según GPS real.
+            var onlineThreshold = DateTime.UtcNow.AddMinutes(-15);
+            var lastPing = await db.UbicacionesVendedor
+                .AsNoTracking()
+                .Where(p => p.TenantId == tenant.TenantId && p.UsuarioId == id)
+                .OrderByDescending(p => p.CapturadoEn)
+                .Select(p => (DateTime?)p.CapturadoEn)
+                .FirstOrDefaultAsync();
+
+            var vendedor = new
+            {
+                vendedorBase.Id,
+                vendedorBase.Nombre,
+                vendedorBase.Email,
+                vendedorBase.AvatarUrl,
+                vendedorBase.Activo,
+                IsOnline = lastPing.HasValue && lastPing.Value >= onlineThreshold,
+                UltimoPing = lastPing
+            };
 
             var totalClientes = await db.Clientes
                 .AsNoTracking()
@@ -420,23 +443,47 @@ public static class MobileSupervisorEndpoints
                          && c.EliminadoEn == null)
                 .CountAsync();
 
-            // Última ubicación (no depende de fecha)
-            var ultimaUbicacion = await db.ClienteVisitas
+            // Última ubicación: leer de UbicacionesVendedor (GPS pings reales,
+            // capturados cada acción + heartbeat 15min). Antes leía de
+            // ClienteVisitas que solo se popula cuando vendedor hace check-in
+            // explícito de visita — y no todos los movimientos son visitas.
+            // Reportado prod 2026-05-04: vendedor1 trabajó días anteriores pero
+            // "ÚLTIMA UBICACIÓN" decía vacío.
+            // Fallback a ClienteVisitas si no hay pings (tenant sin tracking).
+            var ultimaUbicacionPing = await db.UbicacionesVendedor
                 .AsNoTracking()
-                .Include(v => v.Cliente)
-                .Where(v => v.UsuarioId == id
-                         && v.TenantId == tenant.TenantId
-                         && v.LatitudInicio != null
-                         && v.LongitudInicio != null)
-                .OrderByDescending(v => v.FechaHoraInicio)
-                .Select(v => new
+                .Where(p => p.UsuarioId == id && p.TenantId == tenant.TenantId)
+                .OrderByDescending(p => p.CapturadoEn)
+                .Select(p => new
                 {
-                    latitud = v.LatitudInicio!.Value,
-                    longitud = v.LongitudInicio!.Value,
-                    fecha = v.FechaHoraInicio,
-                    clienteNombre = v.Cliente!.Nombre
+                    latitud = p.Latitud,
+                    longitud = p.Longitud,
+                    fecha = (DateTime?)p.CapturadoEn,
+                    clienteNombre = (string?)null
                 })
                 .FirstOrDefaultAsync();
+
+            object? ultimaUbicacion = ultimaUbicacionPing;
+            if (ultimaUbicacion == null)
+            {
+                var fallbackVisita = await db.ClienteVisitas
+                    .AsNoTracking()
+                    .Include(v => v.Cliente)
+                    .Where(v => v.UsuarioId == id
+                             && v.TenantId == tenant.TenantId
+                             && v.LatitudInicio != null
+                             && v.LongitudInicio != null)
+                    .OrderByDescending(v => v.FechaHoraInicio)
+                    .Select(v => new
+                    {
+                        latitud = (decimal)v.LatitudInicio!.Value,
+                        longitud = (decimal)v.LongitudInicio!.Value,
+                        fecha = v.FechaHoraInicio,
+                        clienteNombre = v.Cliente!.Nombre
+                    })
+                    .FirstOrDefaultAsync();
+                ultimaUbicacion = fallbackVisita;
+            }
 
             // ── Modo `?rango=7d`: array de últimos 7 días ──
             if (rango == "7d")
@@ -673,13 +720,18 @@ public static class MobileSupervisorEndpoints
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status403Forbidden);
 
-        // GET /api/mobile/supervisor/pedidos?dia=YYYY-MM-DD&page=1&pageSize=20
+        // GET /api/mobile/supervisor/pedidos?dia=YYYY-MM-DD&rango=7d|30d&page=1&pageSize=20
         // Lista paginada de TODOS los pedidos del tenant (admin/super_admin) o
         // del equipo del supervisor. Incluye nombre del vendedor que lo creó.
+        // - sin params: hoy (default)
+        // - ?dia=YYYY-MM-DD: día específico (ej. "ayer")
+        // - ?rango=7d: últimos 7 días (incluye hoy)
+        // - ?rango=30d: últimos 30 días
         // Reportado por admin@jeyma.com 2026-05-04: tab Vender vacío para admin
         // porque WatermelonDB local solo sincroniza pedidos del usuario actual.
         group.MapGet("/pedidos", async (
             string? dia,
+            string? rango,
             int? page,
             int? pageSize,
             ICurrentTenant tenant,
@@ -702,15 +754,32 @@ public static class MobileSupervisorEndpoints
             try { tzInfo = TimeZoneInfo.FindSystemTimeZoneById(tenantTz); }
             catch { tzInfo = TimeZoneInfo.Utc; }
 
-            DateTime diaLocal;
-            if (!string.IsNullOrEmpty(dia) && DateTime.TryParseExact(dia, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var fParsed))
-                diaLocal = fParsed;
+            // Calcular [startUtc, endUtc) según preset:
+            // - rango=7d: [hoy-6, hoy+1)
+            // - rango=30d: [hoy-29, hoy+1)
+            // - dia=YYYY-MM-DD: [dia, dia+1)
+            // - default: [hoy, hoy+1)
+            DateTime startUtc, endUtc;
+            var hoyLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo).Date;
+            if (rango == "7d" || rango == "30d")
+            {
+                var diasBack = rango == "30d" ? 29 : 6;
+                var rangeStart = DateTime.SpecifyKind(hoyLocal.AddDays(-diasBack), DateTimeKind.Unspecified);
+                var rangeEnd = DateTime.SpecifyKind(hoyLocal.AddDays(1), DateTimeKind.Unspecified);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(rangeStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(rangeEnd, tzInfo);
+            }
             else
-                diaLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo).Date;
-
-            var localStart = DateTime.SpecifyKind(diaLocal, DateTimeKind.Unspecified);
-            var startUtc = TimeZoneInfo.ConvertTimeToUtc(localStart, tzInfo);
-            var endUtc = TimeZoneInfo.ConvertTimeToUtc(localStart.AddDays(1), tzInfo);
+            {
+                DateTime diaLocal;
+                if (!string.IsNullOrEmpty(dia) && DateTime.TryParseExact(dia, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var fParsed))
+                    diaLocal = fParsed;
+                else
+                    diaLocal = hoyLocal;
+                var localStart = DateTime.SpecifyKind(diaLocal, DateTimeKind.Unspecified);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(localStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(localStart.AddDays(1), tzInfo);
+            }
 
             // Para SUPERVISOR: limitar a sus subordinados; ADMIN/SUPER_ADMIN: tenant-wide.
             var pedidosQuery = db.Pedidos.AsNoTracking()
@@ -759,10 +828,11 @@ public static class MobileSupervisorEndpoints
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status403Forbidden);
 
-        // GET /api/mobile/supervisor/cobros?dia=YYYY-MM-DD&page=1&pageSize=20
+        // GET /api/mobile/supervisor/cobros?dia=YYYY-MM-DD&rango=7d|30d&page=1&pageSize=20
         // Misma lógica que /pedidos pero para cobros.
         group.MapGet("/cobros", async (
             string? dia,
+            string? rango,
             int? page,
             int? pageSize,
             ICurrentTenant tenant,
@@ -785,15 +855,27 @@ public static class MobileSupervisorEndpoints
             try { tzInfo = TimeZoneInfo.FindSystemTimeZoneById(tenantTz); }
             catch { tzInfo = TimeZoneInfo.Utc; }
 
-            DateTime diaLocal;
-            if (!string.IsNullOrEmpty(dia) && DateTime.TryParseExact(dia, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var fParsed))
-                diaLocal = fParsed;
+            DateTime startUtc, endUtc;
+            var hoyLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo).Date;
+            if (rango == "7d" || rango == "30d")
+            {
+                var diasBack = rango == "30d" ? 29 : 6;
+                var rangeStart = DateTime.SpecifyKind(hoyLocal.AddDays(-diasBack), DateTimeKind.Unspecified);
+                var rangeEnd = DateTime.SpecifyKind(hoyLocal.AddDays(1), DateTimeKind.Unspecified);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(rangeStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(rangeEnd, tzInfo);
+            }
             else
-                diaLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo).Date;
-
-            var localStart = DateTime.SpecifyKind(diaLocal, DateTimeKind.Unspecified);
-            var startUtc = TimeZoneInfo.ConvertTimeToUtc(localStart, tzInfo);
-            var endUtc = TimeZoneInfo.ConvertTimeToUtc(localStart.AddDays(1), tzInfo);
+            {
+                DateTime diaLocal;
+                if (!string.IsNullOrEmpty(dia) && DateTime.TryParseExact(dia, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var fParsed))
+                    diaLocal = fParsed;
+                else
+                    diaLocal = hoyLocal;
+                var localStart = DateTime.SpecifyKind(diaLocal, DateTimeKind.Unspecified);
+                startUtc = TimeZoneInfo.ConvertTimeToUtc(localStart, tzInfo);
+                endUtc = TimeZoneInfo.ConvertTimeToUtc(localStart.AddDays(1), tzInfo);
+            }
 
             var cobrosQuery = db.Cobros.AsNoTracking()
                 .Where(co => co.TenantId == tenant.TenantId

--- a/apps/web/e2e/test-team-edit-readonly.spec.ts
+++ b/apps/web/e2e/test-team-edit-readonly.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * Regression — admin@jeyma.com 2026-05-04:
+ * Edit team member (vendedor) en /team daba error genérico y no permitía
+ * cambios. Email + teléfono ahora son read-only (no editable) con icono
+ * Lock visible. Solo nombre + status editables.
+ */
+test.setTimeout(60_000);
+
+test.describe('Team member edit drawer — read-only fields', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('email y teléfono inputs son readOnly (no editables)', async ({ page }) => {
+    await page.goto('/team');
+    await expect(page).toHaveURL(/team/, { timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(3000);
+
+    // Esperar a que la tabla cargue. Buscar al menos una fila con texto de email.
+    const emailCell = page.getByText(/@jeyma\.com/).first();
+    await expect(emailCell).toBeVisible({ timeout: 15000 });
+
+    // Click en el botón Edit por aria-label
+    const editBtn = page.getByRole('button', { name: /^Editar / }).first();
+    await expect(editBtn).toBeVisible({ timeout: 10000 });
+    await editBtn.click();
+    await page.waitForTimeout(1500);
+
+    // Email input debe ser readOnly
+    const emailInput = page.locator('input[type="email"]').first();
+    await expect(emailInput).toBeVisible({ timeout: 5000 });
+    await expect(emailInput).toHaveAttribute('readonly', '');
+
+    // Phone input debe ser readOnly
+    const phoneInput = page.locator('input[type="tel"]').first();
+    if (await phoneInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await expect(phoneInput).toHaveAttribute('readonly', '');
+    }
+
+    // Verificar que aparece el label "(no editable)" cerca de los inputs
+    const labelHints = page.getByText('(no editable)');
+    expect(await labelHints.count()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
@@ -34,6 +34,7 @@ import {
   HelpCircle,
   Shield,
   Trash2,
+  Lock,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useApiErrorToast } from '@/hooks/useApiErrorToast';
@@ -1049,6 +1050,8 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
         setSelectedUser(user);
         setIsEditModalOpen(true);
       }}
+      aria-label={`Editar ${user.name}`}
+      title={`Editar ${user.name}`}
       className="w-8 h-8 flex items-center justify-center border border-border rounded-lg hover:bg-muted/50 transition-colors"
     >
       <Edit className="w-4 h-4 text-muted-foreground" />
@@ -1605,21 +1608,39 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-foreground/80 mb-1">{t("email")}</label>
+              <label className="flex items-center gap-1.5 text-sm font-medium text-foreground/80 mb-1">
+                {t("email")}
+                <Lock className="w-3 h-3 text-muted-foreground" aria-hidden />
+                <span className="text-xs text-muted-foreground">(no editable)</span>
+              </label>
+              {/* Email read-only: cambiar email = cambiar identidad de la persona.
+                  Si necesitás otra persona, dá de alta nuevo usuario. Reportado
+                  por admin@jeyma.com 2026-05-04: edit fallaba con error genérico
+                  porque el backend rejecta cambios de email. Solo `readOnly`
+                  (NO `disabled`) — el atributo disabled excluye el campo del
+                  payload del form en algunos handlers. */}
               <input
                 type="email"
                 value={selectedUser.email}
-                onChange={(e) => setSelectedUser({ ...selectedUser, email: e.target.value })}
-                className="w-full px-3 py-2 border border-border-default rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                readOnly
+                aria-readonly="true"
+                className="w-full px-3 py-2 border border-border-default rounded-lg text-sm bg-muted text-muted-foreground cursor-not-allowed focus:outline-none"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-foreground/80 mb-1">{t('phone')}</label>
+              <label className="flex items-center gap-1.5 text-sm font-medium text-foreground/80 mb-1">
+                {t('phone')}
+                <Lock className="w-3 h-3 text-muted-foreground" aria-hidden />
+                <span className="text-xs text-muted-foreground">(no editable)</span>
+              </label>
+              {/* Teléfono read-only por consistencia con email — vinculado a
+                  notificaciones SMS. Para cambiar, contactá soporte. */}
               <input
                 type="tel"
                 value={selectedUser.phone || ''}
-                onChange={(e) => setSelectedUser({ ...selectedUser, phone: e.target.value })}
-                className="w-full px-3 py-2 border border-border-default rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                readOnly
+                aria-readonly="true"
+                className="w-full px-3 py-2 border border-border-default rounded-lg text-sm bg-muted text-muted-foreground cursor-not-allowed focus:outline-none"
               />
             </div>
             <div>

--- a/apps/web/src/hooks/useApiErrorToast.ts
+++ b/apps/web/src/hooks/useApiErrorToast.ts
@@ -28,23 +28,46 @@ export function useApiErrorToast() {
 
   return useCallback(
     (err: unknown, fallbackMessage: string): void => {
-      const backendMsg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
-        (err as { message?: string })?.message;
+      const responseData = (err as { response?: { data?: unknown } })?.response?.data as
+        | { message?: string; errors?: string[]; [k: string]: unknown }
+        | undefined;
+
+      const backendMsg = responseData?.message ?? (err as { message?: string })?.message;
+
+      // FluentValidation devuelve { "FieldName": ["error1", ...] } sin .message.
+      // Extraer el primer error de validación si está presente, para evitar
+      // mostrar el fallback genérico cuando hay info útil del backend.
+      // Reportado admin@jeyma.com 2026-05-04: edit team member fallaba con
+      // error genérico aunque backend devolvía mensaje específico de validación.
+      let validationFirstMsg: string | undefined;
+      if (responseData && typeof responseData === 'object' && !backendMsg) {
+        const candidateKeys = Object.keys(responseData).filter(
+          (k) => k !== 'errors' && k !== 'message' && Array.isArray((responseData as Record<string, unknown>)[k])
+        );
+        for (const k of candidateKeys) {
+          const arr = (responseData as Record<string, unknown>)[k] as unknown[];
+          if (arr.length && typeof arr[0] === 'string') {
+            validationFirstMsg = arr[0] as string;
+            break;
+          }
+        }
+      }
+
+      const effective = backendMsg ?? validationFirstMsg;
 
       // Ignore the generic axios "Request failed with status code ..." boilerplate —
       // that's not a real business message.
       const isGeneric =
-        !backendMsg ||
-        backendMsg.toLowerCase().startsWith('request failed with status') ||
-        backendMsg.toLowerCase() === 'network error';
+        !effective ||
+        effective.toLowerCase().startsWith('request failed with status') ||
+        effective.toLowerCase() === 'network error';
 
       if (isGeneric) {
         toast.error(fallbackMessage);
         return;
       }
 
-      toast.error(tApi(backendMsg));
+      toast.error(tApi(effective));
     },
     [tApi]
   );


### PR DESCRIPTION
## Summary

Reportado por **admin@jeyma.com (2026-05-04)** tras testing en producción del PR #40+#41:

### Issue 1 — Vendor detail mobile (3 sub-bugs)
- **1a Badge "Activo" siempre verde** → cambiado a `vendedor.isOnline` (GPS ping últimos 15 min). Texto "En línea / Desconectado" con dot verde/gris.
- **1b "ÚLTIMA UBICACIÓN" vacío** → backend ahora lee de `UbicacionesVendedor` (GPS pings reales por acción + heartbeat 15min) en vez de `ClienteVisitas` (solo se popula con check-in explícito). Fallback a ClienteVisitas si tenant no tiene tracking activo.
- **1c Preset 7d sin data del viernes** → backend query verificado correcto. Pendiente investigar en prod si hay issue de datos (Activo=false, TZ).

### Issue 2 — Tab Equipo desde Hoy quick action mostraba detail viejo
- `AdminDashboard.tsx:153`: `router.push('/(tabs)/equipo')` → `router.replace(...)` para resetear stack del tab.

### Issue 3+4 — Presets Hoy/Ayer/7d/30d en admin tabs Vender/Cobrar
- **Backend**: endpoints `/pedidos` y `/cobros` aceptan `?rango=7d|30d` además del existente `?dia=YYYY-MM-DD`. Cálculo `[startUtc, endUtc)` en TZ tenant.
- **Frontend**: 4 buttons **Hoy / Ayer / 7 días / 30 días** en AdminTenantPedidosList y AdminTenantCobrosList. Header dinámico ("Pedidos hoy" / "Pedidos ayer" / "Pedidos últimos 7 días" / "Pedidos últimos 30 días"). Touch target ≥44dp (WCAG 2.5.5).
- **Cobrar SafeArea**: admin path ahora envuelve componente con `customHeader + paddingTop: insets.top`, alineado con `vender/index.tsx`.

### Issue 5 — Notificación tap silencioso
- `notificaciones.tsx`: tipo `'announcement'` ahora navega a `/(tabs)/anuncios` (antes retornaba null silently → user veía nada al tap).
- Toast fallback "Notificación solo informativa" cuando `deepLink == null` para feedback visual en tipos no mapeados.

### Issue 6 — Edit team member web (`/team`)
- `MiembrosTab.tsx`: email + teléfono inputs ahora **`readOnly`** (NO `disabled` — disabled excluye campo del payload) con icono Lock y label "(no editable)". Solo nombre + status editables. aria-label en button Edit.
- `useApiErrorToast.ts`: extrae mensajes de **FluentValidation** (`{ FieldName: ["error"] }`) además del `.message` general → mensajes específicos al user en errores de validación, no genéricos.

### Bug crítico introducido y arreglado
Mi primer commit del refactor admin Vender/Cobrar tenía un **early return condicional ANTES de varios useState/useMemo**, violando Rules of Hooks:
> "Rendered fewer hooks than expected. This may be caused by an accidental early return statement."

**Fix**: split en componentes separados (`VenderAdminContent` / `VenderVendedorContent` / wrapper `VenderListScreenContent`) con un solo hook (`useAuthStore`) en el wrapper que decide cuál renderizar. Mismo patrón para Cobrar.

## Validaciones aplicadas

- ✅ frontend-ui-ux-validator review (touch targets 44dp, lock icon, neutral toast text)
- ✅ Type-check mobile + web 0 errors
- ✅ dotnet build mobile API 0 errors
- ✅ **Validación visual emulador Android post-fix**:
  - Vendor detail badge "Desconectado" gris ✓
  - Tab Equipo nav (quick action → Mi Equipo, no detail viejo) ✓
  - Vender admin: header "Pedidos hoy" + 4 buttons preset, tap "Ayer" cambia header ✓
  - Cobrar admin: SafeArea correcto + 4 buttons preset ✓
- ✅ Playwright `test-team-edit-readonly.spec.ts` 1 test pasa
- ✅ CI verde en staging HEAD `d0e5ced9`: Vercel + Railway main-api + billing-api + mobile-api

## Test plan post-merge

- [ ] Vercel auto-deploy del web (Issue 6)
- [ ] Railway api_mobile auto-deploy (backend changes Issues 1, 3, 4)
- [ ] **EAS Update OTA producción CON `--environment production`**:
  ```bash
  cd apps/mobile-app && eas update --branch production --environment production --message "6 bugs Jeyma + hooks fix"
