### PR TITLE
feat: avatar sync web↔mobile + badge notif al lado del avatar (#PR via staging)

### DIFF
--- a/apps/mobile-app/.maestro/vendedor/03-avatar-tap-perfil-notif.yaml
+++ b/apps/mobile-app/.maestro/vendedor/03-avatar-tap-perfil-notif.yaml
@@ -1,0 +1,58 @@
+appId: host.exp.exponent
+name: "Vendedor: tap avatar → /profile → link Notificaciones → /notificaciones"
+---
+
+# ════════════════════════════════════════════════════════════
+# PREREQ: ya logueado como vendedor1@jeyma.com (preserva sesión)
+#
+# Valida los cambios reportados 2026-05-04:
+#   - El avatar/iniciales en el header del dashboard es tappable.
+#   - Tap navega a Mi Perfil (/profile).
+#   - Mi Perfil tiene una card "Notificaciones" arriba con badge.
+#   - Tap a la card navega a /notificaciones.
+# ════════════════════════════════════════════════════════════
+
+# Reset al tab Hoy (donde vive el VendedorDashboard)
+- tapOn: "Hoy"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "ACCIONES RÁPIDAS"
+    timeout: 15000
+
+# ────────────────────────────────────────────
+# PASO 1: tap al avatar/iniciales del header
+# ────────────────────────────────────────────
+# UserAvatar tiene testID="header-avatar" y accessibilityLabel "Mi perfil".
+- tapOn:
+    id: "header-avatar"
+- waitForAnimationToEnd
+
+# ────────────────────────────────────────────
+# PASO 2: estamos en /profile, validamos shape
+# ────────────────────────────────────────────
+- extendedWaitUntil:
+    visible: "Vendedor 1 Jeyma"
+    timeout: 5000
+- assertVisible: "Notificaciones"
+- assertVisible:
+    text: "Estás al día|sin leer"
+    optional: false
+
+- takeScreenshot: "avatar-01-profile"
+
+# ────────────────────────────────────────────
+# PASO 3: tap a la card Notificaciones
+# ────────────────────────────────────────────
+- tapOn:
+    id: "profile-notifications-link"
+- waitForAnimationToEnd
+
+# ────────────────────────────────────────────
+# PASO 4: estamos en /notificaciones
+# ────────────────────────────────────────────
+# La pantalla muestra empty state si no hay notif, o una lista si las hay.
+- assertVisible:
+    text: "No tienes notificaciones|Notificaciones"
+    optional: false
+
+- takeScreenshot: "avatar-02-notificaciones"

--- a/apps/mobile-app/app/(tabs)/profile.tsx
+++ b/apps/mobile-app/app/(tabs)/profile.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Application from 'expo-application';
 import { useAuthStore } from '@/stores';
-import { useLogout } from '@/hooks';
-import { Card, Button, Badge, ConfirmModal } from '@/components/ui';
-import { Mail, Shield, Building2, Smartphone, ChevronLeft } from 'lucide-react-native';
+import { useLogout, useUnreadNotificationCount } from '@/hooks';
+import { Card, Button, Badge, ConfirmModal, UserAvatar } from '@/components/ui';
+import { Mail, Shield, Building2, Smartphone, ChevronLeft, Bell, ChevronRight } from 'lucide-react-native';
 import { HandyLogo } from '@/components/shared/HandyLogo';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { COLORS } from '@/theme/colors';
@@ -30,6 +30,7 @@ export default function ProfileScreen() {
   const router = useRouter();
   const { user } = useAuthStore();
   const logoutMutation = useLogout();
+  const { count: unreadNotifs } = useUnreadNotificationCount();
   const [showLogout, setShowLogout] = useState(false);
 
   const handleLogout = () => {
@@ -54,12 +55,17 @@ export default function ProfileScreen() {
         </TouchableOpacity>
       </View>
 
-      {/* Overlapping avatar + profile info */}
+      {/* Overlapping avatar + profile info — usa UserAvatar centralizado para
+          que la foto de perfil cambiada desde web aparezca aquí (vía useMe). */}
       <Animated.View entering={FadeInDown.duration(400)} style={styles.profileHeader}>
-        <View style={styles.avatarLarge}>
-          <Text style={styles.avatarText}>
-            {user.name?.[0]?.toUpperCase() || 'U'}
-          </Text>
+        <View style={styles.avatarLargeWrap}>
+          <UserAvatar
+            name={user.name}
+            avatarUrl={user.avatarUrl}
+            size={80}
+            badgeRingColor={COLORS.card}
+            testID="profile-avatar-large"
+          />
         </View>
         <Text style={styles.userName}>{user.name}</Text>
         <View style={styles.emailRow}>
@@ -78,6 +84,43 @@ export default function ProfileScreen() {
 
       {/* Info Cards */}
       <Animated.View entering={FadeInDown.delay(100).duration(400)} style={styles.infoSection}>
+        {/* Link directo a notificaciones — el owner pidió este atajo para que
+            el vendedor entre rápido a "ver qué está sucediendo" sin tener que
+            buscarlo en la tab Más. El badge espeja el count del header. */}
+        <TouchableOpacity
+          activeOpacity={0.85}
+          onPress={() => router.push('/(tabs)/notificaciones' as any)}
+          testID="profile-notifications-link"
+          accessibilityRole="button"
+          accessibilityLabel={
+            unreadNotifs > 0
+              ? `Notificaciones, ${unreadNotifs} sin leer`
+              : 'Notificaciones'
+          }
+        >
+          <Card className="mb-3">
+            <View style={styles.infoRow}>
+              <View style={styles.notifIconWrap}>
+                <Bell size={16} color="#f97316" />
+                {unreadNotifs > 0 && (
+                  <View style={styles.notifBadge} pointerEvents="none">
+                    <Text style={styles.notifBadgeText}>
+                      {unreadNotifs > 9 ? '9+' : unreadNotifs}
+                    </Text>
+                  </View>
+                )}
+              </View>
+              <View style={styles.infoContent}>
+                <Text style={styles.infoLabel}>Notificaciones</Text>
+                <Text style={styles.infoValue}>
+                  {unreadNotifs > 0 ? `${unreadNotifs} sin leer` : 'Estás al día'}
+                </Text>
+              </View>
+              <ChevronRight size={18} color={COLORS.textTertiary} />
+            </View>
+          </Card>
+        </TouchableOpacity>
+
         <Card className="mb-3">
           <View style={styles.infoRow}>
             <Shield size={16} color="#6b7280" style={{ marginRight: 12 }} />
@@ -167,26 +210,47 @@ const styles = StyleSheet.create({
     marginTop: -50,
     paddingBottom: 20,
   },
-  avatarLarge: {
-    width: 80,
-    height: 80,
-    borderRadius: 24,
-    backgroundColor: COLORS.headerBg,
-    alignItems: 'center',
-    justifyContent: 'center',
+  avatarLargeWrap: {
     marginBottom: 16,
-    borderWidth: 4,
-    borderColor: COLORS.card,
+    padding: 4,
+    borderRadius: 48,
+    backgroundColor: COLORS.card,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.15,
     shadowRadius: 12,
     elevation: 6,
   },
-  avatarText: {
-    fontSize: 32,
+  notifIconWrap: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 10,
+    backgroundColor: '#fff7ed',
+    // Android clips children absolutos por default → sin esto el badge
+    // (top:-4 right:-4) se corta en Android.
+    overflow: 'visible',
+  },
+  notifBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#dc2626',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 3,
+    borderWidth: 2,
+    borderColor: '#ffffff',
+  },
+  notifBadgeText: {
+    color: '#ffffff',
+    fontSize: 9,
     fontWeight: '700',
-    color: COLORS.headerText,
   },
   userName: {
     fontSize: 22,

--- a/apps/mobile-app/app/_layout.tsx
+++ b/apps/mobile-app/app/_layout.tsx
@@ -4,7 +4,8 @@ import { Slot, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Linking from 'expo-linking';
-import { View, ActivityIndicator, LogBox, BackHandler, Alert, Platform } from 'react-native';
+import { View, ActivityIndicator, LogBox, BackHandler, Alert, Platform, AppState, type AppStateStatus } from 'react-native';
+import { focusManager } from '@tanstack/react-query';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { DatabaseProvider } from '@nozbe/watermelondb/DatabaseProvider';
 import { crashReporter } from '@/services/crashReporter';
@@ -36,7 +37,7 @@ import { database } from '@/db/database';
 import Toast from 'react-native-toast-message';
 import { ConfirmModal } from '@/components/ui';
 import { usePermissionDialogStore } from '@/stores/permissionDialogStore';
-import { useRealtime } from '@/hooks';
+import { useRealtime, useMe } from '@/hooks';
 import { useSessionRefresh } from '@/hooks/useSessionRefresh';
 import { useHorarioLaboralWatcher } from '@/hooks/useHorarioLaboralWatcher';
 import { useRutaJornadaWatcher } from '@/hooks/useRutaJornadaWatcher';
@@ -63,6 +64,32 @@ function RealtimeBridge() {
 function SessionRefreshBridge() {
   useSessionRefresh();
   return null;
+}
+
+/**
+ * Mantiene `useAuthStore.user` sincronizado con el backend (avatar, nombre,
+ * role). Refresca al pasar a foreground (vía focusManager bridge) y respeta
+ * `staleTime: 30s` mientras la app está activa. Resuelve el caso "admin sube
+ * foto en web → mobile la ve al regresar a la app" sin SignalR.
+ */
+function MeRefreshBridge() {
+  useMe();
+  return null;
+}
+
+/**
+ * Bridge AppState → focusManager. Forma idiomática que recomienda la doc
+ * oficial de TanStack Query para React Native: en lugar de listeners ad-hoc
+ * en cada hook, expones `focusManager.setFocused(active)` y todas las queries
+ * con `refetchOnWindowFocus: true` se refrescan automáticamente al volver al
+ * foreground. Una sola vez al root, no por hook.
+ */
+function setupTanStackFocusBridge() {
+  if (Platform.OS === 'web') return undefined;
+  const sub = AppState.addEventListener('change', (status: AppStateStatus) => {
+    focusManager.setFocused(status === 'active');
+  });
+  return () => sub.remove();
 }
 
 /**
@@ -231,6 +258,12 @@ export default function RootLayout() {
   const [appReady, setAppReady] = useState(false);
   const [needsInitialSync, setNeedsInitialSync] = useState(false);
 
+  // Cableado AppState → focusManager para que `refetchOnWindowFocus: true`
+  // funcione en RN. Una sola registración por sesión de app.
+  useEffect(() => {
+    return setupTanStackFocusBridge();
+  }, []);
+
   const handleAppReady = useCallback((firstSync?: boolean) => {
     if (!appReady) {
       setAppReady(true);
@@ -257,6 +290,7 @@ export default function RootLayout() {
             <AuthGate onReady={handleAppReady} />
             <RealtimeBridge />
             <SessionRefreshBridge />
+            <MeRefreshBridge />
             <LocationTrackingBridge />
             {showSplash && appReady && (
               <AnimatedSplash

--- a/apps/mobile-app/src/api/auth.ts
+++ b/apps/mobile-app/src/api/auth.ts
@@ -4,10 +4,13 @@ import { validateResponse } from './validateResponse';
 import {
   ApiResponseSchema,
   LoginResponseSchema,
+  MeResponseSchema,
 } from './schemas';
 import type { ApiResponse, LoginResponse } from '@/types';
+import type { MeResponse } from './schemas';
 
 const LoginResponseWrapperSchema = ApiResponseSchema(LoginResponseSchema);
+const MeResponseWrapperSchema = ApiResponseSchema(MeResponseSchema);
 
 class MobileAuthApi {
   private basePath = '/api/mobile/auth';
@@ -114,6 +117,24 @@ class MobileAuthApi {
     } catch {
       // Ignore — always clear local state
     }
+  }
+
+  /**
+   * Snapshot del usuario actual desde JWT claims. Se invoca al volver al
+   * foreground para detectar cambios de avatar/nombre hechos desde web.
+   * NO retorna tokens — sólo `{ user }`.
+   */
+  async getMe(): Promise<MeResponse> {
+    const response = await api.get<ApiResponse<MeResponse>>(`${this.basePath}/me`);
+    const validated = validateResponse(
+      MeResponseWrapperSchema,
+      response.data,
+      'GET /api/mobile/auth/me'
+    );
+    if (!validated.success) {
+      throw new Error('No se pudo obtener el perfil');
+    }
+    return validated.data;
   }
 }
 

--- a/apps/mobile-app/src/api/schemas/auth.ts
+++ b/apps/mobile-app/src/api/schemas/auth.ts
@@ -6,6 +6,7 @@ export const AuthUserSchema = z
     email: z.string(),
     name: z.string(),
     role: z.enum(['SUPER_ADMIN', 'ADMIN', 'SUPERVISOR', 'VENDEDOR']),
+    avatarUrl: z.string().nullable().optional(),
     tenantName: z.string().nullable().optional(),
     tenantLogo: z.string().nullable().optional(),
   })
@@ -22,6 +23,15 @@ export const LoginResponseSchema = z
   .passthrough();
 
 export type LoginResponse = z.infer<typeof LoginResponseSchema>;
+
+// GET /api/mobile/auth/me — solo retorna el snapshot del usuario, sin tokens.
+export const MeResponseSchema = z
+  .object({
+    user: AuthUserSchema,
+  })
+  .passthrough();
+
+export type MeResponse = z.infer<typeof MeResponseSchema>;
 
 // Request types (no Zod needed — outgoing, not validated)
 export interface LoginRequest {

--- a/apps/mobile-app/src/api/schemas/index.ts
+++ b/apps/mobile-app/src/api/schemas/index.ts
@@ -11,8 +11,9 @@ export type { Pagination, ApiError } from './common';
 export {
   AuthUserSchema,
   LoginResponseSchema,
+  MeResponseSchema,
 } from './auth';
-export type { AuthUser, LoginResponse, LoginRequest, RefreshRequest } from './auth';
+export type { AuthUser, LoginResponse, LoginRequest, RefreshRequest, MeResponse } from './auth';
 
 // Client
 export {

--- a/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
@@ -7,7 +7,8 @@ import Animated, { FadeInDown } from 'react-native-reanimated';
 
 import { performSync } from '@/sync/syncEngine';
 import { useSupervisorDashboard, useMisVendedores } from '@/hooks/useSupervisor';
-import { useTenantLocale } from '@/hooks';
+import { useTenantLocale, useUnreadNotificationCount } from '@/hooks';
+import { UserAvatar } from '@/components/ui';
 import { getGreetingForTz } from '@/utils/greeting';
 import { COLORS } from '@/theme/colors';
 import type { VendedorEquipo } from '@/api/schemas/supervisor';
@@ -28,13 +29,8 @@ export function AdminDashboard() {
     setRefreshing(false);
   };
 
-  const initials = (user?.name ?? 'A')
-    .split(' ')
-    .filter(Boolean)
-    .map(w => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+  // Badge de notif sin leer encima de la foto/iniciales del avatar.
+  const { count: unreadNotifs } = useUnreadNotificationCount();
 
   // Separate supervisors and vendedores
   const supervisors = vendedores?.filter(v => v.rol === 'SUPERVISOR') ?? [];
@@ -61,9 +57,15 @@ export function AdminDashboard() {
               })()}
             </Text>
           </View>
-          <View style={styles.headerAvatar}>
-            <Text style={styles.headerAvatarText}>{initials}</Text>
-          </View>
+          <UserAvatar
+            name={user?.name}
+            avatarUrl={user?.avatarUrl}
+            size={40}
+            unreadCount={unreadNotifs}
+            onPress={() => router.push('/(tabs)/profile')}
+            badgeRingColor={COLORS.headerBg}
+            testID="header-avatar"
+          />
         </View>
       </View>
 

--- a/apps/mobile-app/src/components/dashboard/SupervisorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/SupervisorDashboard.tsx
@@ -6,7 +6,8 @@ import { useAuthStore } from '@/stores';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { performSync } from '@/sync/syncEngine';
 import { useSupervisorDashboard, useMisVendedores } from '@/hooks/useSupervisor';
-import { useTenantLocale } from '@/hooks';
+import { useTenantLocale, useUnreadNotificationCount } from '@/hooks';
+import { UserAvatar } from '@/components/ui';
 import { getGreetingForTz } from '@/utils/greeting';
 import { COLORS } from '@/theme/colors';
 import type { VendedorEquipo } from '@/api/schemas/supervisor';
@@ -27,13 +28,8 @@ export function SupervisorDashboard() {
     setRefreshing(false);
   };
 
-  const initials = (user?.name ?? 'S')
-    .split(' ')
-    .filter(Boolean)
-    .map(w => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+  // Badge de notif sin leer encima de la foto/iniciales del avatar.
+  const { count: unreadNotifs } = useUnreadNotificationCount();
 
   return (
     <View style={styles.container}>
@@ -56,9 +52,15 @@ export function SupervisorDashboard() {
               })()}
             </Text>
           </View>
-          <View style={styles.headerAvatar}>
-            <Text style={styles.headerAvatarText}>{initials}</Text>
-          </View>
+          <UserAvatar
+            name={user?.name}
+            avatarUrl={user?.avatarUrl}
+            size={40}
+            unreadCount={unreadNotifs}
+            onPress={() => router.push('/(tabs)/profile')}
+            badgeRingColor={COLORS.headerBg}
+            testID="header-avatar"
+          />
         </View>
       </View>
 

--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -7,9 +7,9 @@ import { useAuthStore } from '@/stores';
 import { useOfflineTodayVisits, useOfflineRutaHoy, useOfflineOrders, useOfflineCobros } from '@/hooks';
 import { database } from '@/db/database';
 import { Q } from '@nozbe/watermelondb';
-import { Card, LoadingSpinner } from '@/components/ui';
+import { Card, LoadingSpinner, UserAvatar } from '@/components/ui';
 import { StatusBadge } from '@/components/shared/StatusBadge';
-import { useTenantLocale } from '@/hooks';
+import { useTenantLocale, useUnreadNotificationCount } from '@/hooks';
 import { getGreetingForTz } from '@/utils/greeting';
 import { MapPin } from 'lucide-react-native';
 import Animated, { FadeInDown } from 'react-native-reanimated';
@@ -112,13 +112,9 @@ export function VendedorDashboard() {
       .reduce((sum, p) => sum + (p.total || 0), 0);
   }, [pedidos]);
 
-  const initials = (user?.name ?? 'V')
-    .split(' ')
-    .filter(Boolean)
-    .map(w => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+  // Badge de notif sin leer — al lado de la foto/iniciales en el header.
+  // Tap al avatar abre /profile que tiene link directo a /notificaciones.
+  const { count: unreadNotifs } = useUnreadNotificationCount();
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -150,9 +146,15 @@ export function VendedorDashboard() {
               {greeting}, {user?.name?.split(' ')[0] || 'Vendedor'}
             </Text>
           </View>
-          <View style={styles.headerAvatar}>
-            <Text style={styles.headerAvatarText}>{initials}</Text>
-          </View>
+          <UserAvatar
+            name={user?.name}
+            avatarUrl={user?.avatarUrl}
+            size={40}
+            unreadCount={unreadNotifs}
+            onPress={() => router.push('/(tabs)/profile')}
+            badgeRingColor={COLORS.headerBg}
+            testID="header-avatar"
+          />
         </View>
       </View>
 

--- a/apps/mobile-app/src/components/ui/UserAvatar.tsx
+++ b/apps/mobile-app/src/components/ui/UserAvatar.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import { View, Text, Image, TouchableOpacity, StyleSheet, type ViewStyle } from 'react-native';
+import { COLORS } from '@/theme/colors';
+
+export type UserAvatarProps = {
+  /** Nombre completo del usuario — usado para iniciales fallback. */
+  name?: string | null;
+  /** URL absoluta de la foto. Si null/undefined o falla la carga, render iniciales. */
+  avatarUrl?: string | null;
+  /** Diámetro en px del círculo. Default 40. */
+  size?: number;
+  /** Cantidad de notificaciones no leídas. Si > 0, render badge rojo en esquina sup-derecha. */
+  unreadCount?: number;
+  /** Si presente, wrap en TouchableOpacity con accessibilityRole=button. */
+  onPress?: () => void;
+  /** Color de borde del badge para ring de contraste. Default blanco. */
+  badgeRingColor?: string;
+  /** Color de fondo del avatar cuando muestra iniciales. Default header bg. */
+  fallbackBgColor?: string;
+  /** Color del texto de iniciales. Default headerText. */
+  fallbackTextColor?: string;
+  /** Estilo extra para el contenedor (margin, alignSelf, etc.). */
+  style?: ViewStyle;
+  /** Versión cache-buster — agregada como query param a `avatarUrl`. Útil cuando
+   *  Cloudinary reusa la misma URL al sustituir foto y el cache de RN devuelve
+   *  bytes viejos. Pasar `Usuario.actualizadoEn` o `Date.now()` (menos preciso). */
+  cacheKey?: string | number;
+  /** testID para Maestro/E2E. */
+  testID?: string;
+};
+
+function computeInitials(name?: string | null): string {
+  if (!name || !name.trim()) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Avatar reutilizable con foto + fallback a iniciales + badge opcional de
+ * notificaciones. Espejo del patrón Avatar+badge usado en el header web.
+ *
+ * Uso:
+ * ```tsx
+ * <UserAvatar
+ *   name={user.name}
+ *   avatarUrl={user.avatarUrl}
+ *   size={40}
+ *   unreadCount={unread}
+ *   onPress={() => router.push('/(tabs)/profile')}
+ * />
+ * ```
+ *
+ * Accesibilidad:
+ * - Si `onPress` está presente, usa role=button con label "Mi perfil, N sin leer".
+ * - Tap target mínimo asegurado vía `hitSlop` cuando `size < 44`.
+ */
+export function UserAvatar({
+  name,
+  avatarUrl,
+  size = 40,
+  unreadCount = 0,
+  onPress,
+  badgeRingColor = '#ffffff',
+  fallbackBgColor = COLORS.headerBg,
+  fallbackTextColor = COLORS.headerText,
+  style,
+  cacheKey,
+  testID,
+}: UserAvatarProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const initials = computeInitials(name);
+  const showImage = !!avatarUrl && !imageFailed;
+
+  // Cache-bust si nos dan una key
+  const finalUri = avatarUrl
+    ? cacheKey != null
+      ? `${avatarUrl}${avatarUrl.includes('?') ? '&' : '?'}v=${cacheKey}`
+      : avatarUrl
+    : undefined;
+
+  const fontSize = Math.max(10, Math.round(size * 0.4));
+  const badgeSize = Math.max(16, Math.round(size * 0.45));
+  const badgeFontSize = Math.max(9, Math.round(badgeSize * 0.55));
+
+  const content = (
+    <View
+      style={[
+        styles.container,
+        { width: size, height: size, overflow: 'visible' },
+        style,
+      ]}
+      testID={testID}
+    >
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: showImage ? 'transparent' : fallbackBgColor,
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+        }}
+      >
+        {showImage ? (
+          <Image
+            source={{ uri: finalUri }}
+            style={{ width: size, height: size, borderRadius: size / 2 }}
+            onError={() => setImageFailed(true)}
+            accessibilityIgnoresInvertColors
+          />
+        ) : (
+          <Text
+            style={{
+              fontSize,
+              fontWeight: '700',
+              color: fallbackTextColor,
+            }}
+          >
+            {initials}
+          </Text>
+        )}
+      </View>
+
+      {unreadCount > 0 && (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            top: -4,
+            right: -4,
+            minWidth: badgeSize,
+            height: badgeSize,
+            borderRadius: badgeSize / 2,
+            backgroundColor: '#dc2626',
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 4,
+            borderWidth: 2,
+            borderColor: badgeRingColor,
+          }}
+          accessibilityElementsHidden={false}
+          accessibilityLabel={`${unreadCount} sin leer`}
+        >
+          <Text style={{ color: '#ffffff', fontSize: badgeFontSize, fontWeight: '700' }}>
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+
+  if (!onPress) return content;
+
+  // hitSlop: el avatar suele ser ø40 (debajo del 44dp WCAG). Expandimos el
+  // área tappable sin afectar el render visual. +2dp extra de comfort
+  // padding sobre el mínimo WCAG para evitar fat-finger errors en displays
+  // de alta densidad.
+  const slop = size < 44 ? Math.ceil((44 - size) / 2) + 2 : 0;
+  const a11yLabel = unreadCount > 0
+    ? `Mi perfil, ${unreadCount} notificaciones sin leer`
+    : 'Mi perfil';
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel}
+      hitSlop={slop > 0 ? { top: slop, bottom: slop, left: slop, right: slop } : undefined}
+      testID={testID}
+    >
+      {content}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Android clips absolutely-positioned children por default. Necesario
+    // para que el badge (top:-4 right:-4) no se corte en Android.
+    overflow: 'visible',
+  },
+});

--- a/apps/mobile-app/src/components/ui/index.ts
+++ b/apps/mobile-app/src/components/ui/index.ts
@@ -7,3 +7,5 @@ export { EmptyState } from './EmptyState';
 export { ConfirmModal } from './ConfirmModal';
 export { BottomSheet } from './BottomSheet';
 export { OfflineBanner } from './OfflineBanner';
+export { UserAvatar } from './UserAvatar';
+export type { UserAvatarProps } from './UserAvatar';

--- a/apps/mobile-app/src/hooks/index.ts
+++ b/apps/mobile-app/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useLogin, useForceLogin, useLogout } from './useAuth';
+export { useMe, invalidateMe } from './useMe';
 export { useRealtime } from './useRealtime';
 export { useClientsList, useClientDetail } from './useClients';
 export { useOrdersList, useOrderDetail, useConfirmarPedido, useEnRutaPedido, useEntregarPedido, useCancelarPedido } from './useOrders';

--- a/apps/mobile-app/src/hooks/useMe.tsx
+++ b/apps/mobile-app/src/hooks/useMe.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { authApi } from '@/api/auth';
+import { useAuthStore } from '@/stores';
+
+const STALE_TIME_MS = 30 * 1000; // 30s — el avatar puede cambiar desde web sin notif
+export const ME_QUERY_KEY = ['auth', 'me'] as const;
+
+/**
+ * Refresca el snapshot del usuario logueado (avatar, nombre, role, tenantLogo)
+ * desde el backend mobile. La query se hidrata al montar, se invalida al volver
+ * al foreground (vía `focusManager` montado en `app/_layout.tsx`), y propaga
+ * los cambios al `useAuthStore` vía `setUser(partial)`.
+ *
+ * Razón de existir:
+ * - Cuando un admin/vendedor actualiza su foto de perfil desde la web (Cloudinary),
+ *   el mobile mostraba iniciales hasta el próximo re-login (o hasta que el silent
+ *   refresh de `useSessionRefresh` se ejecutara — y ese está throttled a 5 min).
+ *   Este hook cierra esa brecha sin agregar SignalR ni polling pesado.
+ *
+ * Patrón: TanStack Query con `staleTime: 30s` + `refetchOnWindowFocus: true`.
+ * El bridge `AppState → focusManager.setFocused` vive en `_layout.tsx` (es la
+ * forma idiomática que recomienda la doc oficial de TanStack Query para RN).
+ */
+export function useMe() {
+  const isAuthenticated = useAuthStore(s => s.isAuthenticated);
+  const setUser = useAuthStore(s => s.setUser);
+
+  const query = useQuery({
+    queryKey: ME_QUERY_KEY,
+    queryFn: () => authApi.getMe(),
+    staleTime: STALE_TIME_MS,
+    enabled: isAuthenticated,
+    // refetchOnWindowFocus=true es el default; con focusManager bridged a
+    // AppState (en _layout.tsx) cubre el caso "volver al foreground".
+    refetchOnWindowFocus: true,
+    // No retry agresivo — si falla un fetch (e.g. perdiste red por 1s), el
+    // próximo focus re-intentará automáticamente.
+    retry: 1,
+  });
+
+  // Propaga el snapshot al authStore SOLO si trae diferencias (evita re-renders
+  // innecesarios y escrituras a secureStorage en cada poll).
+  useEffect(() => {
+    if (!query.data?.user) return;
+    const fresh = query.data.user;
+    const stored = useAuthStore.getState().user;
+    if (!stored) return;
+    const same =
+      stored.avatarUrl === fresh.avatarUrl &&
+      stored.name === fresh.name &&
+      stored.role === fresh.role &&
+      stored.tenantLogo === fresh.tenantLogo;
+    if (!same) {
+      setUser({
+        avatarUrl: fresh.avatarUrl ?? null,
+        name: fresh.name,
+        role: fresh.role,
+        tenantLogo: fresh.tenantLogo ?? null,
+      });
+    }
+  }, [query.data, setUser]);
+
+  return query;
+}
+
+/** Helper para forzar refresh externo (e.g. tras recibir push de cambio de perfil). */
+export function invalidateMe(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: ME_QUERY_KEY });
+}

--- a/apps/mobile-app/src/hooks/usePushNotifications.ts
+++ b/apps/mobile-app/src/hooks/usePushNotifications.ts
@@ -34,6 +34,11 @@ function invalidateCachesForType(queryClient: ReturnType<typeof useQueryClient>,
     queryClient.invalidateQueries({ queryKey: ['dashboard'] });
   } else if (type.startsWith('goal.')) {
     queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+  } else if (type.startsWith('user.') || type.startsWith('profile.')) {
+    // Cambio de avatar/nombre/role del propio usuario o de un equipo: refresca
+    // el snapshot `me` para que el avatar/badge en el header se vea al instante.
+    queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
   } else {
     // For any other type, at least refresh the dashboard
     queryClient.invalidateQueries({ queryKey: ['dashboard'] });

--- a/apps/mobile-app/src/stores/authStore.ts
+++ b/apps/mobile-app/src/stores/authStore.ts
@@ -17,6 +17,12 @@ interface AuthState {
   logout: () => Promise<void>;
   restoreSession: () => Promise<void>;
   setLoggingIn: (loading: boolean) => void;
+  /**
+   * Actualiza campos del usuario logueado (merge parcial). Persiste el
+   * snapshot en secureStorage. Usado por `useMe` cuando refresca el perfil
+   * desde el backend (e.g. avatar cambiado desde web).
+   */
+  setUser: (partial: Partial<AuthUser>) => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -35,6 +41,9 @@ export const useAuthStore = create<AuthState>((set) => ({
         email: user.email,
         name: user.name,
         role: user.role,
+        avatarUrl: user.avatarUrl ?? null,
+        tenantName: user.tenantName ?? null,
+        tenantLogo: user.tenantLogo ?? null,
       })),
     ]);
     set({ user, isAuthenticated: true, isLoading: false, isLoggingIn: false });
@@ -75,6 +84,7 @@ export const useAuthStore = create<AuthState>((set) => ({
           email: parsed.email,
           name: parsed.name,
           role: parsed.role,
+          avatarUrl: parsed.avatarUrl ?? null,
           tenantName: parsed.tenantName ?? null,
           tenantLogo: parsed.tenantLogo ?? null,
         };
@@ -92,6 +102,26 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   setLoggingIn: (loading) => set({ isLoggingIn: loading }),
+
+  setUser: async (partial) => {
+    const current = useAuthStore.getState().user;
+    if (!current) return;
+    const merged: AuthUser = { ...current, ...partial };
+    set({ user: merged });
+    try {
+      await secureStorage.set(STORAGE_KEYS.USER_DATA, JSON.stringify({
+        id: merged.id,
+        email: merged.email,
+        name: merged.name,
+        role: merged.role,
+        avatarUrl: merged.avatarUrl ?? null,
+        tenantName: merged.tenantName ?? null,
+        tenantLogo: merged.tenantLogo ?? null,
+      }));
+    } catch {
+      // Persistencia best-effort. State en memoria ya está actualizado.
+    }
+  },
 }));
 
 // Listen for force logout from API interceptor

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
@@ -131,6 +131,29 @@ public static class MobileAuthEndpoints
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized);
 
+        // GET /api/mobile/auth/me — snapshot del usuario actual (avatar, nombre,
+        // role) desde JWT claims + DB. El cliente mobile lo invoca al volver al
+        // foreground para detectar cambios hechos desde web (foto de perfil).
+        group.MapGet("/me", async (
+            [FromServices] MobileAuthService auth,
+            HttpContext context) =>
+        {
+            var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                           ?? context.User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+                return Results.Unauthorized();
+
+            var data = await auth.GetMeAsync(userId);
+            if (data == null) return Results.NotFound();
+
+            return Results.Ok(new { success = true, data });
+        })
+        .RequireAuthorization()
+        .WithSummary("Snapshot del usuario logueado")
+        .WithDescription("Retorna { user: { id, email, name, role, avatarUrl, tenantLogo } } del usuario en el JWT. Usado por el cliente para refrescar avatar al volver al foreground.")
+        .Produces<object>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized);
+
         group.MapPost("/refresh", async (
             RefreshTokenDto dto,
             [FromServices] MobileAuthService auth) =>

--- a/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
@@ -187,6 +187,7 @@ public class MobileAuthService
                     email = usuario.Email,
                     name = usuario.Nombre,
                     role = usuario.Rol,
+                    avatarUrl = usuario.AvatarUrl,
                     tenantLogo = companyLogo ?? ""
                 },
                 token = token,
@@ -262,10 +263,44 @@ public class MobileAuthService
                 email = tokenEntity.Usuario.Email,
                 name = tokenEntity.Usuario.Nombre,
                 role = tokenEntity.Usuario.Rol,
+                avatarUrl = tokenEntity.Usuario.AvatarUrl,
                 tenantLogo = companyLogo ?? ""
             },
             token = newAccessToken,
             refreshToken = newPlainToken
+        };
+    }
+
+    /// <summary>
+    /// Devuelve el snapshot del usuario logueado a partir de las claims del JWT.
+    /// Usado por el cliente mobile para refrescar avatar/nombre/role cuando se
+    /// vuelve al foreground (p. ej. el admin actualizó la foto desde web).
+    /// SIEMPRE retorna SOLO los datos del usuario en el token — nunca otro id.
+    /// </summary>
+    public async Task<object?> GetMeAsync(int userId)
+    {
+        var usuario = await _db.Usuarios
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId);
+        if (usuario == null) return null;
+
+        var companyLogo = await _db.CompanySettings
+            .AsNoTracking()
+            .Where(cs => cs.TenantId == usuario.TenantId)
+            .Select(cs => cs.LogoUrl)
+            .FirstOrDefaultAsync();
+
+        return new
+        {
+            user = new
+            {
+                id = usuario.Id.ToString(),
+                email = usuario.Email,
+                name = usuario.Nombre,
+                role = usuario.Rol,
+                avatarUrl = usuario.AvatarUrl,
+                tenantLogo = companyLogo ?? ""
+            }
         };
     }
 
@@ -489,6 +524,7 @@ public class MobileAuthService
                     email = usuario.Email,
                     name = usuario.Nombre,
                     role = usuario.Rol,
+                    avatarUrl = usuario.AvatarUrl,
                     tenantLogo = companyLogo ?? ""
                 },
                 token = token,

--- a/apps/web/e2e/avatar-badge-flow.spec.ts
+++ b/apps/web/e2e/avatar-badge-flow.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * Avatar + badge de notificaciones + atajo a /notifications desde el dropdown
+ * y desde Mi Perfil.
+ *
+ * Cobertura:
+ *  - Avatar visible en el header (con o sin foto, fallback a iniciales).
+ *  - Click avatar abre el dropdown del user menu.
+ *  - Dropdown tiene un item "Notificaciones" como primero, antes de "Mi Perfil".
+ *  - Click "Notificaciones" navega a `/notifications`.
+ *  - Click "Mi Perfil" en el dropdown navega a `/profile`.
+ *  - En `/profile` hay una card con icono Bell + texto "Notificaciones" + "Ver
+ *    todas →" que navega a `/notifications`.
+ *  - Si hay unread > 0, el badge rojo se renderiza encima del avatar y dentro
+ *    del dropdown. (Test asume cuenta de prueba puede o no tener unread —
+ *    asserta solo el shape, no count específico.)
+ */
+test.describe('Avatar + notifications badge', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('avatar visible in header + clickable opens dropdown', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    // El avatar trigger es el botón con data-tour="header-user-menu"
+    const trigger = page.getByTestId('header-user-menu').or(
+      page.locator('[data-tour="header-user-menu"]')
+    );
+    await expect(trigger).toBeVisible();
+
+    // Si hay unread > 0, el badge debe estar visible encima del avatar
+    const headerBadge = page.getByTestId('avatar-unread-badge');
+    if (await headerBadge.count()) {
+      await expect(headerBadge).toBeVisible();
+      // Texto: número o "99+"
+      const text = (await headerBadge.textContent())?.trim() ?? '';
+      expect(text).toMatch(/^(\d+|99\+)$/);
+    }
+
+    await trigger.click();
+
+    // El dropdown abre con item "Notificaciones" como primero
+    const notifItem = page.getByTestId('user-menu-notifications');
+    await expect(notifItem).toBeVisible();
+  });
+
+  test('dropdown notifications item navigates to /notifications', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-tour="header-user-menu"]').click();
+
+    const notifItem = page.getByTestId('user-menu-notifications');
+    await expect(notifItem).toBeVisible();
+    await notifItem.click();
+
+    await expect(page).toHaveURL(/\/notifications/);
+  });
+
+  test('dropdown Mi Perfil navigates to /profile', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-tour="header-user-menu"]').click();
+
+    const myProfile = page.getByRole('button', { name: /mi perfil/i });
+    await expect(myProfile).toBeVisible();
+    await myProfile.click();
+
+    await expect(page).toHaveURL(/\/profile/);
+  });
+
+  test('profile page shows notifications card linking to /notifications', async ({ page }) => {
+    await page.goto('/profile');
+
+    // Card "Notificaciones" arriba de los Tabs
+    const card = page.getByTestId('profile-notifications-link');
+    await expect(card).toBeVisible();
+    // CTA "Ver todas →"
+    await expect(card.getByText(/ver todas/i)).toBeVisible();
+
+    // Click — Next.js <Link> navega
+    await card.click();
+    await expect(page).toHaveURL(/\/notifications/);
+  });
+});

--- a/apps/web/src/app/(dashboard)/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/profile/page.tsx
@@ -17,6 +17,7 @@ import { useUnsavedChanges } from '@/hooks/useUnsavedChanges';
 import { UnsavedChangesDialog } from '@/components/ui/UnsavedChangesDialog';
 import { SecurityTab } from '@/app/(dashboard)/settings/components/SecurityTab';
 import { NotificationsTab } from '@/app/(dashboard)/settings/components/NotificationsTab';
+import Link from 'next/link';
 import {
   User,
   Shield,
@@ -26,7 +27,10 @@ import {
   MapPin,
   Building,
   Clock,
+  Bell,
+  ArrowRight,
 } from 'lucide-react';
+import { useNotifications } from '@/hooks/useNotifications';
 import { getInitials } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
 import { useFormatters } from '@/hooks/useFormatters';
@@ -52,6 +56,8 @@ export default function ProfilePage() {
     uploadAvatar,
     deleteAvatar,
   } = useProfile();
+  const { unreadCount } = useNotifications();
+  const unreadDisplay = unreadCount > 99 ? '99+' : String(unreadCount);
 
   const [devices, setDevices] = useState<DeviceSessionDto[]>([]);
   const [activityLog, setActivityLog] = useState<ActivityLogEntry[]>([]);
@@ -308,6 +314,53 @@ export default function ProfilePage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Quick link to /notifications — el owner pidió un acceso directo desde
+          Mi Perfil al listado de notificaciones (no la tab de preferencias).
+          La tab "Notifications" abajo sigue siendo para preferencias (email,
+          push, etc.); aquí mostramos el badge con sin-leer y CTA a la lista. */}
+      <Link
+        href="/notifications"
+        data-testid="profile-notifications-link"
+        className="block group"
+        aria-label={
+          unreadCount > 0
+            ? `Notificaciones, ${unreadCount} sin leer`
+            : 'Notificaciones'
+        }
+      >
+        <Card className="transition-colors hover:bg-accent/50 cursor-pointer">
+          <CardContent className="flex items-center justify-between gap-4 py-4">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="relative flex-shrink-0 rounded-lg bg-orange-50 dark:bg-orange-950/30 p-2.5">
+                <Bell className="h-5 w-5 text-orange-500" strokeWidth={2} />
+                {unreadCount > 0 && (
+                  <span
+                    data-testid="profile-notifications-badge"
+                    className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[20px] h-5 rounded-full bg-red-600 px-1.5 text-[10px] font-bold leading-none text-white ring-2 ring-white dark:ring-gray-900"
+                  >
+                    {unreadDisplay}
+                  </span>
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-foreground truncate">
+                  {tc('notificationsTitle')}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {unreadCount > 0
+                    ? `${unreadCount} sin leer`
+                    : 'Estás al día'}
+                </p>
+              </div>
+            </div>
+            <span className="inline-flex items-center text-xs font-medium text-blue-600 group-hover:text-blue-700 transition-colors flex-shrink-0">
+              Ver todas
+              <ArrowRight className="ml-1 h-3.5 w-3.5" />
+            </span>
+          </CardContent>
+        </Card>
+      </Link>
 
       <Tabs defaultValue="personal" className="space-y-4">
         <TabsList data-tour="profile-tabs">

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -391,22 +391,35 @@ export const Header: React.FC<HeaderProps> = ({ onMenuClick, onHelpClick, isImpe
           {/* Divider */}
           <div className="hidden md:block w-px h-6 bg-border mx-1" />
 
-          {/* User menu */}
+          {/* User menu — avatar con badge de notif no leídas (mismo dato que
+              el Bell icon, doble entrada visual por decisión del owner) */}
           <Button
             data-tour="header-user-menu"
             variant="ghost"
             className="flex items-center gap-2 px-2 py-1.5 hover:bg-accent rounded-full h-auto transition-colors duration-200"
             onClick={() => setIsUserMenuOpen(true)}
+            aria-label={unread > 0 ? `Mi cuenta, ${unread} sin leer` : 'Mi cuenta'}
           >
             <div className="hidden md:block text-right">
               <p className="text-sm font-medium text-foreground leading-none">{currentUser.name}</p>
             </div>
-            <Avatar className="h-8 w-8 ring-2 ring-gray-100 dark:ring-gray-800">
-              <AvatarImage src={currentUser.avatar} alt={currentUser.name} />
-              <AvatarFallback className="bg-primary/10 text-primary font-semibold text-sm">
-                {getInitials(currentUser.name)}
-              </AvatarFallback>
-            </Avatar>
+            <span className="relative inline-flex overflow-visible">
+              <Avatar className="h-8 w-8 ring-2 ring-gray-100 dark:ring-gray-800">
+                <AvatarImage src={currentUser.avatar} alt={currentUser.name} />
+                <AvatarFallback className="bg-primary/10 text-primary font-semibold text-sm">
+                  {getInitials(currentUser.name)}
+                </AvatarFallback>
+              </Avatar>
+              {unread > 0 && (
+                <span
+                  data-testid="avatar-unread-badge"
+                  className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[18px] h-[18px] rounded-full bg-red-600 px-1 text-[10px] font-bold leading-none text-white ring-2 ring-white dark:ring-gray-900"
+                  aria-label={`${unread} notificaciones sin leer`}
+                >
+                  {unreadDisplay}
+                </span>
+              )}
+            </span>
           </Button>
         </div>
       </div>
@@ -555,6 +568,31 @@ export const Header: React.FC<HeaderProps> = ({ onMenuClick, onHelpClick, isImpe
             </div>
 
             <div className="space-y-2">
+              <Button
+                data-testid="user-menu-notifications"
+                variant="ghost"
+                className="w-full justify-start h-12 text-foreground hover:bg-accent"
+                onClick={() => {
+                  router.push('/notifications');
+                  setIsUserMenuOpen(false);
+                }}
+                aria-label={
+                  unread > 0
+                    ? `${tc('notificationsTitle')}, ${unread} sin leer`
+                    : undefined
+                }
+              >
+                <Bell className="h-4 w-4 mr-3 text-orange-500" />
+                <span className="flex-1 text-left">{tc('notificationsTitle')}</span>
+                {unread > 0 && (
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex items-center justify-center min-w-[20px] h-5 rounded-full bg-red-600 px-1.5 text-[10px] font-bold text-white"
+                  >
+                    {unreadDisplay}
+                  </span>
+                )}
+              </Button>
               <Button
                 variant="ghost"
                 className="w-full justify-start h-12 text-foreground hover:bg-accent"


### PR DESCRIPTION
## Cambios

Sync de foto de perfil web→mobile (campo `Usuario.AvatarUrl` ya existía
en backend, faltaba exponerlo en mobile API + render en mobile). Plus
badge rojo de notificaciones no leídas al lado del avatar en web Y
mobile, tap → /profile, en /profile link directo a /notifications.

Detalles completos en el commit [`06b3c16d`](https://github.com/joshmen/handy-sales-crm/commit/06b3c16d).

## Test plan

- [x] `npx tsc --noEmit` mobile-app → 0 errores
- [x] `npm run type-check` web → 0 errores
- [x] `dotnet test apps/mobile/HandySuites.Mobile.Tests` → 44/44 PASS
- [x] Maestro `vendedor/03-avatar-tap-perfil-notif.yaml` → PASS en
      emulador con vendedor1@jeyma.com
- [x] frontend-ui-ux-validator: 3 críticos aplicados (overflow visible
      en Android para badge clipping, hitSlop comfort padding, aria-label)
- [x] context7: refactor a `focusManager.setFocused()` idiomático para
      RN (en lugar de AppState listener por hook)
- [ ] Validación manual web (Playwright): `apps/web/e2e/avatar-badge-flow.spec.ts`
      creado, correr en CI/local
- [ ] Validación manual end-to-end del sync: subir avatar en web → ver
      en mobile al volver al foreground

## Deployment checklist

- ✅ No nuevas env vars
- ✅ No EF Core migrations (campo `AvatarUrl` ya existe en DB)
- ✅ No CI/CD changes
- ✅ Backwards compat: `avatarUrl` opcional en login response
