### PR TITLE
fix(mobile): BottomSheet "Preventa/Autoventa" en Hoy + preselect cliente desde Mapa

### DIFF
--- a/apps/mobile-app/app/(tabs)/mapa.tsx
+++ b/apps/mobile-app/app/(tabs)/mapa.tsx
@@ -28,6 +28,7 @@ import { NextStopPanel } from '@/components/map/NextStopPanel';
 import { CheckInPanel } from '@/components/map/CheckInPanel';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { COLORS } from '@/theme/colors';
+import { useCreateOrderFlow } from '@/hooks/useCreateOrderFlow';
 
 const DEFAULT_REGION: Region = {
   latitude: 19.4326,
@@ -42,6 +43,12 @@ function MapaScreenContent() {
   const { mode: initialMode } = useLocalSearchParams<{ mode?: string }>();
   const mapRef = useRef<any>(null);
   const user = useAuthStore((s) => s.user);
+
+  // Flujo "crear pedido" compartido (FAB Vender + quick action Hoy + Vender desde Mapa).
+  // Cuando se invoca con cliente preseleccionado, abre el sheet con título "Vender a {nombre}"
+  // y al confirmar tipo de venta navega a /vender/crear con query params que auto-seleccionan
+  // cliente y saltan al paso de productos.
+  const { openCreateOrder, SheetComponent } = useCreateOrderFlow();
 
   // Map mode
   const [mapMode, setMapMode] = useState<MapMode>(
@@ -418,7 +425,12 @@ function MapaScreenContent() {
           bottomInset={insets.bottom}
           onClose={() => setSelectedClient(null)}
           onViewDetail={() => router.push(`/(tabs)/clients/${selectedClient.id}` as any)}
-          onSell={() => router.push('/(tabs)/vender/crear' as any)}
+          onSell={() =>
+            openCreateOrder({
+              clienteId: String(selectedClient.id),
+              clienteNombre: selectedClient.nombre,
+            })
+          }
         />
       )}
 
@@ -434,6 +446,9 @@ function MapaScreenContent() {
           onCheckIn={handleNextStopCheckIn}
         />
       )}
+
+      {/* BottomSheet "Preventa / Venta Directa" — provisto por useCreateOrderFlow. */}
+      {SheetComponent}
     </View>
   );
 }

--- a/apps/mobile-app/app/(tabs)/vender/index.tsx
+++ b/apps/mobile-app/app/(tabs)/vender/index.tsx
@@ -7,19 +7,19 @@ import { View, Text, FlatList, RefreshControl, ScrollView, TouchableOpacity, Sty
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useOfflineOrders, useClientNameMap } from '@/hooks';
-import { useEmpresa } from '@/hooks/useEmpresa';
-import { useAuthStore, useOrderDraftStore } from '@/stores';
-import { Card, LoadingSpinner, EmptyState, BottomSheet } from '@/components/ui';
+import { useAuthStore } from '@/stores';
+import { Card, LoadingSpinner, EmptyState } from '@/components/ui';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { ORDER_STATUS_COLORS } from '@/constants/colors';
 import { COLORS } from '@/theme/colors';
 import { useTenantLocale } from '@/hooks';
-import { ShoppingCart, ChevronRight, Calendar, Plus, ClipboardList, Truck } from 'lucide-react-native';
+import { ShoppingCart, ChevronRight, Calendar, Plus } from 'lucide-react-native';
 import { performSync } from '@/sync/syncEngine';
 import Animated, { FadeInDown, ZoomIn } from 'react-native-reanimated';
 import type Pedido from '@/db/models/Pedido';
 import { AdminTenantPedidosList } from '@/components/admin/AdminTenantPedidosList';
+import { useCreateOrderFlow } from '@/hooks/useCreateOrderFlow';
 
 const STATUS_FILTERS = [
   { label: 'Todos', value: undefined },
@@ -56,16 +56,16 @@ function VenderListScreenContent() {
 }
 
 // Vista vendedor regular — flujo original con WatermelonDB local + filtros
-// + BottomSheet + FAB. NO hace fetch al API supervisor.
+// + FAB que dispara `useCreateOrderFlow`. NO hace fetch al API supervisor.
 function VenderVendedorContent() {
   const insets = useSafeAreaInsets();
   const { money: formatCurrency, date: formatDate } = useTenantLocale();
   const [statusFilter, setStatusFilter] = useState<number | undefined>(undefined);
-  const [showOrderTypeSheet, setShowOrderTypeSheet] = useState(false);
   const router = useRouter();
-  const { setTipoVenta, reset: resetDraft } = useOrderDraftStore();
-  const { data: empresa } = useEmpresa();
-  const modoDefault = empresa?.modoVentaDefault ?? 'Preguntar';
+
+  // Hook compartido con VendedorDashboard (Hoy) y mapa.tsx — encapsula la
+  // lógica modoVentaDefault + BottomSheet + navegación.
+  const { openCreateOrder, SheetComponent } = useCreateOrderFlow();
 
   const { data: allOrders, isLoading } = useOfflineOrders();
   const clienteIds = useMemo(
@@ -81,27 +81,6 @@ function VenderVendedorContent() {
   }, [allOrders, statusFilter]);
 
   const total = orders.length;
-
-  const handleFabPress = () => {
-    // Si admin configuró un modo default (no "Preguntar"), saltamos el sheet
-    // de selección y vamos directo al picker de cliente con el modo seteado.
-    if (modoDefault === 'Preventa') {
-      handleOrderTypeSelect(0);
-      return;
-    }
-    if (modoDefault === 'VentaDirecta') {
-      handleOrderTypeSelect(1);
-      return;
-    }
-    setShowOrderTypeSheet(true);
-  };
-
-  const handleOrderTypeSelect = (tipo: number) => {
-    setShowOrderTypeSheet(false);
-    resetDraft();
-    setTipoVenta(tipo);
-    router.push('/(tabs)/vender/crear' as any);
-  };
 
   const renderItem = useCallback(
     ({ item }: { item: Pedido }) => (
@@ -213,7 +192,7 @@ function VenderVendedorContent() {
             title="Sin pedidos"
             message="No tienes pedidos registrados"
             actionText="Crear Pedido"
-            onAction={handleFabPress}
+            onAction={() => openCreateOrder()}
           />
         }
       />
@@ -222,7 +201,7 @@ function VenderVendedorContent() {
       <TouchableOpacity
         testID="fab-nuevo-pedido"
         style={styles.fab}
-        onPress={handleFabPress}
+        onPress={() => openCreateOrder()}
         activeOpacity={0.85}
         accessibilityLabel="Nuevo pedido"
         accessibilityRole="button"
@@ -230,44 +209,8 @@ function VenderVendedorContent() {
         <Plus size={24} color={COLORS.headerText} />
       </TouchableOpacity>
 
-      {/* BottomSheet for order type (Supervisor/Admin) */}
-      <BottomSheet
-        visible={showOrderTypeSheet}
-        title="¿Qué tipo de pedido?"
-        subtitle="Selecciona el tipo de venta"
-        onClose={() => setShowOrderTypeSheet(false)}
-      >
-        <View style={styles.orderTypeOptions}>
-          <TouchableOpacity
-            style={styles.orderTypeCard}
-            onPress={() => handleOrderTypeSelect(0)}
-            activeOpacity={0.85}
-            accessibilityLabel="Preventa"
-            accessibilityRole="button"
-          >
-            <ClipboardList size={24} color="#6b7280" />
-            <View style={styles.orderTypeInfo}>
-              <Text style={styles.orderTypeTitle}>Preventa</Text>
-              <Text style={styles.orderTypeDesc}>Registrar pedido para entrega posterior</Text>
-            </View>
-            <ChevronRight size={18} color={COLORS.textTertiary} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.orderTypeCard}
-            onPress={() => handleOrderTypeSelect(1)}
-            activeOpacity={0.85}
-            accessibilityLabel="Venta Directa"
-            accessibilityRole="button"
-          >
-            <Truck size={24} color="#6b7280" />
-            <View style={styles.orderTypeInfo}>
-              <Text style={styles.orderTypeTitle}>Venta Directa</Text>
-              <Text style={styles.orderTypeDesc}>Vender, cobrar y entregar ahora</Text>
-            </View>
-            <ChevronRight size={18} color={COLORS.textTertiary} />
-          </TouchableOpacity>
-        </View>
-      </BottomSheet>
+      {/* BottomSheet "Preventa / Venta Directa" — provisto por useCreateOrderFlow */}
+      {SheetComponent}
     </View>
   );
 }
@@ -302,20 +245,6 @@ const styles = StyleSheet.create({
     alignItems: 'center', justifyContent: 'center',
     shadowColor: COLORS.button, shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.3, shadowRadius: 8, elevation: 8,
   },
-  orderTypeOptions: { gap: 12 },
-  orderTypeCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: COLORS.card,
-    borderRadius: 14,
-    padding: 16,
-    borderWidth: 1,
-    borderColor: COLORS.border,
-    gap: 14,
-  },
-  orderTypeInfo: { flex: 1 },
-  orderTypeTitle: { fontSize: 16, fontWeight: '700', color: COLORS.foreground },
-  orderTypeDesc: { fontSize: 13, color: COLORS.textSecondary, marginTop: 2 },
 });
 
 export default function VenderListScreen() {

--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -18,6 +18,7 @@ import { COLORS } from '@/theme/colors';
 import { api } from '@/api/client';
 import { Target } from 'lucide-react-native';
 import { JornadaCard } from './JornadaCard';
+import { useCreateOrderFlow } from '@/hooks/useCreateOrderFlow';
 
 export function VendedorDashboard() {
   const insets = useSafeAreaInsets();
@@ -26,6 +27,12 @@ export function VendedorDashboard() {
   const user = useAuthStore(s => s.user);
   const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
+
+  // Hook compartido — abre BottomSheet "¿Preventa o Autoventa?" si la
+  // empresa tiene modoVentaDefault='Preguntar'; sino salta directo. Antes
+  // este quick action navegaba a /vender/crear sin preguntar tipo (bug
+  // reportado por vendedor1@jeyma.com 2026-05-04).
+  const { openCreateOrder, SheetComponent } = useCreateOrderFlow();
 
   // Route stats — single source of truth via direct query on focus
   const [routeStats, setRouteStats] = useState({ total: 0, atendidas: 0, routeName: '', routeEstado: 0 });
@@ -121,6 +128,7 @@ export function VendedorDashboard() {
 
 
   return (
+    <>
     <ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
@@ -285,7 +293,7 @@ export function VendedorDashboard() {
         <View style={styles.quickActions}>
           <TouchableOpacity
             style={styles.quickAction}
-            onPress={() => router.push('/(tabs)/vender/crear' as any)}
+            onPress={() => openCreateOrder()}
             activeOpacity={0.85}
           >
             <Text style={styles.quickActionText}>Nuevo Pedido</Text>
@@ -317,6 +325,9 @@ export function VendedorDashboard() {
         </View>
       </Card>
     </ScrollView>
+    {/* BottomSheet "Preventa / Venta Directa" — provisto por useCreateOrderFlow */}
+    {SheetComponent}
+    </>
   );
 }
 

--- a/apps/mobile-app/src/hooks/useCreateOrderFlow.tsx
+++ b/apps/mobile-app/src/hooks/useCreateOrderFlow.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { ClipboardList, Truck, ChevronRight } from 'lucide-react-native';
+import { useOrderDraftStore } from '@/stores';
+import { useEmpresa } from '@/hooks/useEmpresa';
+import { BottomSheet } from '@/components/ui';
+import { COLORS } from '@/theme/colors';
+
+/**
+ * Flujo de "crear pedido" reutilizable desde tres entry points:
+ * - FAB en tab Vender
+ * - Quick action "Nuevo Pedido" en tab Hoy (VendedorDashboard)
+ * - Botón "Vender" en panel de cliente del tab Mapa (con cliente preseleccionado)
+ *
+ * Comportamiento:
+ * - Si `empresa.modoVentaDefault === 'Preguntar'`: abre BottomSheet con
+ *   "Preventa" / "Venta Directa". Al seleccionar, navega.
+ * - Si `'Preventa'` o `'VentaDirecta'`: salta el sheet y navega directo
+ *   con el tipo pre-seleccionado (consistente con la config admin que
+ *   acelera el flujo).
+ * - Si se pasa `clienteId` + `clienteNombre` (caso Mapa), se pasan como
+ *   query params al `/vender/crear`. Esa pantalla auto-selecciona el
+ *   cliente y salta a productos (lógica YA existente en crear/index.tsx).
+ *
+ * El hook devuelve:
+ * - `openCreateOrder(opts?)` — invocar desde el button onPress
+ * - `SheetComponent` — JSX del BottomSheet, renderizar dentro del árbol
+ *   del componente que invoca el hook
+ *
+ * Reportado por vendedor1@jeyma.com 2026-05-04: quick action de Hoy y
+ * botón Vender de Mapa saltaban el sheet y/o no preseleccionaban cliente.
+ */
+export type CreateOrderOpts = { clienteId?: string; clienteNombre?: string };
+
+export function useCreateOrderFlow() {
+  const router = useRouter();
+  const { setTipoVenta, reset: resetDraft } = useOrderDraftStore();
+  const { data: empresa } = useEmpresa();
+  const modoDefault = empresa?.modoVentaDefault ?? 'Preguntar';
+
+  const [showSheet, setShowSheet] = useState(false);
+  const [pendingCliente, setPendingCliente] = useState<CreateOrderOpts | undefined>(undefined);
+
+  const navigateToCrear = useCallback(
+    (tipo: 0 | 1, cliente?: CreateOrderOpts) => {
+      resetDraft();
+      setTipoVenta(tipo);
+      if (cliente?.clienteId) {
+        router.push({
+          pathname: '/(tabs)/vender/crear',
+          params: {
+            clienteId: cliente.clienteId,
+            clienteNombre: encodeURIComponent(cliente.clienteNombre ?? ''),
+          },
+        } as any);
+      } else {
+        router.push('/(tabs)/vender/crear' as any);
+      }
+    },
+    [resetDraft, setTipoVenta, router]
+  );
+
+  const openCreateOrder = useCallback(
+    (opts?: CreateOrderOpts) => {
+      if (modoDefault === 'Preventa') {
+        navigateToCrear(0, opts);
+        return;
+      }
+      if (modoDefault === 'VentaDirecta') {
+        navigateToCrear(1, opts);
+        return;
+      }
+      setPendingCliente(opts);
+      setShowSheet(true);
+    },
+    [modoDefault, navigateToCrear]
+  );
+
+  const handleSelect = useCallback(
+    (tipo: 0 | 1) => {
+      setShowSheet(false);
+      navigateToCrear(tipo, pendingCliente);
+      setPendingCliente(undefined);
+    },
+    [navigateToCrear, pendingCliente]
+  );
+
+  const sheetTitle = pendingCliente?.clienteNombre
+    ? `Vender a ${pendingCliente.clienteNombre}`
+    : '¿Qué tipo de pedido?';
+
+  const SheetComponent = (
+    <BottomSheet
+      visible={showSheet}
+      title={sheetTitle}
+      subtitle="Selecciona el tipo de venta"
+      onClose={() => {
+        setShowSheet(false);
+        setPendingCliente(undefined);
+      }}
+    >
+      <View style={styles.options}>
+        <TouchableOpacity
+          style={styles.card}
+          onPress={() => handleSelect(0)}
+          activeOpacity={0.85}
+          accessibilityLabel="Preventa"
+          accessibilityRole="button"
+        >
+          <ClipboardList size={24} color="#6b7280" />
+          <View style={styles.info}>
+            <Text style={styles.title}>Preventa</Text>
+            <Text style={styles.desc}>Registrar pedido para entrega posterior</Text>
+          </View>
+          <ChevronRight size={18} color={COLORS.textTertiary} />
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.card}
+          onPress={() => handleSelect(1)}
+          activeOpacity={0.85}
+          accessibilityLabel="Venta Directa"
+          accessibilityRole="button"
+        >
+          <Truck size={24} color="#6b7280" />
+          <View style={styles.info}>
+            <Text style={styles.title}>Venta Directa</Text>
+            <Text style={styles.desc}>Vender, cobrar y entregar ahora</Text>
+          </View>
+          <ChevronRight size={18} color={COLORS.textTertiary} />
+        </TouchableOpacity>
+      </View>
+    </BottomSheet>
+  );
+
+  return { openCreateOrder, SheetComponent };
+}
+
+const styles = StyleSheet.create({
+  options: { gap: 12 },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: COLORS.card,
+    borderRadius: 14,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    gap: 14,
+  },
+  info: { flex: 1 },
+  title: { fontSize: 16, fontWeight: '700', color: COLORS.foreground },
+  desc: { fontSize: 13, color: COLORS.textSecondary, marginTop: 2 },
+});


### PR DESCRIPTION
## Bugs reportados por vendedor1@jeyma.com (2026-05-04)

1. **Tab Hoy → "Nuevo Pedido"** saltaba el BottomSheet y no preguntaba tipo
   de venta. Ahora abre el sheet (o salta directo si admin configuró
   `modoVentaDefault` distinto a "Preguntar", consistente con el FAB).

2. **Tab Mapa → marker tienda → "Vender"** abría el cliente picker desde
   cero perdiendo el contexto. Ahora abre el sheet con título "Vender a
   {cliente}" y al seleccionar tipo navega a `/vender/crear` con query
   params `clienteId` + `clienteNombre` que activan la auto-preselección
   ya existente en `crear/index.tsx:23-35` → salta a productos directo.

## Refactor

Nuevo hook `src/hooks/useCreateOrderFlow.tsx` encapsula la lógica
`modoVentaDefault` + BottomSheet + navegación. Reusada por:
- FAB en tab Vender (`vender/index.tsx`)
- Quick action "Nuevo Pedido" en Hoy (`VendedorDashboard.tsx`)
- Botón "Vender" en panel cliente del Mapa (`mapa.tsx`)

Elimina la duplicación del sheet inline en `vender/index.tsx` (~70 líneas)
y deja los tres entry points consistentes.

## Test plan

- [x] `npx tsc --noEmit` en `apps/mobile-app` → 0 errores
- [x] Emulador + vendedor1: tab Hoy → "Nuevo Pedido" → BottomSheet "¿Qué tipo de pedido?" con Preventa / Venta Directa visible (screenshot validado)
- [ ] Device real + vendedor1: tab Mapa → marker tienda → "Vender" → BottomSheet "Vender a {cliente}" → tap Preventa → llega a `/vender/crear/productos` con cliente preseleccionado
- [ ] Regression: FAB tab Vender sigue funcionando
- [ ] Regression: si admin configura `modoVentaDefault='Preventa'`, los 3 entry points saltan el sheet directo

## Archivos

- **Nuevo**: `apps/mobile-app/src/hooks/useCreateOrderFlow.tsx`
- **Modificado**:
  - `apps/mobile-app/app/(tabs)/vender/index.tsx` (-70 líneas duplicadas)
  - `apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx`
  - `apps/mobile-app/app/(tabs)/mapa.tsx`
