### PR TITLE
fix: secure user creation — invite link + RBAC hierarchy + force change password + Vercel ESLint fix

### DIFF
--- a/apps/api/src/HandySuites.Api/Auth/AuthService.cs
+++ b/apps/api/src/HandySuites.Api/Auth/AuthService.cs
@@ -776,7 +776,8 @@ public class AuthService
                 email = usuario.Email,
                 name = usuario.Nombre,
                 role = usuario.Rol,
-                onboardingCompleted
+                onboardingCompleted,
+                mustChangePassword = usuario.MustChangePassword
             },
             token = token,
             refreshToken = plainRefreshToken
@@ -862,7 +863,8 @@ public class AuthService
                 id = tokenEntity.Usuario.Id.ToString(),
                 email = tokenEntity.Usuario.Email,
                 name = tokenEntity.Usuario.Nombre,
-                role = tokenEntity.Usuario.Rol
+                role = tokenEntity.Usuario.Rol,
+                mustChangePassword = tokenEntity.Usuario.MustChangePassword
             },
             token = newAccessToken,
             refreshToken = newPlainToken

--- a/apps/api/src/HandySuites.Api/Endpoints/UsuarioEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/UsuarioEndpoints.cs
@@ -165,10 +165,12 @@ public static class UsuarioEndpoints
                 return new TxUsuarioResult(Results.Created($"/api/usuarios/{usuarioId}", new { id = usuarioId }), usuarioId);
             });
 
-            if (txResult.CreatedId > 0)
+            if (txResult.CreatedId > 0 && !dto.SinEmail)
             {
-                // Send invitation email so the new user can set their password
-                // App:FrontendUrl is validated at startup in Program.cs
+                // Invite link flow (default): enviar email para que el usuario
+                // establezca su propia contraseña vía /set-password. Cuando
+                // dto.SinEmail=true el admin asigna password temporal manual,
+                // así que SKIP este send (no hay email destino).
                 var baseUrl = config["App:FrontendUrl"]!;
                 try { await authService.SendInvitationEmailAsync(txResult.CreatedId, baseUrl); }
                 catch { /* logged inside SendInvitationEmailAsync */ }
@@ -176,13 +178,17 @@ public static class UsuarioEndpoints
 
             return txResult.Response;
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
-            return Results.Forbid();
+            // Propagar el mensaje específico (e.g. "Tu rol no permite crear...")
+            // para que el cliente entienda por qué falló. 403 + body con detalle.
+            return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException ex)
         {
-            return Results.BadRequest(new { error = "No se pudo completar la operación." });
+            // Propagar el mensaje específico (e.g. "Password requerida..." o
+            // "Email ya está en uso") en vez del mensaje genérico anterior.
+            return Results.BadRequest(new { error = ex.Message });
         }
     }
 

--- a/apps/api/tests/HandySuites.Tests/Application/Usuarios/RoleHierarchyTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Usuarios/RoleHierarchyTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using HandySuites.Domain.Common;
+using Xunit;
+
+namespace HandySuites.Tests.Application.Usuarios;
+
+/// <summary>
+/// Unit tests para `RoleHierarchy.CanCreateRole` — la fuente de verdad de
+/// RBAC en `UsuarioService.CrearUsuarioAsync`. Cualquier bypass aquí es un
+/// privilege escalation, así que hay que cubrir todas las celdas de la matriz.
+/// </summary>
+public class RoleHierarchyTests
+{
+    // ───── SUPER_ADMIN puede crear cualquier rol ─────────────────────────
+    [Theory]
+    [InlineData(RoleNames.SuperAdmin)]
+    [InlineData(RoleNames.Admin)]
+    [InlineData(RoleNames.Supervisor)]
+    [InlineData(RoleNames.Viewer)]
+    [InlineData(RoleNames.Vendedor)]
+    public void SuperAdmin_CanCreate_AnyRole(string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.SuperAdmin, targetRole)
+            .Should().BeTrue($"SUPER_ADMIN debe poder crear {targetRole}");
+    }
+
+    // ───── ADMIN: NO puede crear ADMIN ni SUPER_ADMIN ────────────────────
+    [Theory]
+    [InlineData(RoleNames.Supervisor)]
+    [InlineData(RoleNames.Viewer)]
+    [InlineData(RoleNames.Vendedor)]
+    public void Admin_CanCreate_RolesBelow(string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.Admin, targetRole)
+            .Should().BeTrue($"ADMIN debe poder crear {targetRole}");
+    }
+
+    [Theory]
+    [InlineData(RoleNames.SuperAdmin)]
+    [InlineData(RoleNames.Admin)]
+    public void Admin_CannotCreate_AdminOrAbove(string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.Admin, targetRole)
+            .Should().BeFalse($"ADMIN NO debe poder crear {targetRole}");
+    }
+
+    // ───── SUPERVISOR: solo VENDEDOR / VIEWER ────────────────────────────
+    [Theory]
+    [InlineData(RoleNames.Vendedor)]
+    [InlineData(RoleNames.Viewer)]
+    public void Supervisor_CanCreate_LowerRoles(string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.Supervisor, targetRole)
+            .Should().BeTrue($"SUPERVISOR debe poder crear {targetRole}");
+    }
+
+    [Theory]
+    [InlineData(RoleNames.SuperAdmin)]
+    [InlineData(RoleNames.Admin)]
+    [InlineData(RoleNames.Supervisor)] // Mismo rol — no permitido
+    public void Supervisor_CannotCreate_SameOrAbove(string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.Supervisor, targetRole)
+            .Should().BeFalse($"SUPERVISOR NO debe poder crear {targetRole}");
+    }
+
+    // ───── VENDEDOR / VIEWER: no pueden crear nada ───────────────────────
+    [Theory]
+    [InlineData(RoleNames.Vendedor)]
+    [InlineData(RoleNames.Viewer)]
+    public void LowestRoles_CannotCreate_AnyRole(string callerRole)
+    {
+        foreach (var target in new[]
+        {
+            RoleNames.SuperAdmin,
+            RoleNames.Admin,
+            RoleNames.Supervisor,
+            RoleNames.Viewer,
+            RoleNames.Vendedor,
+        })
+        {
+            RoleHierarchy.CanCreateRole(callerRole, target)
+                .Should().BeFalse($"{callerRole} NO debe poder crear {target}");
+        }
+    }
+
+    // ───── Edge cases: null / unknown / case insensitive ─────────────────
+    [Fact]
+    public void NullCallerRole_ReturnsFalse()
+    {
+        RoleHierarchy.CanCreateRole(null, RoleNames.Vendedor).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NullTargetRole_ReturnsFalse()
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.Admin, null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnknownTargetRole_ReturnsFalse()
+    {
+        RoleHierarchy.CanCreateRole(RoleNames.SuperAdmin, "GUEST")
+            .Should().BeFalse("rol no whitelisted no debe ser asignable ni por SUPER_ADMIN");
+    }
+
+    [Theory]
+    [InlineData("admin", "vendedor")]
+    [InlineData("ADMIN", "VENDEDOR")]
+    [InlineData("Admin", "Vendedor")]
+    public void CaseInsensitive_Comparison(string callerRole, string targetRole)
+    {
+        RoleHierarchy.CanCreateRole(callerRole, targetRole)
+            .Should().BeTrue("la comparación debe ser case-insensitive");
+    }
+
+    // ───── AssignableRoles helper ────────────────────────────────────────
+    [Fact]
+    public void AssignableRoles_SuperAdmin_ReturnsAll()
+    {
+        var roles = RoleHierarchy.AssignableRoles(RoleNames.SuperAdmin);
+        roles.Should().Contain(new[]
+        {
+            RoleNames.SuperAdmin,
+            RoleNames.Admin,
+            RoleNames.Supervisor,
+            RoleNames.Viewer,
+            RoleNames.Vendedor,
+        });
+    }
+
+    [Fact]
+    public void AssignableRoles_Admin_ExcludesAdminAndSuperAdmin()
+    {
+        var roles = RoleHierarchy.AssignableRoles(RoleNames.Admin);
+        roles.Should().NotContain(RoleNames.SuperAdmin);
+        roles.Should().NotContain(RoleNames.Admin);
+        roles.Should().Contain(RoleNames.Supervisor);
+        roles.Should().Contain(RoleNames.Vendedor);
+    }
+
+    [Fact]
+    public void AssignableRoles_Vendedor_ReturnsEmpty()
+    {
+        RoleHierarchy.AssignableRoles(RoleNames.Vendedor).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AssignableRoles_Null_ReturnsEmpty()
+    {
+        RoleHierarchy.AssignableRoles(null).Should().BeEmpty();
+    }
+}

--- a/apps/mobile-app/.maestro/onboarding/05-must-change-password.yaml
+++ b/apps/mobile-app/.maestro/onboarding/05-must-change-password.yaml
@@ -1,0 +1,127 @@
+appId: host.exp.exponent
+name: "Onboarding: pantalla cambiar-password forzada al primer login"
+---
+
+# ════════════════════════════════════════════════════════════
+# Valida el flow forzado de cambiar-password (2026-05-04):
+#
+# Caso: vendedor de campo MX creado por admin con password temporal
+# (SinEmail=true → backend marca MustChangePassword=true).
+#
+# Comportamiento esperado:
+#   1. Login con email vacío + password temp → backend retorna user con
+#      mustChangePassword=true.
+#   2. AuthGate (`app/_layout.tsx`) detecta el flag y redirige
+#      automáticamente a `/(auth)/cambiar-password`.
+#   3. La pantalla muestra header "Cambia tu contraseña" + 3 inputs +
+#      botón "Guardar nueva contraseña" + link "Cerrar sesión" (escape).
+#   4. Submit con password válido → POST /api/mobile/auth/change-password
+#      → MustChangePassword=false → redirect a tabs.
+#
+# PREREQ: este flow asume que existe un usuario de prueba con
+# `must_change_password=true` (creado por admin via API o seeder). Si tu
+# entorno no lo tiene, este test asserta solo el shape de la pantalla
+# cuando el AuthGate la dispara — el submit real requiere DB seteada.
+# ════════════════════════════════════════════════════════════
+
+# Reset: forzar logout previo si está autenticado.
+- runFlow:
+    when:
+      visible: "Hoy"
+    commands:
+      - tapOn: "Más"
+      - waitForAnimationToEnd
+      - scroll
+      - tapOn: "Cerrar Sesión"
+      - waitForAnimationToEnd
+      - tapOn: "Cerrar Sesión"
+      - waitForAnimationToEnd
+
+# ────────────────────────────────────────────
+# PASO 1: login con vendedor que tiene must_change_password=true
+# ────────────────────────────────────────────
+# NOTA: este test depende de un usuario seeded con MustChangePassword=true.
+# Si no existe en tu DB, el assert siguiente fallará — ajusta credenciales
+# en este flow o crea el usuario via curl al endpoint /api/usuarios con
+# {sinEmail: true, password: "Temp123!", ...}.
+- extendedWaitUntil:
+    visible: "Iniciar Sesión"
+    timeout: 15000
+
+- tapOn:
+    id: "input-email"
+    optional: true
+- inputText: "vendedor-temp@jeyma.com"
+- tapOn:
+    id: "input-password"
+    optional: true
+- inputText: "Temp123!"
+- tapOn: "Iniciar Sesión"
+- waitForAnimationToEnd
+
+# ────────────────────────────────────────────
+# PASO 2: AuthGate redirige a cambiar-password automáticamente
+# ────────────────────────────────────────────
+- extendedWaitUntil:
+    visible: "Cambia tu contraseña"
+    timeout: 10000
+
+- assertVisible: "Tu administrador te creó una contraseña temporal"
+- assertVisible: "Contraseña actual"
+- assertVisible: "Nueva contraseña"
+- assertVisible: "Confirmar nueva contraseña"
+- assertVisible: "Guardar nueva contraseña"
+- assertVisible: "Cerrar sesión"
+
+- takeScreenshot: "cambiar-pwd-01-forzado"
+
+# ────────────────────────────────────────────
+# PASO 3: hardware back NO debe permitir bypass (Android)
+# ────────────────────────────────────────────
+- pressKey: "Back"
+- waitForAnimationToEnd
+- assertVisible: "Cambia tu contraseña"
+
+# ────────────────────────────────────────────
+# PASO 4: validación client-side — password débil rechaza
+# ────────────────────────────────────────────
+- tapOn:
+    id: "cambiar-pwd-old"
+- inputText: "Temp123!"
+- tapOn:
+    id: "cambiar-pwd-new"
+- inputText: "abc"
+- tapOn:
+    id: "cambiar-pwd-confirm"
+- inputText: "abc"
+- tapOn:
+    id: "cambiar-pwd-submit"
+- waitForAnimationToEnd
+
+- assertVisible: "al menos 8 caracteres"
+
+# ────────────────────────────────────────────
+# PASO 5: password fuerte + distinto del actual + match → submit
+# ────────────────────────────────────────────
+- tapOn:
+    id: "cambiar-pwd-new"
+- eraseText: 100
+- inputText: "Nuevo123Pass!"
+- tapOn:
+    id: "cambiar-pwd-confirm"
+- eraseText: 100
+- inputText: "Nuevo123Pass!"
+- tapOn:
+    id: "cambiar-pwd-submit"
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "ACCIONES RÁPIDAS|Hoy|Buenas"
+    timeout: 10000
+
+- takeScreenshot: "cambiar-pwd-02-tabs-llegada"
+
+# ────────────────────────────────────────────
+# PASO 6: re-login NO debe forzar la pantalla otra vez
+# ────────────────────────────────────────────
+# (skip si tu emulador no tiene credenciales para re-login automático)

--- a/apps/mobile-app/app/(auth)/cambiar-password.tsx
+++ b/apps/mobile-app/app/(auth)/cambiar-password.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, KeyboardAvoidingView, Platform, BackHandler, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useFocusEffect } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+import { useAuthStore } from '@/stores';
+import { useLogout } from '@/hooks';
+import { authApi } from '@/api/auth';
+import { Button, Input, Card } from '@/components/ui';
+import { ShieldCheck, KeyRound } from 'lucide-react-native';
+import { COLORS } from '@/theme/colors';
+import Animated, { FadeInDown } from 'react-native-reanimated';
+
+/**
+ * Pantalla de "Cambiar contraseña" forzada al primer login cuando el admin
+ * creó al usuario con password temporal (caso vendedor de campo MX sin
+ * email — `mustChangePassword=true`). El AuthGate (`app/_layout.tsx`)
+ * redirige aquí antes de cualquier otra navegación si la flag está activa.
+ *
+ * Validaciones espejo del backend `MobileAuthEndpoints.MapPost("/change-password")`:
+ * - Min 8 caracteres
+ * - 1 minúscula + 1 mayúscula + 1 dígito
+ * - Distinta a la actual
+ *
+ * UX:
+ * - Hardware back en Android bloqueado para evitar bypass.
+ * - Mensaje claro "por seguridad" para que el usuario entienda por qué se
+ *   le obliga a cambiar.
+ */
+export default function CambiarPasswordScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const setUser = useAuthStore(s => s.setUser);
+  const logoutMutation = useLogout();
+
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Bloquear back hardware en Android — el usuario no puede saltar este step.
+  useFocusEffect(
+    useCallback(() => {
+      if (Platform.OS !== 'android') return;
+      const sub = BackHandler.addEventListener('hardwareBackPress', () => true);
+      return () => sub.remove();
+    }, [])
+  );
+
+  const mutation = useMutation({
+    mutationFn: () => authApi.changePassword(oldPassword, newPassword),
+    onSuccess: async () => {
+      // Sync local: ya no debe forzar la pantalla en re-renders.
+      await setUser({ mustChangePassword: false });
+      Toast.show({ type: 'success', text1: 'Contraseña actualizada' });
+      router.replace('/(tabs)' as any);
+    },
+    onError: (e: Error) => {
+      setError(e.message || 'No se pudo cambiar la contraseña');
+    },
+  });
+
+  const validate = (): string | null => {
+    if (!oldPassword) return 'Ingresa tu contraseña actual';
+    if (newPassword.length < 8) return 'La nueva contraseña debe tener al menos 8 caracteres';
+    if (!/[a-z]/.test(newPassword)) return 'Debe contener al menos una letra minúscula';
+    if (!/[A-Z]/.test(newPassword)) return 'Debe contener al menos una letra mayúscula';
+    if (!/\d/.test(newPassword)) return 'Debe contener al menos un número';
+    if (newPassword === oldPassword) return 'La nueva contraseña debe ser distinta a la actual';
+    if (newPassword !== confirmPassword) return 'La confirmación no coincide';
+    return null;
+  };
+
+  const handleSubmit = () => {
+    setError(null);
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.content, { paddingTop: insets.top + 24 }]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Animated.View entering={FadeInDown.duration(400)} style={styles.header}>
+          <View style={styles.iconWrap}>
+            <ShieldCheck size={32} color={COLORS.headerBg} />
+          </View>
+          <Text style={styles.title}>Cambia tu contraseña</Text>
+          <Text style={styles.subtitle}>
+            Tu administrador te creó una contraseña temporal. Por tu seguridad, debes cambiarla ahora antes de continuar.
+          </Text>
+        </Animated.View>
+
+        <Animated.View entering={FadeInDown.delay(100).duration(400)}>
+          <Card className="p-4">
+            <Input
+              label="Contraseña actual"
+              placeholder="La que te dio tu administrador"
+              secureTextEntry
+              value={oldPassword}
+              onChangeText={setOldPassword}
+              testID="cambiar-pwd-old"
+            />
+            <View style={{ height: 12 }} />
+            <Input
+              label="Nueva contraseña"
+              placeholder="Mín. 8 caracteres, con mayúscula, minúscula y número"
+              secureTextEntry
+              value={newPassword}
+              onChangeText={setNewPassword}
+              testID="cambiar-pwd-new"
+            />
+            <View style={{ height: 12 }} />
+            <Input
+              label="Confirmar nueva contraseña"
+              placeholder="Repite la nueva contraseña"
+              secureTextEntry
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              testID="cambiar-pwd-confirm"
+            />
+
+            {error && (
+              <View style={styles.errorBox}>
+                <Text style={styles.errorText}>{error}</Text>
+              </View>
+            )}
+
+            <View style={{ height: 16 }} />
+            <Button
+              title="Guardar nueva contraseña"
+              onPress={handleSubmit}
+              loading={mutation.isPending}
+              fullWidth
+              testID="cambiar-pwd-submit"
+            />
+          </Card>
+        </Animated.View>
+
+        <Animated.View entering={FadeInDown.delay(200).duration(400)} style={styles.footer}>
+          <KeyRound size={14} color={COLORS.textTertiary} />
+          <Text style={styles.footerText}>
+            Tu nueva contraseña sustituirá la temporal. Se cerrarán otras sesiones activas.
+          </Text>
+        </Animated.View>
+
+        {/* Escape de seguridad: si el usuario olvidó la contraseña temporal,
+            puede cerrar sesión y pedir a su admin que se la reasigne. Sin esto
+            el BackHandler bloqueado lo dejaría atrapado. */}
+        <Animated.View entering={FadeInDown.delay(300).duration(400)} style={styles.escapeWrap}>
+          <TouchableOpacity
+            onPress={() => logoutMutation.mutate()}
+            disabled={logoutMutation.isPending}
+            accessibilityRole="button"
+            accessibilityLabel="Cerrar sesión"
+            testID="cambiar-pwd-logout"
+          >
+            <Text style={styles.escapeText}>
+              {logoutMutation.isPending ? 'Cerrando...' : 'Cerrar sesión'}
+            </Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: COLORS.background },
+  scroll: { flex: 1 },
+  content: { paddingHorizontal: 20, paddingBottom: 40 },
+  header: {
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  iconWrap: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: '#dbeafe',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: COLORS.foreground,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: COLORS.textSecondary,
+    textAlign: 'center',
+    marginTop: 8,
+    paddingHorizontal: 8,
+  },
+  errorBox: {
+    marginTop: 12,
+    padding: 10,
+    borderRadius: 8,
+    backgroundColor: '#fef2f2',
+    borderWidth: 1,
+    borderColor: '#fecaca',
+  },
+  errorText: {
+    fontSize: 13,
+    color: '#b91c1c',
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: 24,
+    paddingHorizontal: 16,
+  },
+  footerText: {
+    fontSize: 12,
+    color: COLORS.textTertiary,
+    textAlign: 'center',
+    flex: 1,
+  },
+  escapeWrap: {
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  escapeText: {
+    fontSize: 13,
+    color: COLORS.textTertiary,
+    textDecorationLine: 'underline',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+});

--- a/apps/mobile-app/app/_layout.tsx
+++ b/apps/mobile-app/app/_layout.tsx
@@ -158,7 +158,7 @@ SplashScreen.preventAutoHideAsync();
 const INITIAL_SYNC_KEY = 'initial_sync_complete';
 
 function AuthGate({ onReady }: { onReady: (firstSync?: boolean) => void }) {
-  const { isAuthenticated, isLoading, restoreSession } = useAuthStore();
+  const { isAuthenticated, isLoading, restoreSession, user } = useAuthStore();
   const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
   const segments = useSegments();
   const router = useRouter();
@@ -201,6 +201,7 @@ function AuthGate({ onReady }: { onReady: (firstSync?: boolean) => void }) {
 
     const inAuthGroup = segments[0] === '(auth)';
     const inTabsGroup = segments[0] === '(tabs)';
+    const onCambiarPasswordScreen = inAuthGroup && (segments as string[])[1] === 'cambiar-password';
 
     if (!isAuthenticated && !inAuthGroup) {
       if (!onboardingDone) {
@@ -208,11 +209,17 @@ function AuthGate({ onReady }: { onReady: (firstSync?: boolean) => void }) {
       } else {
         router.replace('/(auth)/login');
       }
-    } else if (isAuthenticated && !inTabsGroup) {
+    } else if (isAuthenticated && user?.mustChangePassword && !onCambiarPasswordScreen) {
+      // Force-redirect a cambiar-password — el usuario fue creado con password
+      // temporal por un admin (caso vendedor de campo MX sin email). No puede
+      // navegar a otra pantalla hasta cambiarla. Backend MustChangePassword
+      // flag = source of truth; sync local en setUser tras success.
+      router.replace('/(auth)/cambiar-password' as any);
+    } else if (isAuthenticated && !user?.mustChangePassword && !inTabsGroup) {
       // Navigate to tabs — splash overlay handles sync if needed
       router.replace('/(tabs)');
     }
-  }, [isAuthenticated, isLoading, onboardingDone,segments]);
+  }, [isAuthenticated, isLoading, onboardingDone, segments, user?.mustChangePassword]);
 
   // Handle cold-start deep links (e.g., from killed notification tap)
   useEffect(() => {

--- a/apps/mobile-app/src/api/auth.ts
+++ b/apps/mobile-app/src/api/auth.ts
@@ -136,6 +136,26 @@ class MobileAuthApi {
     }
     return validated.data;
   }
+
+  /**
+   * Cambia la contraseña del usuario logueado. Se invoca:
+   * - Forzado al primer login si `mustChangePassword=true`
+     (vendedor de campo creado por admin con password temporal).
+   * - Cambio voluntario desde la pantalla de configuración (futuro).
+   *
+   * Backend: revoca refresh tokens del usuario en otros devices al cambiar.
+   */
+  async changePassword(oldPassword: string, newPassword: string): Promise<void> {
+    try {
+      await api.post(`${this.basePath}/change-password`, { oldPassword, newPassword });
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        const msg = error.response?.data?.error;
+        if (msg) throw new Error(msg);
+      }
+      throw new Error('No se pudo cambiar la contraseña');
+    }
+  }
 }
 
 export const authApi = new MobileAuthApi();

--- a/apps/mobile-app/src/api/schemas/auth.ts
+++ b/apps/mobile-app/src/api/schemas/auth.ts
@@ -9,6 +9,13 @@ export const AuthUserSchema = z
     avatarUrl: z.string().nullable().optional(),
     tenantName: z.string().nullable().optional(),
     tenantLogo: z.string().nullable().optional(),
+    /**
+     * True cuando el usuario fue creado por admin con password temporal
+     * (vendedor de campo sin email) y debe cambiar contraseña en su primer
+     * login. AuthGate (`app/_layout.tsx`) fuerza navegación a
+     * `/(auth)/cambiar-password` antes de cualquier otra pantalla.
+     */
+    mustChangePassword: z.boolean().optional().default(false),
   })
   .passthrough();
 

--- a/apps/mobile-app/src/stores/authStore.ts
+++ b/apps/mobile-app/src/stores/authStore.ts
@@ -44,6 +44,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         avatarUrl: user.avatarUrl ?? null,
         tenantName: user.tenantName ?? null,
         tenantLogo: user.tenantLogo ?? null,
+        mustChangePassword: user.mustChangePassword ?? false,
       })),
     ]);
     set({ user, isAuthenticated: true, isLoading: false, isLoggingIn: false });
@@ -87,6 +88,7 @@ export const useAuthStore = create<AuthState>((set) => ({
           avatarUrl: parsed.avatarUrl ?? null,
           tenantName: parsed.tenantName ?? null,
           tenantLogo: parsed.tenantLogo ?? null,
+          mustChangePassword: parsed.mustChangePassword ?? false,
         };
         set({
           user,
@@ -117,6 +119,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         avatarUrl: merged.avatarUrl ?? null,
         tenantName: merged.tenantName ?? null,
         tenantLogo: merged.tenantLogo ?? null,
+        mustChangePassword: merged.mustChangePassword ?? false,
       }));
     } catch {
       // Persistencia best-effort. State en memoria ya está actualizado.

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
@@ -154,6 +154,68 @@ public static class MobileAuthEndpoints
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized);
 
+        // POST /api/mobile/auth/change-password — cambiar contraseña del propio
+        // usuario logueado. Forzado al primer login si MustChangePassword=true
+        // (vendedor de campo creado por admin con password temporal). También
+        // disponible en cualquier momento como cambio voluntario.
+        group.MapPost("/change-password", async (
+            ChangePasswordDto dto,
+            [FromServices] HandySuitesDbContext db,
+            HttpContext context) =>
+        {
+            var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                           ?? context.User.FindFirst("sub")?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+                return Results.Unauthorized();
+
+            // Validación strong password (regex similar al register/crear).
+            if (string.IsNullOrEmpty(dto.NewPassword) || dto.NewPassword.Length < 8)
+                return Results.BadRequest(new { error = "La nueva contraseña debe tener al menos 8 caracteres." });
+            if (!System.Text.RegularExpressions.Regex.IsMatch(dto.NewPassword, @"[a-z]")
+                || !System.Text.RegularExpressions.Regex.IsMatch(dto.NewPassword, @"[A-Z]")
+                || !System.Text.RegularExpressions.Regex.IsMatch(dto.NewPassword, @"\d"))
+            {
+                return Results.BadRequest(new { error = "La nueva contraseña debe contener al menos una minúscula, una mayúscula y un número." });
+            }
+            if (dto.NewPassword == dto.OldPassword)
+                return Results.BadRequest(new { error = "La nueva contraseña debe ser distinta a la actual." });
+
+            var usuario = await db.Usuarios.FirstOrDefaultAsync(u => u.Id == userId);
+            if (usuario == null) return Results.NotFound();
+
+            // Validar password actual contra hash. Usamos BCrypt.Verify.
+            if (string.IsNullOrEmpty(dto.OldPassword)
+                || !BCrypt.Net.BCrypt.Verify(dto.OldPassword, usuario.PasswordHash))
+            {
+                return Results.BadRequest(new { error = "La contraseña actual es incorrecta." });
+            }
+
+            usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.NewPassword);
+            usuario.MustChangePassword = false;
+
+            // Revocar todos los refresh tokens del usuario para forzar re-login con
+            // el nuevo password en otros dispositivos. El device actual sigue
+            // funcionando con su access token vigente hasta que expire.
+            var activeTokens = await db.RefreshTokens
+                .Where(t => t.UserId == userId && !t.IsRevoked && t.ExpiresAt > DateTime.UtcNow)
+                .ToListAsync();
+            foreach (var t in activeTokens)
+            {
+                t.IsRevoked = true;
+                t.RevokedAt = DateTime.UtcNow;
+            }
+
+            await db.SaveChangesAsync();
+
+            return Results.Ok(new { success = true, message = "Contraseña actualizada exitosamente." });
+        })
+        .RequireAuthorization()
+        .WithSummary("Cambiar contraseña del usuario logueado")
+        .WithDescription("Valida oldPassword contra hash actual; setea nueva (BCrypt) + MustChangePassword=false. Revoca refresh tokens del usuario en otros devices.")
+        .Produces<object>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized);
+
         group.MapPost("/refresh", async (
             RefreshTokenDto dto,
             [FromServices] MobileAuthService auth) =>
@@ -302,3 +364,6 @@ public class LogoutRequest
 {
     public string? RefreshToken { get; set; }
 }
+
+/// <summary>Payload para POST /api/mobile/auth/change-password.</summary>
+public record ChangePasswordDto(string OldPassword, string NewPassword);

--- a/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
@@ -188,7 +188,8 @@ public class MobileAuthService
                     name = usuario.Nombre,
                     role = usuario.Rol,
                     avatarUrl = usuario.AvatarUrl,
-                    tenantLogo = companyLogo ?? ""
+                    tenantLogo = companyLogo ?? "",
+                    mustChangePassword = usuario.MustChangePassword
                 },
                 token = token,
                 refreshToken = plainRefreshToken
@@ -264,7 +265,8 @@ public class MobileAuthService
                 name = tokenEntity.Usuario.Nombre,
                 role = tokenEntity.Usuario.Rol,
                 avatarUrl = tokenEntity.Usuario.AvatarUrl,
-                tenantLogo = companyLogo ?? ""
+                tenantLogo = companyLogo ?? "",
+                mustChangePassword = tokenEntity.Usuario.MustChangePassword
             },
             token = newAccessToken,
             refreshToken = newPlainToken
@@ -299,7 +301,8 @@ public class MobileAuthService
                 name = usuario.Nombre,
                 role = usuario.Rol,
                 avatarUrl = usuario.AvatarUrl,
-                tenantLogo = companyLogo ?? ""
+                tenantLogo = companyLogo ?? "",
+                mustChangePassword = usuario.MustChangePassword
             }
         };
     }
@@ -525,7 +528,8 @@ public class MobileAuthService
                     name = usuario.Nombre,
                     role = usuario.Rol,
                     avatarUrl = usuario.AvatarUrl,
-                    tenantLogo = companyLogo ?? ""
+                    tenantLogo = companyLogo ?? "",
+                    mustChangePassword = usuario.MustChangePassword
                 },
                 token = token,
                 refreshToken = plainRefreshToken

--- a/apps/web/e2e/team-invite-flow.spec.ts
+++ b/apps/web/e2e/team-invite-flow.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * Audit del modal "Crear nuevo usuario" en /equipo (2026-05-04).
+ *
+ * Cobertura:
+ * - Modal abre desde "Nuevo usuario".
+ * - Por default, el password field está OCULTO (invite-link flow).
+ * - Banner azul informativo aparece SOLO cuando email tiene contenido.
+ * - Toggle "Vendedor de campo (sin email)" → muestra password field +
+ *   deshabilita email field.
+ * - Filtro de roles según rol del caller (admin no ve SUPER_ADMIN ni ADMIN).
+ * - Submit con email + sin password → backend invita al usuario.
+ *
+ * NOTA: este spec NO submitea usuarios reales para no contaminar la DB de
+ * staging/dev. Solo valida shape de UI + interacciones del form.
+ */
+test.describe('Team — invite-link create user flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/equipo');
+  });
+
+  test('opens modal sin campo password por default', async ({ page }) => {
+    // Botón abrir modal — busca por testID o por texto "Nuevo usuario"
+    const newUserBtn = page.getByRole('button', { name: /nuevo usuario/i }).first();
+    await expect(newUserBtn).toBeVisible();
+    await newUserBtn.click();
+
+    // Modal abierto: título visible
+    await expect(page.getByRole('heading', { name: /crear nuevo usuario|crear usuario/i })).toBeVisible();
+
+    // Checkbox "sin email" presente y NO marcado por default
+    const sinEmailCheckbox = page.getByTestId('create-user-sin-email');
+    await expect(sinEmailCheckbox).toBeVisible();
+    await expect(sinEmailCheckbox).not.toBeChecked();
+
+    // Password field NO debe estar visible por default (invite-link flow)
+    const passwordField = page.getByTestId('create-user-password');
+    await expect(passwordField).toHaveCount(0);
+  });
+
+  test('banner invite aparece solo cuando email no esta vacio', async ({ page }) => {
+    await page.getByRole('button', { name: /nuevo usuario/i }).first().click();
+
+    // Sin email tipeado: banner NO debe aparecer
+    await expect(page.getByText(/le enviaremos un correo a/i)).toHaveCount(0);
+
+    // Tipea email válido
+    const emailInput = page.locator('input[type="email"]').first();
+    await emailInput.fill('test-invite@example.com');
+
+    // Banner debe aparecer mostrando el email
+    await expect(page.getByText(/le enviaremos un correo a/i)).toBeVisible();
+    await expect(page.getByText(/test-invite@example.com/)).toBeVisible();
+    await expect(page.getByText(/expira en 24 horas/i)).toBeVisible();
+  });
+
+  test('toggle sin-email muestra password + deshabilita email', async ({ page }) => {
+    await page.getByRole('button', { name: /nuevo usuario/i }).first().click();
+
+    const sinEmailCheckbox = page.getByTestId('create-user-sin-email');
+    await sinEmailCheckbox.check();
+
+    // Password field debe aparecer
+    const passwordField = page.getByTestId('create-user-password');
+    await expect(passwordField).toBeVisible();
+
+    // Email field debe quedar disabled
+    const emailInput = page.locator('input[type="email"]').first();
+    await expect(emailInput).toBeDisabled();
+
+    // Banner invite NO debe aparecer
+    await expect(page.getByText(/le enviaremos un correo a/i)).toHaveCount(0);
+  });
+
+  test('dropdown rol filtra SUPER_ADMIN y ADMIN cuando caller es admin', async ({ page }) => {
+    // loginAsAdmin → admin (no super_admin)
+    await page.getByRole('button', { name: /nuevo usuario/i }).first().click();
+
+    // Tap dropdown rol — busca por placeholder "Seleccionar rol" o por label
+    const roleDropdown = page.locator('[role="combobox"]').first();
+    await roleDropdown.click();
+
+    // ADMIN normal NO debe ver SUPER_ADMIN ni ADMIN como opciones
+    // (filtro RoleHierarchy mirror del backend).
+    await expect(page.getByRole('option', { name: /^SUPER_ADMIN$/i })).toHaveCount(0);
+    await expect(page.getByRole('option', { name: /^ADMIN$/i })).toHaveCount(0);
+
+    // SI debe ver SUPERVISOR / VENDEDOR
+    await expect(page.getByRole('option', { name: /SUPERVISOR/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /VENDEDOR/i })).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
@@ -686,7 +686,10 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
         rol: formData.role,
         sinEmail: formData.sinEmail,
       });
-      toast.success(formData.sinEmail ? t('userCreated') : (t as any)('inviteSent') || 'Invitación enviada');
+      // Mensaje distinto según el flujo: vendedor sin email vs invite-link.
+      // Hardcodeado en español por simplicidad — agregar a i18n cuando se
+      // expanda el bundle (bypass de t-typing strict para la key 'inviteSent').
+      toast.success(formData.sinEmail ? t('userCreated') : 'Invitación enviada');
       setIsCreateModalOpen(false);
       setFormData({ email: '', nombre: '', password: '', telefono: '', role: 'VENDEDOR', sinEmail: false });
       loadUsers();

--- a/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
+++ b/apps/web/src/app/(dashboard)/team/components/MiembrosTab.tsx
@@ -553,6 +553,7 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
     password: '',
     telefono: '',
     role: 'VENDEDOR',
+    sinEmail: false, // 2026-05-04: vendedor de campo MX sin email corporativo
   });
 
   // Load roles and zones
@@ -671,16 +672,23 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
 
   const handleCreateUser = async () => {
     try {
+      // 2 flujos según `sinEmail`:
+      // - false (default): mandar solo email + nombre + rol. Backend genera
+      //   placeholder password + envía invite link. Usuario establece su
+      //   password vía /set-password.
+      // - true (vendedor de campo): mandar email opcional + password temporal.
+      //   Backend marca MustChangePassword=true → forzado en primer login.
       await createUserMutation.mutateAsync({
-        email: formData.email,
+        email: formData.email || undefined,
         nombre: formData.nombre,
-        password: formData.password,
-        telefono: formData.telefono,
+        password: formData.sinEmail ? formData.password : undefined,
+        telefono: formData.telefono || undefined,
         rol: formData.role,
+        sinEmail: formData.sinEmail,
       });
-      toast.success(t('userCreated'));
+      toast.success(formData.sinEmail ? t('userCreated') : (t as any)('inviteSent') || 'Invitación enviada');
       setIsCreateModalOpen(false);
-      setFormData({ email: '', nombre: '', password: '', telefono: '', role: 'VENDEDOR' });
+      setFormData({ email: '', nombre: '', password: '', telefono: '', role: 'VENDEDOR', sinEmail: false });
       loadUsers();
     } catch (err) {
       showApiError(err, t('errorCreating'));
@@ -1505,26 +1513,73 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
                   placeholder={t('placeholderName')}
                 />
               </div>
+
+              {/* Toggle "sin email" — vendedor de campo MX. Default off:
+                  invite-link via email (best practice OWASP/NIST). On:
+                  admin asigna password temporal + el usuario lo cambia en
+                  primer login (MustChangePassword=true). */}
+              <div className="flex items-start gap-2 p-3 rounded-lg border border-border-subtle bg-surface-1/40">
+                <input
+                  type="checkbox"
+                  id="sin-email-checkbox"
+                  data-testid="create-user-sin-email"
+                  checked={formData.sinEmail}
+                  onChange={(e) => setFormData({ ...formData, sinEmail: e.target.checked })}
+                  className="mt-1 cursor-pointer"
+                />
+                <label htmlFor="sin-email-checkbox" className="text-sm text-foreground/80 cursor-pointer flex-1">
+                  <span className="font-medium">Vendedor de campo (sin email)</span>
+                  <span className="block text-xs text-muted-foreground mt-0.5">
+                    Marca esta opción para asignar una contraseña temporal manualmente. El usuario la cambiará en su primer inicio de sesión.
+                  </span>
+                </label>
+              </div>
+
               <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">{t("email")} *</label>
+                <label className="block text-sm font-medium text-foreground/80 mb-1">
+                  {t("email")} {!formData.sinEmail && '*'}
+                </label>
                 <input
                   type="email"
                   value={formData.email}
                   onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  className="w-full px-3 py-2 border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
                   placeholder={t('placeholderEmail')}
+                  required={!formData.sinEmail}
+                  disabled={formData.sinEmail}
                 />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">{t("password")} *</label>
-                <input
-                  type="password"
-                  value={formData.password}
-                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                  className="w-full px-3 py-2 border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
-                  placeholder="********"
-                />
-              </div>
+
+              {formData.sinEmail ? (
+                <div>
+                  <label className="block text-sm font-medium text-foreground/80 mb-1">
+                    Contraseña temporal *
+                  </label>
+                  <input
+                    type="password"
+                    data-testid="create-user-password"
+                    value={formData.password}
+                    onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                    className="w-full px-3 py-2 border border-border-default rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+                    placeholder="Min. 8 caracteres con mayúsculas, minúsculas y números"
+                    required
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Compártela verbalmente con el vendedor. Él la cambiará al iniciar sesión.
+                  </p>
+                </div>
+              ) : formData.email ? (
+                <div
+                  role="alert"
+                  className="flex gap-2 items-start text-xs text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3"
+                >
+                  <span aria-hidden="true">📧</span>
+                  <span>
+                    Le enviaremos un correo a <strong>{formData.email}</strong> con instrucciones para que establezca su propia contraseña. El enlace expira en 24 horas.
+                  </span>
+                </div>
+              ) : null}
+
               <div>
                 <label className="block text-sm font-medium text-foreground/80 mb-1">{t("phone")}</label>
                 <input
@@ -1539,7 +1594,20 @@ function AdminUsersView({ onExportReady, onCreateReady }: { onExportReady?: (fn:
                 <label className="block text-sm font-medium text-foreground/80 mb-1">{t("role")}</label>
                 <SearchableSelect
                   options={roles
-                    .filter(role => isSuperAdmin || role.nombre.toUpperCase() !== 'ADMIN')
+                    .filter(role => {
+                      // RoleHierarchy mirror del backend (libs/HandySuites.Domain/Common/RoleHierarchy.cs).
+                      // Source of truth sigue siendo server-side en UsuarioService.
+                      const target = role.nombre.toUpperCase();
+                      const caller = (session?.user?.role || '').toUpperCase();
+                      if (caller === 'SUPER_ADMIN') return true;
+                      if (caller === 'ADMIN') {
+                        return target === 'SUPERVISOR' || target === 'VIEWER' || target === 'VENDEDOR';
+                      }
+                      if (caller === 'SUPERVISOR') {
+                        return target === 'VENDEDOR' || target === 'VIEWER';
+                      }
+                      return false;
+                    })
                     .map(role => ({ value: role.nombre, label: role.nombre }))}
                   value={formData.role || null}
                   onChange={(val) => setFormData({ ...formData, role: val ? String(val) : '' })}

--- a/apps/web/src/services/api/users.ts
+++ b/apps/web/src/services/api/users.ts
@@ -41,11 +41,19 @@ export interface UsuarioUbicacion {
 }
 
 export interface CreateUserRequest {
-  email: string;
-  password: string;
+  /** Required cuando sinEmail=false (default). Opcional cuando sinEmail=true. */
+  email?: string;
+  /** Required SOLO cuando sinEmail=true (vendedor sin email). En el flujo invite-link el backend genera placeholder. */
+  password?: string;
   nombre: string;
   telefono?: string;
   rol: string;
+  /**
+   * True = vendedor de campo MX sin email corporativo. Admin asigna password
+   * temporal; backend marca MustChangePassword=true para forzar cambio en el
+   * primer login mobile. False (default) = invite link al email del usuario.
+   */
+  sinEmail?: boolean;
 }
 
 export interface UpdateUserRequest {

--- a/libs/HandySuites.Application/Usuarios/DTOs/CrearUsuarioDto.cs
+++ b/libs/HandySuites.Application/Usuarios/DTOs/CrearUsuarioDto.cs
@@ -1,10 +1,49 @@
 namespace HandySuites.Application.Usuarios.DTOs;
 
+/// <summary>
+/// Payload para crear un usuario desde el tab Equipo (web) o desde un endpoint
+/// admin del mobile API. Soporta dos flujos:
+///
+/// 1. <b>Invite link (default, recommended)</b>: el caller envía solo
+///    Email + Nombre + Rol (+ Telefono opcional). Backend genera password
+///    placeholder + envía email de invitación con token 24h. Usuario abre
+///    el link y establece SU OWN password en `/set-password`.
+///
+/// 2. <b>Sin email (fallback)</b>: vendedor de campo MX que no tiene email
+///    corporativo. Caller marca <see cref="SinEmail"/>=true y envía
+///    <see cref="Password"/> temporal. Backend persiste con
+///    `MustChangePassword=true` para que en el primer login mobile se fuerce
+///    cambio de contraseña.
+///
+/// Validador en `CrearUsuarioDtoValidator` aplica reglas condicionales según
+/// `SinEmail`. Service `UsuarioService.CrearUsuarioAsync` enforcea
+/// `RoleHierarchy.CanCreateRole(callerRole, dto.Rol)`.
+/// </summary>
 public class CrearUsuarioDto
 {
+    /// <summary>Email del usuario. Required cuando <see cref="SinEmail"/>=false. Vacío permitido cuando true.</summary>
     public string Email { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
+
+    /// <summary>Nombre completo. Required siempre.</summary>
     public string Nombre { get; set; } = string.Empty;
-    public string? Telefono { get; set; }
+
+    /// <summary>Rol explícito. Required. Validador whitelist contra <c>RoleNames</c>. Sujeto a RoleHierarchy.</summary>
     public string Rol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Password temporal. SOLO se acepta cuando <see cref="SinEmail"/>=true.
+    /// Si SinEmail=false, debe estar null/empty (validador rechaza si viene
+    /// password con email — para que el admin no caiga en bad practice).
+    /// </summary>
+    public string? Password { get; set; }
+
+    /// <summary>Teléfono opcional (E.164 internacional, formato libre).</summary>
+    public string? Telefono { get; set; }
+
+    /// <summary>
+    /// True = vendedor de campo sin email corporativo. Admin asigna password
+    /// temporal en <see cref="Password"/>; el usuario lo cambia en su primer
+    /// login. False (default) = invite link al email del usuario.
+    /// </summary>
+    public bool SinEmail { get; set; } = false;
 }

--- a/libs/HandySuites.Application/Usuarios/Services/UsuarioService.cs
+++ b/libs/HandySuites.Application/Usuarios/Services/UsuarioService.cs
@@ -83,46 +83,97 @@ public class UsuarioService
 
     public async Task<int> CrearUsuarioAsync(CrearUsuarioDto dto)
     {
-        // Authorization: only Admin or SuperAdmin
-        if (!_tenant.IsAdmin && !_tenant.IsSuperAdmin)
+        // Authorization base: solo Admin/SuperAdmin/Supervisor pueden crear
+        // usuarios. La jerarquía exacta de qué rol puede asignar qué la
+        // resuelve RoleHierarchy.CanCreateRole abajo.
+        if (!_tenant.IsAdmin && !_tenant.IsSuperAdmin && !_tenant.IsSupervisor)
             throw new UnauthorizedAccessException("No tienes permisos para crear usuarios");
 
-        // Validate email
-        if (DisposableEmailService.IsDisposable(dto.Email))
-            throw new InvalidOperationException("No se permiten correos electrónicos temporales o desechables.");
-        if (await _repo.ExisteEmailAsync(dto.Email))
-            throw new InvalidOperationException("El email ya está en uso");
+        var rolUpper = (dto.Rol ?? string.Empty).ToUpperInvariant();
 
-        // Validate password
-        if (_pwnedPasswords != null && await _pwnedPasswords.IsCompromisedAsync(dto.Password))
-            throw new InvalidOperationException("Esta contraseña fue encontrada en filtraciones de datos. Por favor elige una contraseña diferente.");
-
-        // Role resolution — RolExplicito es la fuente de verdad ahora.
-        var rolUpper = dto.Rol?.ToUpperInvariant() ?? RoleNames.Vendedor;
-        int? roleId = null;
-
-        if (rolUpper == RoleNames.Admin)
+        // RBAC hierarchy enforcement (single source of truth: RoleHierarchy).
+        // Bloquea: ADMIN intentando crear SUPER_ADMIN/ADMIN, SUPERVISOR
+        // intentando crear ADMIN/SUPER_ADMIN/SUPERVISOR, etc.
+        if (!RoleHierarchy.CanCreateRole(_tenant.Role, rolUpper))
         {
-            if (!_tenant.IsSuperAdmin)
-                throw new UnauthorizedAccessException("Solo el SuperAdmin puede crear administradores");
+            throw new UnauthorizedAccessException(
+                $"Tu rol no permite crear usuarios con rol {rolUpper}.");
         }
-        else if (rolUpper != RoleNames.Vendedor)
+
+        // Validate email duplicado (solo si email viene — caso SinEmail puede dejar vacío).
+        if (!string.IsNullOrWhiteSpace(dto.Email))
+        {
+            if (DisposableEmailService.IsDisposable(dto.Email))
+                throw new InvalidOperationException("No se permiten correos electrónicos temporales o desechables.");
+            if (await _repo.ExisteEmailAsync(dto.Email))
+                throw new InvalidOperationException("El email ya está en uso");
+        }
+
+        // Resolver RoleId si rol no es Vendedor (legacy compat).
+        int? roleId = null;
+        if (rolUpper != RoleNames.Vendedor)
         {
             var role = await _repo.ObtenerRolPorNombreAsync(rolUpper);
             if (role != null) roleId = role.Id;
         }
 
-        var usuario = new Usuario
+        // Branch: invite link (default) vs sin-email (admin temp password).
+        Usuario usuario;
+        if (dto.SinEmail)
         {
-            Email = dto.Email,
-            PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password),
-            Nombre = dto.Nombre,
-            TenantId = _tenant.TenantId,
-            RolExplicito = rolUpper,
-            RoleId = roleId,
-            Activo = true,
-            CreadoPor = _tenant.UserId
-        };
+            // Vendedor de campo MX sin email corporativo. Admin asigna password
+            // temporal; flag MustChangePassword=true fuerza cambio en primer login.
+            if (string.IsNullOrEmpty(dto.Password))
+                throw new InvalidOperationException("La contraseña temporal es obligatoria para usuarios sin email.");
+
+            // Defense-in-depth: HIBP check incluso para passwords temporales.
+            if (_pwnedPasswords != null && await _pwnedPasswords.IsCompromisedAsync(dto.Password))
+                throw new InvalidOperationException("La contraseña fue encontrada en filtraciones de datos. Elige otra distinta.");
+
+            usuario = new Usuario
+            {
+                Email = dto.Email ?? string.Empty,
+                Nombre = dto.Nombre,
+                Telefono = dto.Telefono,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password),
+                TenantId = _tenant.TenantId,
+                RolExplicito = rolUpper,
+                RoleId = roleId,
+                Activo = true, // puede usar la app de inmediato pero forzado a cambiar password
+                MustChangePassword = true,
+                CreadoPor = _tenant.UserId,
+            };
+        }
+        else
+        {
+            // Invite link flow (default + recommended por OWASP/NIST).
+            // Generamos un placeholder random para que la columna NOT NULL no
+            // falle. El usuario establecerá su propia contraseña al redeem el
+            // invite token (genera AuthService.SendInvitationEmailAsync, ya
+            // cableado en UsuarioEndpoints.CreateUsuario).
+            var placeholderBytes = new byte[32];
+            System.Security.Cryptography.RandomNumberGenerator.Fill(placeholderBytes);
+            var placeholder = Convert.ToBase64String(placeholderBytes);
+
+            usuario = new Usuario
+            {
+                Email = dto.Email,
+                Nombre = dto.Nombre,
+                Telefono = dto.Telefono,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(placeholder),
+                TenantId = _tenant.TenantId,
+                RolExplicito = rolUpper,
+                RoleId = roleId,
+                // Activo=true para que aparezca en listas como "activo" (consistente
+                // con UX existente). El gating real es vía email invite — sin
+                // redeem el usuario no tiene password real para login. El flag
+                // MustChangePassword sigue false (al redeem el invite, /set-password
+                // setea la contraseña directamente, no necesita doble cambio).
+                Activo = true,
+                MustChangePassword = false,
+                CreadoPor = _tenant.UserId,
+            };
+        }
 
         var creado = await _repo.RegistrarAsync(usuario);
         return creado.Id;

--- a/libs/HandySuites.Application/Usuarios/Validators/CrearUsuarioDtoValidator.cs
+++ b/libs/HandySuites.Application/Usuarios/Validators/CrearUsuarioDtoValidator.cs
@@ -1,29 +1,81 @@
 using FluentValidation;
 using HandySuites.Application.Usuarios.DTOs;
+using HandySuites.Domain.Common;
 
 namespace HandySuites.Application.Usuarios.Validators;
 
+/// <summary>
+/// Reglas condicionales según <see cref="CrearUsuarioDto.SinEmail"/>:
+///
+/// - <c>SinEmail=false</c> (invite link, default): Email required + formato.
+///   Password debe estar null/empty (si admin lo manda, error 400 — patrón
+///   anti-leak: admin nunca debe tipear el password de otro usuario).
+/// - <c>SinEmail=true</c> (vendedor de campo sin email): Email opcional.
+///   Password required + reglas fuertes (8+ chars, mayús, minús, número).
+///
+/// Implementado con el patrón idiomático de FluentValidation:
+/// `When(predicate, () => { ... }).Otherwise(() => { ... })` para agrupar
+/// reglas mutuamente exclusivas (validado por context7 review).
+///
+/// Rol: whitelist contra <see cref="RoleNames"/>. La verificación adicional
+/// "el caller PUEDE asignar este rol" vive en el service via
+/// <see cref="RoleHierarchy.CanCreateRole"/>.
+/// </summary>
 public class CrearUsuarioDtoValidator : AbstractValidator<CrearUsuarioDto>
 {
+    private static readonly string[] ValidRoles =
+    {
+        RoleNames.SuperAdmin,
+        RoleNames.Admin,
+        RoleNames.Supervisor,
+        RoleNames.Viewer,
+        RoleNames.Vendedor,
+    };
+
     public CrearUsuarioDtoValidator()
     {
-        RuleFor(x => x.Email)
-            .NotEmpty().WithMessage("El correo electrónico es obligatorio.")
-            .EmailAddress().WithMessage("El formato del correo electrónico es inválido.")
-            .MaximumLength(255).WithMessage("El correo electrónico no debe exceder los 255 caracteres.");
-
+        // Reglas comunes a ambos branches.
         RuleFor(x => x.Nombre)
             .NotEmpty().WithMessage("El nombre es obligatorio.")
             .MaximumLength(100).WithMessage("El nombre no debe exceder los 100 caracteres.");
 
-        RuleFor(x => x.Password)
-            .NotEmpty().WithMessage("La contraseña es obligatoria.")
-            .MinimumLength(8).WithMessage("La contraseña debe tener al menos 8 caracteres.")
-            .Matches(@"[a-z]").WithMessage("La contraseña debe contener al menos una letra minúscula.")
-            .Matches(@"[A-Z]").WithMessage("La contraseña debe contener al menos una letra mayúscula.")
-            .Matches(@"\d").WithMessage("La contraseña debe contener al menos un número.");
-
         RuleFor(x => x.Rol)
-            .NotEmpty().WithMessage("El rol es obligatorio.");
+            .NotEmpty().WithMessage("El rol es obligatorio.")
+            .Must(r => ValidRoles.Contains(r))
+            .WithMessage("El rol no es válido. Valores aceptados: SUPER_ADMIN, ADMIN, SUPERVISOR, VIEWER, VENDEDOR.");
+
+        // Telefono opcional con regex permisivo (consistente con UsuarioUpdateDtoValidator).
+        RuleFor(x => x.Telefono)
+            .Matches(@"^\+?[\d\s\-\(\)]{7,20}$")
+            .WithMessage("El teléfono debe contener entre 7 y 20 caracteres (dígitos, espacios, paréntesis o guiones).")
+            .When(x => !string.IsNullOrWhiteSpace(x.Telefono));
+
+        // Branch SinEmail=true (vendedor de campo): email opcional pero si
+        // viene debe ser válido; password required + strong.
+        When(x => x.SinEmail, () =>
+        {
+            RuleFor(x => x.Email)
+                .EmailAddress().WithMessage("El formato del correo electrónico es inválido.")
+                .MaximumLength(255).WithMessage("El correo electrónico no debe exceder los 255 caracteres.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Email));
+
+            RuleFor(x => x.Password)
+                .NotEmpty().WithMessage("La contraseña temporal es obligatoria cuando se crea un usuario sin email.")
+                .MinimumLength(8).WithMessage("La contraseña debe tener al menos 8 caracteres.")
+                .Matches(@"[a-z]").WithMessage("La contraseña debe contener al menos una letra minúscula.")
+                .Matches(@"[A-Z]").WithMessage("La contraseña debe contener al menos una letra mayúscula.")
+                .Matches(@"\d").WithMessage("La contraseña debe contener al menos un número.");
+        }).Otherwise(() =>
+        {
+            // Invite-link flow (default + recommended): email required + formato.
+            // Password DEBE estar vacío — el usuario lo establecerá vía /set-password.
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("El correo electrónico es obligatorio.")
+                .EmailAddress().WithMessage("El formato del correo electrónico es inválido.")
+                .MaximumLength(255).WithMessage("El correo electrónico no debe exceder los 255 caracteres.");
+
+            RuleFor(x => x.Password)
+                .Empty().WithMessage("No envíes contraseña — el usuario la establecerá vía la invitación por email.");
+        });
     }
 }

--- a/libs/HandySuites.Domain/Common/RoleHierarchy.cs
+++ b/libs/HandySuites.Domain/Common/RoleHierarchy.cs
@@ -1,0 +1,91 @@
+namespace HandySuites.Domain.Common;
+
+/// <summary>
+/// Reglas de jerarquía de roles para crear/asignar usuarios.
+/// Aplicado tanto en el frontend (filtrar dropdown de roles) como en el
+/// backend (`UsuarioService.CrearUsuarioAsync`) — la lógica server-side es
+/// la fuente de verdad por seguridad.
+///
+/// Reglas (decididas con owner 2026-05-04):
+/// - SUPER_ADMIN puede asignar cualquier rol.
+/// - ADMIN puede asignar SUPERVISOR, VIEWER, VENDEDOR. NO ADMIN ni SUPER_ADMIN.
+///   (Decisión más restrictiva que la industria. Si owner necesita otro
+///   ADMIN, debe pedirlo a SUPER_ADMIN.)
+/// - SUPERVISOR puede asignar VENDEDOR, VIEWER.
+/// - VIEWER y VENDEDOR no pueden crear usuarios (rechazado en endpoint).
+///
+/// Referencias:
+/// - NIST SP 800-63B Rev. 4 §3.1.1.2 (initial-secret rotation)
+/// - OWASP ASVS 5.0 V6 Authentication
+/// </summary>
+public static class RoleHierarchy
+{
+    /// <summary>
+    /// Devuelve true si un usuario con rol <paramref name="callerRole"/> puede
+    /// crear o asignar un usuario con rol <paramref name="targetRole"/>.
+    /// Comparación case-insensitive contra <see cref="RoleNames"/>.
+    /// </summary>
+    public static bool CanCreateRole(string? callerRole, string? targetRole)
+    {
+        if (string.IsNullOrWhiteSpace(callerRole) || string.IsNullOrWhiteSpace(targetRole))
+            return false;
+
+        var caller = callerRole.ToUpperInvariant();
+        var target = targetRole.ToUpperInvariant();
+
+        // Validar que el target sea un rol conocido
+        if (target != RoleNames.SuperAdmin
+            && target != RoleNames.Admin
+            && target != RoleNames.Supervisor
+            && target != RoleNames.Viewer
+            && target != RoleNames.Vendedor)
+        {
+            return false;
+        }
+
+        return caller switch
+        {
+            RoleNames.SuperAdmin => true, // todos los roles
+            RoleNames.Admin => target == RoleNames.Supervisor
+                            || target == RoleNames.Viewer
+                            || target == RoleNames.Vendedor,
+            RoleNames.Supervisor => target == RoleNames.Vendedor
+                                 || target == RoleNames.Viewer,
+            _ => false, // Viewer, Vendedor, o cualquier otro: no pueden crear
+        };
+    }
+
+    /// <summary>
+    /// Lista de roles que <paramref name="callerRole"/> puede asignar. Útil para
+    /// poblar dropdowns en frontend (mirror del filtro client-side, pero la
+    /// fuente de verdad sigue siendo CanCreateRole en el backend).
+    /// </summary>
+    public static IReadOnlyList<string> AssignableRoles(string? callerRole)
+    {
+        if (string.IsNullOrWhiteSpace(callerRole)) return Array.Empty<string>();
+
+        return callerRole.ToUpperInvariant() switch
+        {
+            RoleNames.SuperAdmin => new[]
+            {
+                RoleNames.SuperAdmin,
+                RoleNames.Admin,
+                RoleNames.Supervisor,
+                RoleNames.Viewer,
+                RoleNames.Vendedor,
+            },
+            RoleNames.Admin => new[]
+            {
+                RoleNames.Supervisor,
+                RoleNames.Viewer,
+                RoleNames.Vendedor,
+            },
+            RoleNames.Supervisor => new[]
+            {
+                RoleNames.Vendedor,
+                RoleNames.Viewer,
+            },
+            _ => Array.Empty<string>(),
+        };
+    }
+}

--- a/libs/HandySuites.Domain/Entities/Usuario.cs
+++ b/libs/HandySuites.Domain/Entities/Usuario.cs
@@ -60,6 +60,16 @@ public class Usuario : AuditableEntity
     [Column("activo")]
     public new bool Activo { get; set; } = false;
 
+    /// <summary>
+    /// True cuando el usuario debe cambiar su contraseña en el primer login.
+    /// Caso típico: vendedor de campo creado por admin con password temporal
+    /// (porque no tiene email corporativo). El cliente mobile/web fuerza la
+    /// pantalla de "cambiar contraseña" antes de cualquier otra navegación.
+    /// Se setea a false cuando el usuario completa el cambio.
+    /// </summary>
+    [Column("must_change_password")]
+    public bool MustChangePassword { get; set; } = false;
+
     // Session management
     [Column("session_version")]
     public int SessionVersion { get; set; } = 1;

--- a/libs/HandySuites.Infrastructure/Migrations/20260504185212_AddMustChangePasswordToUsuario.Designer.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260504185212_AddMustChangePasswordToUsuario.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace HandySuites.Infrastructure.Migrations
 {
     [DbContext(typeof(HandySuitesDbContext))]
-    partial class HandySuitesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504185212_AddMustChangePasswordToUsuario")]
+    partial class AddMustChangePasswordToUsuario
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/HandySuites.Infrastructure/Migrations/20260504185212_AddMustChangePasswordToUsuario.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260504185212_AddMustChangePasswordToUsuario.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HandySuites.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMustChangePasswordToUsuario : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "must_change_password",
+                table: "Usuarios",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "must_change_password",
+                table: "Usuarios");
+        }
+    }
+}


### PR DESCRIPTION
## Resumen

Audit del flow "Crear nuevo usuario" (tab Equipo web) — owner reportó
2026-05-04:
1. Admin escribía contraseña directa al crear usuario (anti-pattern OWASP/NIST).
2. Filtro de roles solo client-side; sin enforcement server-side de jerarquía.

**Hallazgo clave**: la infraestructura del invite-link YA EXISTE
(`AuthService.SendInvitationEmailAsync` + página `/set-password`). El bug
era que el frontend pedía password REDUNDANTE que sobrescribía el flujo
correcto. Este PR conecta los dos extremos correctamente.

## Cambios

### Backend
- Nuevo `RoleHierarchy.CanCreateRole` en `libs/HandySuites.Domain/Common/`
  como **fuente única de verdad RBAC server-side**.
  - SUPER_ADMIN→todos. ADMIN→SUPERVISOR/VIEWER/VENDEDOR. SUPERVISOR→VENDEDOR/VIEWER. Otros→403.
- `CrearUsuarioDto` con flag `SinEmail`. Email/Password ahora opcionales.
- `CrearUsuarioDtoValidator` refactor a `When(predicate, () => {...}).Otherwise(...)` (patrón idiomático FluentValidation, validado por context7).
- `UsuarioService.CrearUsuarioAsync` enforce hierarchy + branch invite vs sin-email.
- Nueva columna `Usuario.MustChangePassword` (bool, default false). EF migration `AddMustChangePasswordToUsuario` reversible.
- Login responses (web + mobile) incluyen `mustChangePassword`.
- Nuevo endpoint `POST /api/mobile/auth/change-password` con validación strong + revocación de refresh tokens.

### Web
- Modal "Crear nuevo usuario" SIN campo password por default.
- Checkbox "Vendedor de campo (sin email)" con UX explícita.
- Banner azul `role="alert"` "Le enviaremos un correo a {email}..." cuando email tiene valor.
- Filtro de roles aplica `RoleHierarchy` mirror del backend.
- Email field disabled cuando sinEmail=true.

### Mobile
- Nueva pantalla `app/(auth)/cambiar-password.tsx`:
  - Forzada cuando `mustChangePassword=true` (AuthGate redirect).
  - Hardware back bloqueado en Android.
  - Link "Cerrar sesión" como escape de seguridad.
  - Validaciones client-side espejo del backend.
- `AuthUser` schema + `authStore` persistencia de `mustChangePassword`.
- AuthGate en `_layout.tsx` redirige automáticamente si la flag está activa.

### Fix Vercel build
- Removido `(t as any)('inviteSent')` cast que disparaba ESLint
  `@typescript-eslint/no-explicit-any` (configurado como error en este
  proyecto). Reemplazado por string hardcoded `'Invitación enviada'`.

## Tests

- ✅ `dotnet test` main: **500/501 pass + 1 skip** (incluye 27 nuevos `RoleHierarchyTests` cubriendo toda la matriz RBAC + edge cases case-insensitive/null/unknown)
- ✅ `dotnet test` mobile: 44/44 pass
- ✅ `npm run type-check` web: 0 errores
- ✅ `npx tsc --noEmit` mobile: 0 errores
- ✅ `npm run build` web (Vercel-equivalent): **74/74 static pages compiladas** post-fix
- ✅ **Validación manual emulador**: vendedor con `must_change_password=true` → AuthGate redirige automáticamente a la pantalla forzada (screenshot verificado)
- 📝 Playwright spec `apps/web/e2e/team-invite-flow.spec.ts` (5 tests)
- 📝 Maestro yaml `apps/mobile-app/.maestro/onboarding/05-must-change-password.yaml`

## Plugins consultados

- **frontend-ui-ux-validator**: 4 fixes aplicados (disable email field si sinEmail, gate banner cuando email vacío, subtitle más explícito, logout escape link).
- **context7**: 2 fixes aplicados (FluentValidation `When/Otherwise` idiomático + recomendación Expo Router `Stack.Protected` noted para futuro).

## Standards alineados

- **NIST SP 800-63B Rev. 4 §3.1.1.2** — subscriber puede cambiar CSP-assigned secret en primer uso.
- **OWASP Auth Cheat Sheet** — send unique time-limited URL, avoid temporary passwords by email.
- **Industry std** (Stripe/Slack/Linear/Atlassian/Auth0): invite link sin password directo + RBAC hierarchy server-side.

## Deployment checklist

- ⚠️ **EF migration** `AddMustChangePasswordToUsuario` corre en CI antes de Railway deploy. Reversible, columna `boolean NOT NULL DEFAULT false`. Backwards compat (existentes = false).
- ✅ Sin nuevas env vars
- ✅ Backwards compat API: campos opcionales con defaults sanos. Login response añade `mustChangePassword` opcional (clientes viejos lo ignoran).
- ✅ Path filter cubre `apps/api/**`, `apps/mobile/**`, `apps/web/**`, `libs/**`.

## Post-merge

```bash
eas update --branch production --environment production \
  --message "Secure user creation: invite link + force change password + RBAC hierarchy"
