### PR TITLE
feat: mobile avatar upload + drawer admin avatares + fix 400 editar vendedor

### DIFF
--- a/apps/api/tests/HandySuites.Tests/Application/Usuarios/UsuarioEndpointsTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Usuarios/UsuarioEndpointsTests.cs
@@ -31,5 +31,37 @@ namespace HandySuites.Tests.Integration.Usuarios
             content.ValueKind.Should().Be(JsonValueKind.Array);
             content.GetArrayLength().Should().BeGreaterThan(0); // El seeder tiene 4 usuarios
         }
+
+        /// <summary>
+        /// Regression: admin web Equipo manda {nombre, rol, activo, telefono} SIN
+        /// email al PUT /api/usuarios/{id}. Antes el DTO requería Email
+        /// (NotEmpty) y caía con 400. Reportado 2026-05-04 por owner.
+        /// </summary>
+        [Fact]
+        public async Task UpdateUsuario_SinEmail_DeberiaRetornar200_NoBadRequest()
+        {
+            _client.DefaultRequestHeaders.Add("Authorization", "Bearer fake-jwt-token");
+
+            // Listamos primero para conseguir un id válido del seeder.
+            var listResp = await _client.GetAsync("/api/usuarios");
+            listResp.StatusCode.Should().Be(HttpStatusCode.OK);
+            var list = await listResp.Content.ReadFromJsonAsync<JsonElement>();
+            var firstId = list[0].GetProperty("id").GetInt32();
+
+            // Payload exactamente como lo manda apps/web/.../MiembrosTab.tsx —
+            // sin email. Se espera 200 con la lógica patch nueva.
+            var payload = new
+            {
+                nombre = "Vendedor Updated Test",
+                rol = "VENDEDOR",
+                activo = true,
+                telefono = "+52 55 1234-5678",
+            };
+
+            var resp = await _client.PutAsJsonAsync($"/api/usuarios/{firstId}", payload);
+
+            resp.StatusCode.Should().Be(HttpStatusCode.OK,
+                because: "PUT con {nombre,rol,activo,telefono} sin email NO debe ser 400");
+        }
     }
 }

--- a/apps/mobile-app/.maestro/vendedor/04-cambiar-foto-perfil.yaml
+++ b/apps/mobile-app/.maestro/vendedor/04-cambiar-foto-perfil.yaml
@@ -1,0 +1,61 @@
+appId: host.exp.exponent
+name: "Mi Perfil: cambiar foto desde mobile (BottomSheet 3 opciones)"
+---
+
+# ════════════════════════════════════════════════════════════
+# PREREQ: ya logueado como vendedor1@jeyma.com (preserva sesión)
+#
+# Valida los cambios del 2026-05-04:
+#   - El avatar grande en /profile es tappable.
+#   - Tap abre BottomSheet con título "Foto de perfil".
+#   - Sheet muestra "Tomar foto" + "Elegir de galería".
+#   - Si el user ya tiene foto, también muestra "Quitar foto".
+#
+# NOTA: el flujo completo de upload no se automatiza con Maestro porque
+# el ImagePicker es nativo (galería del SO). Solo validamos hasta abrir
+# el sheet + verificar las opciones.
+# ════════════════════════════════════════════════════════════
+
+# Reset al tab Hoy
+- tapOn: "Hoy"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "ACCIONES RÁPIDAS"
+    timeout: 15000
+
+# ────────────────────────────────────────────
+# PASO 1: tap al avatar header → /profile
+# ────────────────────────────────────────────
+- tapOn:
+    id: "header-avatar"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "Vendedor 1 Jeyma"
+    timeout: 5000
+
+- takeScreenshot: "foto-01-profile-camera-badge"
+
+# ────────────────────────────────────────────
+# PASO 2: tap al avatar grande → BottomSheet
+# ────────────────────────────────────────────
+- tapOn:
+    id: "profile-avatar-tap"
+- waitForAnimationToEnd
+
+# Verificar shape del sheet
+- assertVisible: "Foto de perfil"
+- assertVisible: "Elige cómo quieres cambiar tu foto"
+- assertVisible: "Tomar foto"
+- assertVisible: "Elegir de galería"
+
+- takeScreenshot: "foto-02-bottom-sheet"
+
+# ────────────────────────────────────────────
+# PASO 3: cancelar — verificar que vuelve a perfil sin cambios
+# ────────────────────────────────────────────
+- tapOn:
+    point: "10%,15%"
+- waitForAnimationToEnd
+
+- assertVisible: "Vendedor 1 Jeyma"
+- assertNotVisible: "Foto de perfil"

--- a/apps/mobile-app/app/(tabs)/profile.tsx
+++ b/apps/mobile-app/app/(tabs)/profile.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Application from 'expo-application';
 import { useAuthStore } from '@/stores';
-import { useLogout, useUnreadNotificationCount } from '@/hooks';
-import { Card, Button, Badge, ConfirmModal, UserAvatar } from '@/components/ui';
-import { Mail, Shield, Building2, Smartphone, ChevronLeft, Bell, ChevronRight } from 'lucide-react-native';
+import { useLogout, useUnreadNotificationCount, useUploadAvatar, useDeleteAvatar } from '@/hooks';
+import { Card, Button, Badge, ConfirmModal, UserAvatar, BottomSheet } from '@/components/ui';
+import { Mail, Shield, Building2, Smartphone, ChevronLeft, Bell, ChevronRight, Camera, Image as ImageIcon, Trash2 } from 'lucide-react-native';
 import { HandyLogo } from '@/components/shared/HandyLogo';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { COLORS } from '@/theme/colors';
@@ -31,10 +31,29 @@ export default function ProfileScreen() {
   const { user } = useAuthStore();
   const logoutMutation = useLogout();
   const { count: unreadNotifs } = useUnreadNotificationCount();
+  const uploadAvatar = useUploadAvatar();
+  const deleteAvatar = useDeleteAvatar();
   const [showLogout, setShowLogout] = useState(false);
+  const [showAvatarSheet, setShowAvatarSheet] = useState(false);
 
   const handleLogout = () => {
     setShowLogout(true);
+  };
+
+  const isAvatarBusy = uploadAvatar.isPending || deleteAvatar.isPending;
+  const closeAvatarSheet = () => setShowAvatarSheet(false);
+
+  const handleTakePhoto = () => {
+    closeAvatarSheet();
+    uploadAvatar.mutate('camera');
+  };
+  const handlePickGallery = () => {
+    closeAvatarSheet();
+    uploadAvatar.mutate('gallery');
+  };
+  const handleRemovePhoto = () => {
+    closeAvatarSheet();
+    deleteAvatar.mutate();
   };
 
   if (!user) return null;
@@ -55,18 +74,40 @@ export default function ProfileScreen() {
         </TouchableOpacity>
       </View>
 
-      {/* Overlapping avatar + profile info — usa UserAvatar centralizado para
-          que la foto de perfil cambiada desde web aparezca aquí (vía useMe). */}
+      {/* Overlapping avatar + profile info — tap al avatar abre el sheet de
+          cambio de foto. UserAvatar mismo es el componente compartido (mismo
+          render que aparece en web). El sync hacia web ocurre vía Cloudinary
+          + useProfile en web. */}
       <Animated.View entering={FadeInDown.duration(400)} style={styles.profileHeader}>
-        <View style={styles.avatarLargeWrap}>
-          <UserAvatar
-            name={user.name}
-            avatarUrl={user.avatarUrl}
-            size={80}
-            badgeRingColor={COLORS.card}
-            testID="profile-avatar-large"
-          />
-        </View>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          onPress={() => setShowAvatarSheet(true)}
+          disabled={isAvatarBusy}
+          accessibilityRole="button"
+          accessibilityLabel="Cambiar foto de perfil"
+          testID="profile-avatar-tap"
+        >
+          <View style={styles.avatarLargeWrap}>
+            <UserAvatar
+              name={user.name}
+              avatarUrl={user.avatarUrl}
+              size={80}
+              badgeRingColor={COLORS.card}
+              cacheKey={user.avatarUrl ? Date.now() : undefined}
+              testID="profile-avatar-large"
+            />
+            {/* Camera affordance badge — señaliza que el avatar es tappable.
+                Patrón espejo del WhatsApp/Telegram para edit profile photo. */}
+            <View style={styles.avatarEditBadge} pointerEvents="none">
+              <Camera size={12} color={COLORS.foreground} />
+            </View>
+            {isAvatarBusy && (
+              <View style={styles.avatarLoadingOverlay} pointerEvents="none">
+                <ActivityIndicator color="#ffffff" />
+              </View>
+            )}
+          </View>
+        </TouchableOpacity>
         <Text style={styles.userName}>{user.name}</Text>
         <View style={styles.emailRow}>
           <Mail size={13} color={COLORS.textTertiary} />
@@ -186,6 +227,64 @@ export default function ProfileScreen() {
       onConfirm={() => { setShowLogout(false); logoutMutation.mutate(); }}
       onCancel={() => setShowLogout(false)}
     />
+
+    <BottomSheet
+      visible={showAvatarSheet}
+      title="Foto de perfil"
+      subtitle="Elige cómo quieres cambiar tu foto"
+      onClose={closeAvatarSheet}
+    >
+      <View style={styles.avatarSheetOptions}>
+        <TouchableOpacity
+          style={styles.avatarSheetCard}
+          onPress={handleTakePhoto}
+          activeOpacity={0.85}
+          accessibilityLabel="Tomar foto"
+          accessibilityRole="button"
+          testID="avatar-sheet-camera"
+        >
+          <Camera size={22} color="#6b7280" />
+          <View style={styles.avatarSheetInfo}>
+            <Text style={styles.avatarSheetTitle}>Tomar foto</Text>
+            <Text style={styles.avatarSheetDesc}>Usar la cámara para tomar una nueva foto</Text>
+          </View>
+          <ChevronRight size={18} color={COLORS.textTertiary} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.avatarSheetCard}
+          onPress={handlePickGallery}
+          activeOpacity={0.85}
+          accessibilityLabel="Elegir de galería"
+          accessibilityRole="button"
+          testID="avatar-sheet-gallery"
+        >
+          <ImageIcon size={22} color="#6b7280" />
+          <View style={styles.avatarSheetInfo}>
+            <Text style={styles.avatarSheetTitle}>Elegir de galería</Text>
+            <Text style={styles.avatarSheetDesc}>Seleccionar una foto guardada en tu dispositivo</Text>
+          </View>
+          <ChevronRight size={18} color={COLORS.textTertiary} />
+        </TouchableOpacity>
+
+        {user.avatarUrl && (
+          <TouchableOpacity
+            style={[styles.avatarSheetCard, styles.avatarSheetCardDanger]}
+            onPress={handleRemovePhoto}
+            activeOpacity={0.85}
+            accessibilityLabel="Quitar foto actual"
+            accessibilityRole="button"
+            testID="avatar-sheet-delete"
+          >
+            <Trash2 size={22} color="#dc2626" />
+            <View style={styles.avatarSheetInfo}>
+              <Text style={[styles.avatarSheetTitle, { color: '#dc2626' }]}>Quitar foto</Text>
+              <Text style={styles.avatarSheetDesc}>Volver a las iniciales como avatar</Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      </View>
+    </BottomSheet>
     </>
   );
 }
@@ -221,6 +320,47 @@ const styles = StyleSheet.create({
     shadowRadius: 12,
     elevation: 6,
   },
+  avatarLoadingOverlay: {
+    position: 'absolute',
+    top: 0, left: 0, right: 0, bottom: 0,
+    borderRadius: 48,
+    // 0.55 alcanza el 3:1 de contraste WCAG 1.4.11 para el spinner blanco
+    // sobre cualquier avatar/iniciales (validado por frontend-ui-ux-validator).
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarEditBadge: {
+    position: 'absolute',
+    bottom: 2,
+    right: 2,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: COLORS.card,
+    borderWidth: 1.5,
+    borderColor: COLORS.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarSheetOptions: { gap: 12 },
+  avatarSheetCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: COLORS.card,
+    borderRadius: 14,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    gap: 14,
+  },
+  avatarSheetCardDanger: {
+    borderColor: '#fecaca',
+    backgroundColor: '#fef2f2',
+  },
+  avatarSheetInfo: { flex: 1 },
+  avatarSheetTitle: { fontSize: 16, fontWeight: '700', color: COLORS.foreground },
+  avatarSheetDesc: { fontSize: 13, color: COLORS.textSecondary, marginTop: 2 },
   notifIconWrap: {
     width: 28,
     height: 28,

--- a/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/AdminDashboard.tsx
@@ -184,13 +184,10 @@ export function AdminDashboard() {
 }
 
 function PersonCard({ person, onPress }: { person: VendedorEquipo; onPress: () => void }) {
-  const initials = person.nombre
-    .split(' ')
-    .filter(Boolean)
-    .map(w => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+  // Color del avatar según rol (cuando no tiene foto). Mantiene la jerarquía
+  // visual del web (supervisor naranja, vendedor verde) — espejo de
+  // ROLE_COLORS en profile.tsx.
+  const fallbackColor = person.rol === 'SUPERVISOR' ? '#d97706' : '#16a34a';
 
   return (
     <TouchableOpacity
@@ -200,9 +197,14 @@ function PersonCard({ person, onPress }: { person: VendedorEquipo; onPress: () =
       accessibilityLabel={`${person.nombre}, ${person.isOnline ? 'En línea' : 'Desconectado'}`}
       accessibilityRole="button"
     >
-      <View style={styles.personAvatar}>
-        <Text style={styles.personAvatarText}>{initials}</Text>
-      </View>
+      <UserAvatar
+        name={person.nombre}
+        avatarUrl={person.avatarUrl}
+        size={40}
+        fallbackBgColor={fallbackColor}
+        fallbackTextColor="#ffffff"
+        style={{ marginRight: 12 }}
+      />
       <View style={styles.personInfo}>
         <Text style={styles.personName}>{person.nombre}</Text>
         <Text style={styles.personEmail}>{person.email}</Text>

--- a/apps/mobile-app/src/components/dashboard/SupervisorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/SupervisorDashboard.tsx
@@ -154,24 +154,33 @@ export function SupervisorDashboard() {
 }
 
 function VendedorCard({ vendedor, onPress }: { vendedor: VendedorEquipo; onPress: () => void }) {
-  const initials = vendedor.nombre
-    .split(' ')
-    .filter(Boolean)
-    .map(w => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+  const fallbackColor = vendedor.rol === 'SUPERVISOR' ? '#d97706' : '#16a34a';
 
   return (
-    <TouchableOpacity style={styles.vendedorCard} onPress={onPress} activeOpacity={0.85}>
-      <View style={styles.vendedorAvatar}>
-        <Text style={styles.vendedorAvatarText}>{initials}</Text>
-      </View>
+    <TouchableOpacity
+      style={styles.vendedorCard}
+      onPress={onPress}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityLabel={`${vendedor.nombre}, ${vendedor.isOnline ? 'En línea' : 'Desconectado'}`}
+    >
+      <UserAvatar
+        name={vendedor.nombre}
+        avatarUrl={vendedor.avatarUrl}
+        size={40}
+        fallbackBgColor={fallbackColor}
+        fallbackTextColor="#ffffff"
+        style={{ marginRight: 12 }}
+      />
       <View style={styles.vendedorInfo}>
         <Text style={styles.vendedorName}>{vendedor.nombre}</Text>
         <Text style={styles.vendedorEmail}>{vendedor.email}</Text>
       </View>
-      <View style={[styles.statusDot, { backgroundColor: vendedor.activo ? '#22c55e' : '#ef4444' }]} />
+      {/* Dot verde = "En línea" (GPS ping <15min). Antes usábamos `vendedor.activo`
+          pero eso es estado de cuenta, no presencia real (creaba inconsistencia
+          con AdminDashboard que ya usa isOnline). Reportado por validator
+          frontend-ui-ux 2026-05-04. */}
+      <View style={[styles.statusDot, { backgroundColor: vendedor.isOnline ? '#22c55e' : '#94a3b8' }]} />
     </TouchableOpacity>
   );
 }

--- a/apps/mobile-app/src/hooks/index.ts
+++ b/apps/mobile-app/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useLogin, useForceLogin, useLogout } from './useAuth';
-export { useMe, invalidateMe } from './useMe';
+export { useMe, invalidateMe, ME_QUERY_KEY } from './useMe';
+export { useUploadAvatar, useDeleteAvatar } from './useAvatarUpload';
 export { useRealtime } from './useRealtime';
 export { useClientsList, useClientDetail } from './useClients';
 export { useOrdersList, useOrderDetail, useConfirmarPedido, useEnRutaPedido, useEntregarPedido, useCancelarPedido } from './useOrders';

--- a/apps/mobile-app/src/hooks/useAvatarUpload.tsx
+++ b/apps/mobile-app/src/hooks/useAvatarUpload.tsx
@@ -1,0 +1,95 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Alert } from 'react-native';
+import Toast from 'react-native-toast-message';
+import {
+  pickAndUploadAvatar,
+  deleteAvatar,
+  AvatarPermissionDeniedError,
+  AvatarUploadError,
+  openAppSettings,
+  type AvatarSource,
+} from '@/services/profileImageService';
+import { useAuthStore } from '@/stores';
+import { ME_QUERY_KEY } from './useMe';
+
+/**
+ * Mutation para subir foto de perfil. Al éxito:
+ * 1. Actualiza el `useAuthStore.user.avatarUrl` (el header avatar refresca al instante).
+ * 2. Invalida `['auth', 'me']` para que el `useMe` refetch cierre cualquier
+ *    drift entre client y backend.
+ * 3. Toast de éxito.
+ *
+ * Si el user niega permisos de cámara/galería, mostramos Alert con shortcut a
+ * Settings (el ImagePicker SDK no re-promptea tras "denied").
+ */
+export function useUploadAvatar() {
+  const queryClient = useQueryClient();
+  const setUser = useAuthStore(s => s.setUser);
+
+  return useMutation({
+    mutationFn: (source: AvatarSource) => pickAndUploadAvatar(source),
+    onSuccess: (result) => {
+      // result === null cuando el user canceló el picker — no error, no toast.
+      if (!result) return;
+
+      // setQueryData directo en lugar de invalidate: el server response es la
+      // fuente de verdad, así evitamos el round-trip extra de refetch + el
+      // doble render que generaba "useMe → setUser efecto" sobre el setUser
+      // que hicimos aquí. Patrón "Updates from Mutation Responses" de
+      // TanStack Query (validado por context7 review).
+      queryClient.setQueryData<{ user: any } | undefined>(
+        ME_QUERY_KEY as any,
+        (old) => (old?.user ? { ...old, user: { ...old.user, avatarUrl: result.avatarUrl } } : old)
+      );
+      setUser({ avatarUrl: result.avatarUrl });
+
+      Toast.show({
+        type: 'success',
+        text1: 'Foto actualizada',
+        text2: 'Tu nueva foto de perfil ya está visible.',
+      });
+    },
+    onError: (error) => {
+      if (error instanceof AvatarPermissionDeniedError) {
+        Alert.alert(
+          error.source === 'camera' ? 'Permiso de cámara' : 'Permiso de galería',
+          error.source === 'camera'
+            ? 'Activa el permiso de cámara en Ajustes para tomar una foto.'
+            : 'Activa el permiso de galería en Ajustes para elegir una foto.',
+          [
+            { text: 'Cancelar', style: 'cancel' },
+            { text: 'Abrir Ajustes', onPress: () => openAppSettings() },
+          ]
+        );
+        return;
+      }
+      const message =
+        error instanceof AvatarUploadError ? error.message : 'No se pudo subir la foto';
+      Toast.show({ type: 'error', text1: 'Error', text2: message });
+    },
+  });
+}
+
+/**
+ * Mutation para borrar la foto de perfil.
+ */
+export function useDeleteAvatar() {
+  const queryClient = useQueryClient();
+  const setUser = useAuthStore(s => s.setUser);
+
+  return useMutation({
+    mutationFn: () => deleteAvatar(),
+    onSuccess: () => {
+      // setQueryData directo (mismo razonamiento que useUploadAvatar).
+      queryClient.setQueryData<{ user: any } | undefined>(
+        ME_QUERY_KEY as any,
+        (old) => (old?.user ? { ...old, user: { ...old.user, avatarUrl: null } } : old)
+      );
+      setUser({ avatarUrl: null });
+      Toast.show({ type: 'success', text1: 'Foto eliminada' });
+    },
+    onError: () => {
+      Toast.show({ type: 'error', text1: 'Error', text2: 'No se pudo eliminar la foto' });
+    },
+  });
+}

--- a/apps/mobile-app/src/services/profileImageService.ts
+++ b/apps/mobile-app/src/services/profileImageService.ts
@@ -1,0 +1,130 @@
+import * as ImagePicker from 'expo-image-picker';
+import { uploadAsync, FileSystemUploadType } from 'expo-file-system/legacy';
+import { Linking } from 'react-native';
+import { api, getAccessToken } from '@/api/client';
+import { API_CONFIG } from '@/utils/constants';
+
+/**
+ * Upload + delete de la foto de perfil del usuario logueado.
+ *
+ * Reusa el patrón del `evidenceManager` (expo-file-system uploadAsync
+ * multipart con Authorization header). Comparte el mismo Cloudinary
+ * configurado en backend.
+ */
+
+export type AvatarSource = 'camera' | 'gallery';
+
+export class AvatarPermissionDeniedError extends Error {
+  source: AvatarSource;
+  constructor(source: AvatarSource) {
+    super(
+      source === 'camera'
+        ? 'Permiso de cámara denegado'
+        : 'Permiso de galería denegado'
+    );
+    this.source = source;
+    this.name = 'AvatarPermissionDeniedError';
+  }
+}
+
+export class AvatarUploadError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+    this.name = 'AvatarUploadError';
+  }
+}
+
+/**
+ * Helper para abrir la pantalla de Settings del SO. UI puede llamarla
+ * cuando el user previamente negó el permiso (ImagePicker NO re-prompts
+ * tras `denied`, hay que mandarlo manual).
+ */
+export function openAppSettings(): Promise<void> {
+  return Linking.openSettings().catch(() => {});
+}
+
+/**
+ * Lanza el picker (cámara o galería) y sube la foto al backend mobile.
+ * Retorna la URL Cloudinary actualizada o null si el user canceló.
+ *
+ * Errores:
+ * - `AvatarPermissionDeniedError` si el user niega el permiso.
+ * - `AvatarUploadError` si el upload falla (red / servidor).
+ */
+export async function pickAndUploadAvatar(
+  source: AvatarSource
+): Promise<{ avatarUrl: string } | null> {
+  // 1. Permisos
+  if (source === 'camera') {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') throw new AvatarPermissionDeniedError('camera');
+  } else {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') throw new AvatarPermissionDeniedError('gallery');
+  }
+
+  // 2. Picker
+  const result =
+    source === 'camera'
+      ? await ImagePicker.launchCameraAsync({
+          mediaTypes: ['images'],
+          quality: 0.7,
+          // Cuadrado: el avatar siempre se renderiza en círculo.
+          allowsEditing: true,
+          aspect: [1, 1],
+          exif: false,
+        })
+      : await ImagePicker.launchImageLibraryAsync({
+          mediaTypes: ['images'],
+          quality: 0.7,
+          allowsEditing: true,
+          aspect: [1, 1],
+          allowsMultipleSelection: false,
+        });
+
+  if (result.canceled || !result.assets?.[0]) return null;
+  const asset = result.assets[0];
+
+  // 3. Upload multipart al backend mobile
+  const token = getAccessToken();
+  const response = await uploadAsync(
+    `${API_CONFIG.BASE_URL}/api/mobile/profile/avatar`,
+    asset.uri,
+    {
+      httpMethod: 'POST',
+      uploadType: FileSystemUploadType.MULTIPART,
+      fieldName: 'file',
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    }
+  );
+
+  if (response.status < 200 || response.status >= 300) {
+    let message = 'No se pudo subir la foto';
+    try {
+      const body = JSON.parse(response.body);
+      message = body.error || body.message || message;
+    } catch {
+      // body no es JSON, mantener message default
+    }
+    throw new AvatarUploadError(message, response.status);
+  }
+
+  // Backend retorna { success, data: { avatarUrl } }
+  const body = JSON.parse(response.body);
+  const avatarUrl: string | undefined = body?.data?.avatarUrl ?? body?.avatarUrl;
+  if (!avatarUrl) {
+    throw new AvatarUploadError('Respuesta del servidor inválida');
+  }
+  return { avatarUrl };
+}
+
+/**
+ * Borra la foto de perfil. El backend la quita de Cloudinary y setea
+ * `Usuario.AvatarUrl = null`. El cliente debe invalidar la query `me`
+ * para que el avatar se vuelva iniciales.
+ */
+export async function deleteAvatar(): Promise<void> {
+  await api.delete('/api/mobile/profile/avatar');
+}

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileProfileEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileProfileEndpoints.cs
@@ -1,0 +1,128 @@
+using HandySuites.Application.CompanySettings.Interfaces;
+using HandySuites.Infrastructure.Persistence;
+using HandySuites.Shared.Imaging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace HandySuites.Mobile.Api.Endpoints;
+
+/// <summary>
+/// Endpoints de perfil del usuario logueado desde mobile. Hoy expone
+/// upload + delete de avatar. El sync hacia el authStore se hace via
+/// `useMe` hook del cliente mobile (refetch al volver al foreground).
+///
+/// Espejo del flujo `POST /api/images/avatar` en el main API pero scoped
+/// a la mobile API: misma host, mismo CORS, mismo JWT issuer. Evita que
+/// el cliente mobile tenga que conocer la URL del main API solo para esto.
+/// </summary>
+public static class MobileProfileEndpoints
+{
+    public static void MapMobileProfileEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/mobile/profile")
+            .WithTags("Profile")
+            .WithOpenApi()
+            .RequireAuthorization();
+
+        // POST /api/mobile/profile/avatar — multipart upload
+        group.MapPost("/avatar", async (
+            IFormFile file,
+            [FromServices] ICloudinaryService cloudinary,
+            [FromServices] HandySuitesDbContext db,
+            HttpContext context) =>
+        {
+            var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                           ?? context.User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+                return Results.Unauthorized();
+
+            // Tamaño + content-type declarado
+            if (file == null || file.Length == 0)
+                return Results.BadRequest(new { error = "Archivo vacío" });
+            if (file.Length > ImageUploadHelpers.MaxAvatarBytes)
+                return Results.BadRequest(new { error = "El archivo no debe superar 5MB" });
+            if (!ImageUploadHelpers.AllowedAvatarContentTypes.Contains(file.ContentType?.ToLower() ?? ""))
+                return Results.BadRequest(new { error = "Tipo de imagen no permitido. Use JPEG, PNG, GIF o WebP." });
+
+            // Defense-in-depth: magic bytes reales (no confiar en content-type del cliente)
+            await using (var stream = file.OpenReadStream())
+            {
+                var header = new byte[12];
+                var read = await stream.ReadAsync(header.AsMemory(0, 12));
+                if (read < 12 || !ImageUploadHelpers.ValidateImageMagicBytes(header, out _))
+                    return Results.BadRequest(new { error = "El archivo no es una imagen válida (JPEG/PNG/GIF/WebP)." });
+            }
+
+            var usuario = await db.Usuarios
+                .Include(u => u.Tenant)
+                .FirstOrDefaultAsync(u => u.Id == userId);
+            if (usuario == null)
+                return Results.NotFound(new { error = "Usuario no encontrado" });
+
+            // Subir a {tenantFolder}/avatars
+            var tenantFolder = cloudinary.GenerateTenantFolder(usuario.TenantId, usuario.Tenant.NombreEmpresa);
+            var avatarFolder = $"{tenantFolder}/avatars";
+
+            var result = await cloudinary.UploadImageAsync(file, avatarFolder);
+            if (!result.IsSuccess)
+                return Results.BadRequest(new { error = result.ErrorMessage ?? "Error al subir imagen" });
+
+            // Borrar avatar anterior (si existía) — best-effort, no falla la request
+            if (!string.IsNullOrEmpty(usuario.AvatarUrl))
+            {
+                var oldPublicId = ImageUploadHelpers.ExtractPublicIdFromCloudinaryUrl(usuario.AvatarUrl);
+                if (!string.IsNullOrEmpty(oldPublicId))
+                {
+                    await cloudinary.DeleteImageAsync(oldPublicId);
+                }
+            }
+
+            usuario.AvatarUrl = result.SecureUrl;
+            await db.SaveChangesAsync();
+
+            return Results.Ok(new { success = true, data = new { avatarUrl = result.SecureUrl } });
+        })
+        .DisableAntiforgery()
+        .WithSummary("Subir foto de perfil del usuario logueado")
+        .WithDescription("Multipart upload con campo `file`. Valida magic bytes + 5MB cap + JPEG/PNG/GIF/WebP. Sube a Cloudinary `{tenant}/avatars/`, borra el anterior si existía, y actualiza `Usuario.AvatarUrl` en DB.")
+        .Produces<object>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized);
+
+        // DELETE /api/mobile/profile/avatar — quita la foto y limpia Cloudinary
+        group.MapDelete("/avatar", async (
+            [FromServices] ICloudinaryService cloudinary,
+            [FromServices] HandySuitesDbContext db,
+            HttpContext context) =>
+        {
+            var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                           ?? context.User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+                return Results.Unauthorized();
+
+            var usuario = await db.Usuarios
+                .FirstOrDefaultAsync(u => u.Id == userId);
+            if (usuario == null)
+                return Results.NotFound(new { error = "Usuario no encontrado" });
+
+            if (!string.IsNullOrEmpty(usuario.AvatarUrl))
+            {
+                var oldPublicId = ImageUploadHelpers.ExtractPublicIdFromCloudinaryUrl(usuario.AvatarUrl);
+                if (!string.IsNullOrEmpty(oldPublicId))
+                {
+                    await cloudinary.DeleteImageAsync(oldPublicId);
+                }
+            }
+
+            usuario.AvatarUrl = null;
+            await db.SaveChangesAsync();
+
+            return Results.Ok(new { success = true, data = new { avatarUrl = (string?)null } });
+        })
+        .WithSummary("Quitar foto de perfil")
+        .WithDescription("Borra la imagen de Cloudinary y setea `Usuario.AvatarUrl = null`.")
+        .Produces<object>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized);
+    }
+}

--- a/apps/mobile/HandySuites.Mobile.Api/Program.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Program.cs
@@ -164,6 +164,7 @@ if (app.Environment.IsDevelopment())
 
 // MOBILE-SPECIFIC ENDPOINTS
 app.MapMobileAuthEndpoints();
+app.MapMobileProfileEndpoints();
 app.MapMobilePedidoEndpoints();
 app.MapMobileVisitaEndpoints();
 app.MapMobileClienteEndpoints();

--- a/libs/HandySuites.Application/Usuarios/DTOs/UsuarioUpdateDto.cs
+++ b/libs/HandySuites.Application/Usuarios/DTOs/UsuarioUpdateDto.cs
@@ -1,6 +1,33 @@
+/// <summary>
+/// DTO de actualización de usuario. Todos los campos son opcionales: solo se
+/// aplican los que vienen en el request, los demás conservan el valor actual.
+/// Esto permite a la web "Equipo" mandar `{nombre, rol, activo, telefono}` sin
+/// tener que reenviar el email del usuario, y al mobile mandar solo `{nombre}`
+/// si solo cambia el nombre.
+/// </summary>
 public class UsuarioUpdateDto
 {
-    public required string Email { get; set; }
+    /// <summary>Opcional. Si null/missing, se conserva el email actual.</summary>
+    public string? Email { get; set; }
+
+    /// <summary>Nombre completo. Required — mínimo este campo siempre se envía.</summary>
     public required string Nombre { get; set; }
+
+    /// <summary>Opcional. Si null/empty, NO se cambia el password.</summary>
     public string? Password { get; set; }
+
+    /// <summary>
+    /// Rol explícito. Valores válidos: SUPER_ADMIN, ADMIN, SUPERVISOR, VIEWER,
+    /// VENDEDOR. Validador whitelist contra `RoleNames`.
+    /// </summary>
+    public string? Rol { get; set; }
+
+    /// <summary>Estado activo/inactivo del usuario. Bool nullable: si null, no cambia.</summary>
+    public bool? Activo { get; set; }
+
+    /// <summary>Teléfono de contacto. Formato libre, validador acepta dígitos + separadores.</summary>
+    public string? Telefono { get; set; }
+
+    /// <summary>URL absoluta a la foto de perfil (Cloudinary). Normalmente seteada por el endpoint /avatar, pero permitimos sobrescribir vía PUT por completitud.</summary>
+    public string? AvatarUrl { get; set; }
 }

--- a/libs/HandySuites.Application/Usuarios/Services/UsuarioService.cs
+++ b/libs/HandySuites.Application/Usuarios/Services/UsuarioService.cs
@@ -276,8 +276,46 @@ public class UsuarioService
             throw new UnauthorizedAccessException("Solo el propio usuario o un SUPER_ADMIN puede modificar cuentas de administrador.");
         }
 
-        usuario.Email = dto.Email;
+        // Patch semantics: solo se aplican los campos que vienen en el request.
+        // Antes el DTO requería Email obligatorio y al editar desde web Equipo
+        // (que solo manda nombre/rol/activo/telefono) caía con 400. Ahora cada
+        // campo es opcional excepto Nombre (que el FE siempre envía).
+        if (!string.IsNullOrWhiteSpace(dto.Email))
+        {
+            usuario.Email = dto.Email;
+        }
+
         usuario.Nombre = dto.Nombre;
+
+        // Rol: solo SUPER_ADMIN puede promover/demover a admin/super_admin.
+        // Un admin que cambia de rol a otro vendedor → OK. Un admin que intenta
+        // cambiar a otro admin a super_admin → bloqueado por chequeo BR-030
+        // arriba (no puede tocar a otros admins). Aquí defendemos contra el
+        // caso "admin se promueve a sí mismo" desde un endpoint malformado.
+        if (!string.IsNullOrWhiteSpace(dto.Rol))
+        {
+            if (dto.Rol == RoleNames.SuperAdmin && !_tenant.IsSuperAdmin)
+            {
+                throw new UnauthorizedAccessException("Solo un SUPER_ADMIN puede asignar el rol SUPER_ADMIN.");
+            }
+            usuario.RolExplicito = dto.Rol;
+        }
+
+        if (dto.Activo.HasValue)
+        {
+            usuario.Activo = dto.Activo.Value;
+        }
+
+        if (dto.Telefono != null)
+        {
+            // Permitir vaciar el campo enviando string vacío.
+            usuario.Telefono = string.IsNullOrWhiteSpace(dto.Telefono) ? null : dto.Telefono.Trim();
+        }
+
+        if (dto.AvatarUrl != null)
+        {
+            usuario.AvatarUrl = string.IsNullOrWhiteSpace(dto.AvatarUrl) ? null : dto.AvatarUrl.Trim();
+        }
 
         if (!string.IsNullOrEmpty(dto.Password))
         {

--- a/libs/HandySuites.Application/Usuarios/Validators/UsuarioUpdateDtoValidator.cs
+++ b/libs/HandySuites.Application/Usuarios/Validators/UsuarioUpdateDtoValidator.cs
@@ -1,15 +1,29 @@
 using FluentValidation;
+using HandySuites.Domain.Common;
 
 namespace HandySuites.Application.Usuarios.Validators
 {
     public class UsuarioUpdateDtoValidator : AbstractValidator<UsuarioUpdateDto>
     {
+        // Whitelist de roles válidos. Mantener en sync con RoleNames.
+        private static readonly string[] ValidRoles =
+        {
+            RoleNames.SuperAdmin,
+            RoleNames.Admin,
+            RoleNames.Supervisor,
+            RoleNames.Viewer,
+            RoleNames.Vendedor,
+        };
+
         public UsuarioUpdateDtoValidator()
         {
+            // Email: opcional desde 2026-05-04. Si viene, valida formato.
+            // Antes era required y rechazaba con 400 al editar desde web Equipo
+            // que solo manda {nombre, rol, activo, telefono}.
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("El correo electrónico es obligatorio.")
                 .EmailAddress().WithMessage("El formato del correo electrónico es inválido.")
-                .MaximumLength(255).WithMessage("El correo electrónico no debe exceder los 255 caracteres.");
+                .MaximumLength(255).WithMessage("El correo electrónico no debe exceder los 255 caracteres.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Email));
 
             RuleFor(x => x.Nombre)
                 .NotEmpty().WithMessage("El nombre es obligatorio.")
@@ -20,6 +34,28 @@ namespace HandySuites.Application.Usuarios.Validators
                 .MinimumLength(6).WithMessage("La contraseña debe tener al menos 6 caracteres.")
                 .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)").WithMessage("La contraseña debe contener al menos una minúscula, una mayúscula y un número.")
                 .When(x => !string.IsNullOrWhiteSpace(x.Password));
+
+            // Rol opcional. Si viene, debe ser uno de los válidos.
+            RuleFor(x => x.Rol)
+                .Must(rol => rol == null || ValidRoles.Contains(rol))
+                .WithMessage("El rol no es válido. Valores aceptados: SUPER_ADMIN, ADMIN, SUPERVISOR, VIEWER, VENDEDOR.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Rol));
+
+            // Teléfono opcional. Acepta dígitos + separadores comunes ("(",
+            // ")", "-", " ") y opcional "+" inicial. Permite formatos
+            // internacionales como "+52 (55) 1234-5678" o nacionales "5512345678".
+            RuleFor(x => x.Telefono)
+                .Matches(@"^\+?[\d\s\-\(\)]{7,20}$")
+                .WithMessage("El teléfono debe contener entre 7 y 20 caracteres (dígitos, espacios, paréntesis o guiones).")
+                .When(x => !string.IsNullOrWhiteSpace(x.Telefono));
+
+            // AvatarUrl opcional. Si viene, validar URL bien formada.
+            RuleFor(x => x.AvatarUrl)
+                .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var u) &&
+                             (u.Scheme == "https" || u.Scheme == "http"))
+                .WithMessage("El URL del avatar debe ser absoluto (http/https).")
+                .MaximumLength(500).WithMessage("El URL del avatar no debe exceder los 500 caracteres.")
+                .When(x => !string.IsNullOrWhiteSpace(x.AvatarUrl));
         }
     }
 }

--- a/libs/HandySuites.Domain/Entities/Usuario.cs
+++ b/libs/HandySuites.Domain/Entities/Usuario.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using HandySuites.Domain.Common;
 
@@ -41,6 +42,17 @@ public class Usuario : AuditableEntity
 
     [Column("avatar_url")]
     public string? AvatarUrl { get; set; }
+
+    /// <summary>
+    /// Teléfono de contacto del usuario. Formato libre — admins MX usan
+    /// "+52 55..." pero permitimos cualquier país. El validador del DTO acepta
+    /// dígitos + separadores comunes ("(", ")", "-", " "). Nullable para
+    /// retro-compat con usuarios existentes. MaxLength 20 cubre formatos
+    /// internacionales completos (E.164 max 15 + separadores).
+    /// </summary>
+    [Column("telefono")]
+    [MaxLength(20)]
+    public string? Telefono { get; set; }
 
     [Column("CompanyId")]
     public int? CompanyId { get; set; }

--- a/libs/HandySuites.Infrastructure/Migrations/20260504091937_AddTelefonoToUsuario.Designer.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260504091937_AddTelefonoToUsuario.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace HandySuites.Infrastructure.Migrations
 {
     [DbContext(typeof(HandySuitesDbContext))]
-    partial class HandySuitesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504091937_AddTelefonoToUsuario")]
+    partial class AddTelefonoToUsuario
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/HandySuites.Infrastructure/Migrations/20260504091937_AddTelefonoToUsuario.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260504091937_AddTelefonoToUsuario.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HandySuites.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTelefonoToUsuario : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "telefono",
+                table: "Usuarios",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "telefono",
+                table: "Usuarios");
+        }
+    }
+}

--- a/libs/HandySuites.Shared/Imaging/ImageUploadHelpers.cs
+++ b/libs/HandySuites.Shared/Imaging/ImageUploadHelpers.cs
@@ -1,0 +1,103 @@
+namespace HandySuites.Shared.Imaging;
+
+/// <summary>
+/// Helpers compartidos por endpoints de upload de imagen (main API + mobile API).
+/// Magic byte validation defense-in-depth + extracción de public_id Cloudinary
+/// para borrar avatares anteriores. SVG explícitamente rechazado: aunque sea
+/// "imagen", es XML ejecutable en browsers.
+///
+/// NOTA: este módulo NO depende de ASP.NET Core (IFormFile) para mantener
+/// HandySuites.Shared agnostic del framework. Cada endpoint pasa los bytes
+/// del header (12 bytes) ya extraídos del IFormFile/multipart.
+/// </summary>
+public static class ImageUploadHelpers
+{
+    /// <summary>Tamaño máximo de avatar en bytes (5 MB).</summary>
+    public const long MaxAvatarBytes = 5 * 1024 * 1024;
+
+    /// <summary>Content types permitidos para avatares.</summary>
+    public static readonly string[] AllowedAvatarContentTypes =
+    {
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+    };
+
+    /// <summary>
+    /// Verifica que los primeros bytes correspondan a JPEG/PNG/GIF/WebP.
+    /// Los callers leen los primeros 12 bytes del IFormFile/stream y los pasan.
+    /// </summary>
+    public static bool ValidateImageMagicBytes(byte[] bytes, out string detectedFormat)
+    {
+        detectedFormat = "unknown";
+        if (bytes.Length < 12) return false;
+
+        // JPEG: FF D8 FF
+        if (bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF) { detectedFormat = "jpeg"; return true; }
+        // PNG: 89 50 4E 47 0D 0A 1A 0A
+        if (bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47
+            && bytes[4] == 0x0D && bytes[5] == 0x0A && bytes[6] == 0x1A && bytes[7] == 0x0A)
+        { detectedFormat = "png"; return true; }
+        // GIF: 47 49 46 38 (GIF8)
+        if (bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x38) { detectedFormat = "gif"; return true; }
+        // WebP: RIFF....WEBP
+        if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46
+            && bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50)
+        { detectedFormat = "webp"; return true; }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Extrae el public_id de una URL Cloudinary. Necesario para borrar
+    /// avatares anteriores antes de subir el nuevo.
+    /// Formato URL: https://res.cloudinary.com/{cloud}/image/upload/{trans}/{folder}/{publicId}.{ext}
+    /// </summary>
+    public static string ExtractPublicIdFromCloudinaryUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return string.Empty;
+
+        try
+        {
+            var uri = new Uri(url);
+            var segments = uri.AbsolutePath.Split('/');
+
+            var uploadIndex = Array.IndexOf(segments, "upload");
+            if (uploadIndex == -1 || uploadIndex >= segments.Length - 1)
+                return string.Empty;
+
+            var fileWithExt = segments[segments.Length - 1];
+            var lastDotIndex = fileWithExt.LastIndexOf('.');
+
+            if (lastDotIndex > 0)
+            {
+                var publicIdPart = fileWithExt.Substring(0, lastDotIndex);
+
+                // Incluir la estructura de carpetas, saltando transformaciones
+                // tipo `v1234567` (versionado Cloudinary).
+                var folderParts = new List<string>();
+                for (int i = uploadIndex + 1; i < segments.Length - 1; i++)
+                {
+                    if (!segments[i].StartsWith("v") || !int.TryParse(segments[i].Substring(1), out _))
+                    {
+                        folderParts.Add(segments[i]);
+                    }
+                }
+
+                if (folderParts.Count > 0)
+                {
+                    return string.Join("/", folderParts) + "/" + publicIdPart;
+                }
+
+                return publicIdPart;
+            }
+
+            return string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Resumen

Tres issues reportados por owner el 2026-05-04, fixados en un solo PR
porque comparten el flujo de identidad de usuario (avatar + edit form).

### 1. Mobile avatar upload (vendedor / supervisor / admin)

Antes solo desde web `/profile`. Ahora desde mobile:
- Tap avatar grande → BottomSheet "Tomar foto / Elegir de galería /
  Quitar foto"
- Crop 1:1 → upload multipart a Cloudinary `{tenant}/avatars/`
- Sync inmediato vía `setQueryData` (sin refetch redundante) + `setUser`
- Camera badge en el avatar como afford­ance visual
- Permisos negados → Alert con shortcut a Settings (graceful)

**Backend nuevo**: `POST/DELETE /api/mobile/profile/avatar`
(magic-byte validation + 5MB cap + JPEG/PNG/GIF/WebP). Helpers
compartidos en `libs/HandySuites.Shared/Imaging/ImageUploadHelpers.cs`
reusados desde main API + mobile API. SVG explícitamente rechazado.

### 2. Drawer admin/supervisor: avatares del equipo

`AdminDashboard.PersonCard` y `SupervisorDashboard.VendedorCard` ahora
renderizan `<UserAvatar>` con foto Cloudinary + fallback a iniciales con
color del rol (supervisor naranja, vendedor verde). Los endpoints
`/api/mobile/supervisor/*` ya retornaban `avatarUrl` desde antes — solo
faltaba la UI.

Bonus a11y: VendedorCard ahora tiene `accessibilityRole="button"` +
`accessibilityLabel`. Status dot usa `isOnline` (GPS ping <15min) en
lugar de `activo` (estado de cuenta) para alinearse con AdminDashboard
y evitar confusión semántica.

### 3. Fix 400 BadRequest al editar vendedor desde web Equipo

**Causa**: el frontend `MiembrosTab.tsx` enviaba
`{nombre, rol, activo, telefono}` SIN email. El DTO requería Email
(NotEmpty) → validator rechazaba con "El correo electrónico es
obligatorio."
