### PR TITLE
Fix QA mobile bugs: notif realtime + ruta hoy refresh + swipe-to-delete + sync trigger

### DIFF
--- a/apps/api/src/HandySuites.Api/Endpoints/RutaVendedorEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/RutaVendedorEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using FluentValidation;
+using HandySuites.Application.Notifications.Interfaces;
 using HandySuites.Application.Rutas.DTOs;
 using HandySuites.Application.Rutas.Services;
 using HandySuites.Domain.Entities;
@@ -94,6 +95,35 @@ public static class RutaVendedorEndpoints
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to notify Mobile API of route assignment ruta {RutaId} pedido {PedidoId}", rutaId, pedidoId);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Emite evento SignalR `RutaAssigned` al vendedor para que el cliente
+    /// mobile dispare un sync inmediato de WatermelonDB y la pantalla "Hoy"
+    /// actualice sin pull. Complementa el push nativo: si el cliente está
+    /// online via SignalR, se entera al instante; si solo recibe el push
+    /// nativo, también dispara sync (vía usePushNotifications.ts).
+    /// Reportado 2026-05-05: vendedor2 no veía la nueva ruta tras admin asignar.
+    /// </summary>
+    private static void EmitRouteAssignedSignalR(
+        IRealtimePushService? realtimePush,
+        int vendedorId,
+        int rutaId,
+        ILogger logger)
+    {
+        if (realtimePush is null) return;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await realtimePush.SendEventToUserAsync(vendedorId, "RutaAssigned",
+                    new { rutaId, usuarioId = vendedorId });
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to emit SignalR RutaAssigned to vendedor {VendedorId} ruta {RutaId}", vendedorId, rutaId);
             }
         });
     }
@@ -256,6 +286,8 @@ public static class RutaVendedorEndpoints
             [FromServices] RutaVendedorService servicio,
             [FromServices] IHttpClientFactory httpClientFactory,
             [FromServices] ICurrentTenant tenantContext,
+            [FromServices] IRealtimePushService realtimePush,
+            [FromServices] ILogger<RutaVendedorEndpointsLog> rtLogger,
             [FromServices] HandySuites.Infrastructure.Notifications.Services.NotificationSettingsService notifSettings) =>
         {
             var validation = await validator.ValidateAsync(dto);
@@ -289,6 +321,8 @@ public static class RutaVendedorEndpoints
                     }
                 }
                 catch { /* push failure should not block route creation */ }
+                // SignalR para sync inmediato en cliente mobile online.
+                EmitRouteAssignedSignalR(realtimePush, dto.UsuarioId, id, rtLogger);
             }
 
             return Results.Created($"/rutas/{id}", new { id });
@@ -316,6 +350,8 @@ public static class RutaVendedorEndpoints
             [FromServices] RutaVendedorService servicio,
             [FromServices] IHttpClientFactory httpClientFactory,
             [FromServices] ICurrentTenant tenantContext,
+            [FromServices] IRealtimePushService realtimePush,
+            [FromServices] ILogger<RutaVendedorEndpointsLog> rtLogger,
             [FromServices] HandySuites.Infrastructure.Notifications.Services.NotificationSettingsService notifSettings) =>
         {
             var rutaAntes = await servicio.ObtenerPorIdAsync(id);
@@ -353,6 +389,8 @@ public static class RutaVendedorEndpoints
                     });
                 }
                 catch { /* push failure should not block route update */ }
+                // SignalR sync inmediato si cliente está conectado.
+                EmitRouteAssignedSignalR(realtimePush, nuevoUsuarioId, id, rtLogger);
             }
 
             return Results.NoContent();
@@ -675,14 +713,19 @@ public static class RutaVendedorEndpoints
             HttpContext context,
             [FromServices] RutaVendedorService servicio,
             [FromServices] IHttpClientFactory httpClientFactory,
+            [FromServices] IRealtimePushService realtimePush,
             [FromServices] ILogger<RutaVendedorEndpointsLog> logger) =>
         {
             var resumen = await servicio.EnviarACargaAsync(id);
 
-            // Push fire-and-forget con resumen para el vendedor.
+            // Push fire-and-forget con resumen para el vendedor + SignalR
+            // event para que el cliente mobile actualice la pantalla "Hoy"
+            // sin pull cuando esté conectado.
             if (int.TryParse(context.User.FindFirst("tenant_id")?.Value, out var tenantId))
             {
                 NotifyMobileRouteSentToLoad(httpClientFactory, tenantId, resumen, logger);
+                if (resumen.VendedorId.HasValue)
+                    EmitRouteAssignedSignalR(realtimePush, resumen.VendedorId.Value, resumen.RutaId, logger);
             }
 
             return Results.Ok(new

--- a/apps/api/src/HandySuites.Api/Hubs/SignalRPushService.cs
+++ b/apps/api/src/HandySuites.Api/Hubs/SignalRPushService.cs
@@ -22,4 +22,7 @@ public class SignalRPushService : IRealtimePushService
             _hub.Clients.Group($"user:{uid}").SendAsync("ReceiveNotification", payload));
         await Task.WhenAll(tasks);
     }
+
+    public Task SendEventToUserAsync(int userId, string eventName, object payload)
+        => _hub.Clients.Group($"user:{userId}").SendAsync(eventName, payload);
 }

--- a/apps/api/tests/HandySuites.Tests/Integration/Common/CustomWebApplicationFactory.cs
+++ b/apps/api/tests/HandySuites.Tests/Integration/Common/CustomWebApplicationFactory.cs
@@ -149,6 +149,7 @@ internal class FakeRealtimePushService : IRealtimePushService
 {
     public Task SendToUserAsync(int userId, object payload) => Task.CompletedTask;
     public Task SendToUsersAsync(IEnumerable<int> userIds, object payload) => Task.CompletedTask;
+    public Task SendEventToUserAsync(int userId, string eventName, object payload) => Task.CompletedTask;
 }
 
 /// <summary>

--- a/apps/mobile-app/app/(tabs)/notificaciones.tsx
+++ b/apps/mobile-app/app/(tabs)/notificaciones.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl } from 'react-native';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl, Animated, PanResponder } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { ChevronLeft, Bell, BellOff, CheckCheck } from 'lucide-react-native';
+import { ChevronLeft, Bell, BellOff, CheckCheck, Trash2 } from 'lucide-react-native';
 import { EmptyState } from '@/components/ui';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
-import Animated, { FadeInDown } from 'react-native-reanimated';
+import Reanimated, { FadeInDown } from 'react-native-reanimated';
 import { COLORS } from '@/theme/colors';
 import { notificationStore, type StoredNotification } from '@/services/notificationStore';
 import { syncNotificationsFromBackend } from '@/services/notificationSync';
@@ -77,11 +77,147 @@ function getDeepLinkForStoredNotification(n: StoredNotification): string | null 
       // screen", pero notificaciones es un screen distinto al de anuncios.
       return '/(tabs)/anuncios';
     case 'route.published':
+    case 'route.assigned':
+    case 'route.closed-by-admin':
     case 'visit.reminder':
       return '/(tabs)/ruta';
     default:
       return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Swipeable item — swipe-to-left revela botón trash. Implementado con
+// PanResponder + Animated (RN core) para no requerir react-native-gesture-handler
+// (no instalado en el proyecto y agregar deps nativas requiere `eas build`,
+// no OTA). Threshold: -80px para revelar; -160 auto-cierra y elimina con
+// fade-out.
+// ---------------------------------------------------------------------------
+const SWIPE_THRESHOLD_REVEAL = -80;
+const SWIPE_THRESHOLD_DELETE = -180;
+const ACTION_WIDTH = 88;
+
+interface SwipeableNotifItemProps {
+  item: StoredNotification;
+  onPress: () => void;
+  onDelete: () => void;
+  index: number;
+}
+
+function SwipeableNotifItem({ item, onPress, onDelete, index }: SwipeableNotifItemProps) {
+  const translateX = useRef(new Animated.Value(0)).current;
+  const opacity = useRef(new Animated.Value(1)).current;
+  const isOpen = useRef(false);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      // Solo responder a movimientos horizontales claros — no robar el scroll vertical de la lista.
+      onMoveShouldSetPanResponder: (_, g) =>
+        Math.abs(g.dx) > 8 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+      onPanResponderMove: (_, g) => {
+        // Solo permitir swipe a la izquierda (dx negativo) — clamp a 0 para derecha.
+        const clamped = Math.min(0, Math.max(g.dx, -ACTION_WIDTH * 2.5));
+        translateX.setValue(clamped);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (g.dx < SWIPE_THRESHOLD_DELETE) {
+          // Swipe muy fuerte → animar fuera y eliminar.
+          Animated.parallel([
+            Animated.timing(translateX, { toValue: -500, duration: 200, useNativeDriver: true }),
+            Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
+          ]).start(() => onDelete());
+          return;
+        }
+        if (g.dx < SWIPE_THRESHOLD_REVEAL) {
+          // Swipe moderado → mantener revelado.
+          isOpen.current = true;
+          Animated.spring(translateX, {
+            toValue: -ACTION_WIDTH,
+            useNativeDriver: true,
+            bounciness: 0,
+          }).start();
+        } else {
+          // Insuficiente → cerrar.
+          isOpen.current = false;
+          Animated.spring(translateX, {
+            toValue: 0,
+            useNativeDriver: true,
+            bounciness: 0,
+          }).start();
+        }
+      },
+      onPanResponderTerminate: () => {
+        // Si otro responder gana (e.g. scroll), cerrar.
+        Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start();
+      },
+    })
+  ).current;
+
+  const handleDeleteTap = () => {
+    // Animar fade-out + slide-out para feedback visual claro.
+    Animated.parallel([
+      Animated.timing(translateX, { toValue: -500, duration: 200, useNativeDriver: true }),
+      Animated.timing(opacity, { toValue: 0, duration: 200, useNativeDriver: true }),
+    ]).start(() => onDelete());
+  };
+
+  const handleItemPress = () => {
+    if (isOpen.current) {
+      // Si está revelado, primer tap cierra (no abre el deep link).
+      Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start();
+      isOpen.current = false;
+      return;
+    }
+    onPress();
+  };
+
+  return (
+    <Reanimated.View entering={FadeInDown.delay(Math.min(index, 10) * 50).duration(300)} style={{ position: 'relative' }}>
+      {/* Capa background con botón trash a la derecha. */}
+      <View style={styles.swipeActions} pointerEvents="box-none">
+        <TouchableOpacity
+          onPress={handleDeleteTap}
+          style={styles.deleteAction}
+          accessibilityLabel="Eliminar notificación"
+          accessibilityRole="button"
+        >
+          <Trash2 size={22} color="#fff" />
+          <Text style={styles.deleteActionLabel}>Eliminar</Text>
+        </TouchableOpacity>
+      </View>
+      {/* Capa item — se desplaza horizontal con PanResponder. */}
+      <Animated.View
+        style={[{ transform: [{ translateX }], opacity }]}
+        {...panResponder.panHandlers}
+      >
+        <TouchableOpacity
+          style={[styles.notifItem, !item.read && styles.notifUnread]}
+          onPress={handleItemPress}
+          activeOpacity={0.7}
+          accessibilityLabel={`Notificación: ${item.title}${!item.read ? ' (sin leer)' : ''}`}
+          accessibilityRole="button"
+        >
+          <View style={styles.notifRow}>
+            {!item.read && <View style={styles.unreadDot} />}
+            <View style={[styles.notifIcon, { backgroundColor: !item.read ? COLORS.primaryLight : '#f1f5f9' }]}>
+              <Bell size={18} color={!item.read ? COLORS.primary : '#94a3b8'} />
+            </View>
+            <View style={styles.notifContent}>
+              <View style={styles.notifHeader}>
+                <Text style={[styles.notifTitle, !item.read && styles.notifTitleUnread]} numberOfLines={1}>
+                  {item.title}
+                </Text>
+                <Text style={styles.notifTime}>{formatRelativeTime(item.receivedAt)}</Text>
+              </View>
+              <Text style={styles.notifMessage} numberOfLines={2}>
+                {item.body}
+              </Text>
+            </View>
+          </View>
+        </TouchableOpacity>
+      </Animated.View>
+    </Reanimated.View>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -106,11 +242,13 @@ function NotificacionesContent() {
     // Al abrir la tab: cargar local + sync backend en background. Si llega un
     // push live mientras hacíamos sync, se dedupea por nhId en el store.
     loadNotifications();
-    syncNotificationsFromBackend()
-      .then((added) => {
-        if (added > 0) loadNotifications();
-      })
-      .catch(() => { /* sync best-effort */ });
+    // Suscribirse a cambios del store: cuando llega push live (vía
+    // usePushNotifications) o sync incremental (SignalR ReceiveNotification),
+    // el store notifica a todos los listeners y la pantalla se actualiza
+    // sin necesidad de pull-to-refresh manual.
+    const unsubscribe = notificationStore.subscribe(() => loadNotifications());
+    syncNotificationsFromBackend().catch(() => { /* sync best-effort */ });
+    return unsubscribe;
   }, [loadNotifications]);
 
   const onRefresh = useCallback(async () => {
@@ -124,9 +262,7 @@ function NotificacionesContent() {
   const handlePress = useCallback(async (item: StoredNotification) => {
     if (!item.read) {
       await notificationStore.markAsRead(item.id);
-      setNotifications(prev =>
-        prev.map(n => (n.id === item.id ? { ...n, read: true } : n))
-      );
+      // No setNotifications optimista — el subscribe ya recarga.
     }
     const deepLink = getDeepLinkForStoredNotification(item);
     if (deepLink) {
@@ -145,39 +281,22 @@ function NotificacionesContent() {
     }
   }, [router]);
 
+  const handleDelete = useCallback(async (id: string) => {
+    await notificationStore.removeById(id);
+    // El subscribe se encarga de recargar la lista — no hace falta setNotifications.
+  }, []);
+
   const handleMarkAllAsRead = useCallback(async () => {
     await notificationStore.markAllAsRead();
-    setNotifications(prev => prev.map(n => ({ ...n, read: true })));
   }, []);
 
   const renderNotification = ({ item, index }: { item: StoredNotification; index: number }) => (
-    <Animated.View entering={FadeInDown.delay(Math.min(index, 10) * 50).duration(300)}>
-      <TouchableOpacity
-        style={[styles.notifItem, !item.read && styles.notifUnread]}
-        onPress={() => handlePress(item)}
-        activeOpacity={0.7}
-        accessibilityLabel={`Notificación: ${item.title}${!item.read ? ' (sin leer)' : ''}`}
-        accessibilityRole="button"
-      >
-        <View style={styles.notifRow}>
-          {!item.read && <View style={styles.unreadDot} />}
-          <View style={[styles.notifIcon, { backgroundColor: !item.read ? COLORS.primaryLight : '#f1f5f9' }]}>
-            <Bell size={18} color={!item.read ? COLORS.primary : '#94a3b8'} />
-          </View>
-          <View style={styles.notifContent}>
-            <View style={styles.notifHeader}>
-              <Text style={[styles.notifTitle, !item.read && styles.notifTitleUnread]} numberOfLines={1}>
-                {item.title}
-              </Text>
-              <Text style={styles.notifTime}>{formatRelativeTime(item.receivedAt)}</Text>
-            </View>
-            <Text style={styles.notifMessage} numberOfLines={2}>
-              {item.body}
-            </Text>
-          </View>
-        </View>
-      </TouchableOpacity>
-    </Animated.View>
+    <SwipeableNotifItem
+      item={item}
+      index={index}
+      onPress={() => handlePress(item)}
+      onDelete={() => handleDelete(item.id)}
+    />
   );
 
   const unreadCount = notifications.filter(n => !n.read).length;
@@ -315,6 +434,31 @@ const styles = StyleSheet.create({
   notifTitleUnread: { fontWeight: '700', color: '#0f172a' },
   notifTime: { fontSize: 11, color: '#94a3b8' },
   notifMessage: { fontSize: 13, color: '#64748b', lineHeight: 18 },
+  // Swipe action background
+  swipeActions: {
+    position: 'absolute',
+    top: 4,
+    bottom: 4,
+    right: 16,
+    width: ACTION_WIDTH,
+    borderRadius: 14,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    overflow: 'hidden',
+  },
+  deleteAction: {
+    flex: 1,
+    backgroundColor: '#dc2626',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  deleteActionLabel: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '600',
+    marginTop: 4,
+  },
 });
 
 export default function NotificacionesScreen() {

--- a/apps/mobile-app/src/hooks/useOfflineRoutes.ts
+++ b/apps/mobile-app/src/hooks/useOfflineRoutes.ts
@@ -49,7 +49,12 @@ export function useOfflineRutaHoy() {
         Q.where('usuario_id', Number(user.id)),
         Q.where('activo', true),
         Q.where('fecha', Q.gte(windowStart)),
-        Q.where('fecha', Q.lt(windowEnd))
+        Q.where('fecha', Q.lt(windowEnd)),
+        // Excluir estados terminales: Cancelada (3), Cerrada (6). Reportado
+        // 2026-05-05: vendedor2 veía solo "RUTA DE MARTES Cancelada" en
+        // pantalla "Hoy" mientras la nueva ruta asignada no aparecía. La
+        // ruta cancelada ya no es accionable y solo confunde.
+        Q.where('estado', Q.notIn([3, 6])),
       )
       .observe();
   }, [user?.id, tz]);

--- a/apps/mobile-app/src/hooks/usePushNotifications.ts
+++ b/apps/mobile-app/src/hooks/usePushNotifications.ts
@@ -39,6 +39,14 @@ function invalidateCachesForType(queryClient: ReturnType<typeof useQueryClient>,
     // el snapshot `me` para que el avatar/badge en el header se vea al instante.
     queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
     queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+  } else if (type.startsWith('route.')) {
+    // Ruta asignada/cancelada/cerrada: invalidar React Query y disparar sync
+    // general (trae nueva ruta + sus pedidos + carga a WDB). Pantalla "Hoy"
+    // es observable de WDB → se actualiza sin pull cuando llega data nueva.
+    // Fallback en caso que SignalR esté caído (ver useRealtime.ts RutaAssigned).
+    queryClient.invalidateQueries({ queryKey: ['rutas'] });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    performSync().catch(() => { /* sync best-effort */ });
   } else {
     // For any other type, at least refresh the dashboard
     queryClient.invalidateQueries({ queryKey: ['dashboard'] });

--- a/apps/mobile-app/src/hooks/useRealtime.ts
+++ b/apps/mobile-app/src/hooks/useRealtime.ts
@@ -82,7 +82,28 @@ export function useRealtime() {
         useAuthStore.getState().logout();
       }),
       signalR.on('ReceiveNotification', () => {
+        // Backend persiste NotificationHistory antes de mandar push. Disparar
+        // sync incremental → trae nuevas entries → notificationStore notifica
+        // a sus subscribers (pantalla notificaciones se actualiza sin pull).
+        // Dedup por nhId garantiza que push live + sync no dupliquen.
         queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        import('@/services/notificationSync')
+          .then(m => m.syncNotificationsFromBackend())
+          .catch(() => { /* best-effort */ });
+      }),
+      // Admin asignó/republicó una ruta al vendedor. Disparar sync general:
+      // trae la ruta nueva (estado=PendienteAceptar/CargaAceptada) + sus
+      // pedidos asignados + carga. Pantalla "Hoy" lee de WDB observable
+      // (useOfflineRutaHoy) → se actualiza solo cuando WDB cambie.
+      signalR.on('RutaAssigned', () => {
+        queryClient.invalidateQueries({ queryKey: ['rutas'] });
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        performSync().catch(() => {});
+      }),
+      signalR.on('RutaCancelada', () => {
+        queryClient.invalidateQueries({ queryKey: ['rutas'] });
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        performSync().catch(() => {});
       }),
       // Cuando admin/super-admin edita datos de empresa o logo/branding desde
       // el backoffice web, el backend emite este evento → mobile invalida el

--- a/apps/mobile-app/src/services/notificationStore.ts
+++ b/apps/mobile-app/src/services/notificationStore.ts
@@ -22,7 +22,32 @@ export type AddNotificationInput = Omit<StoredNotification, 'id' | 'receivedAt' 
   receivedAt?: string;
 };
 
+// ---------------------------------------------------------------------------
+// Reactive subscribe pattern (vanilla, sin Zustand)
+//
+// Necesario para que la pantalla `notificaciones.tsx` se entere cuando el
+// store cambia desde fuera (push live, sync backend, otro tab abierto).
+// Antes solo leía en mount → push llegaba pero la lista no actualizaba
+// hasta pull-to-refresh.
+// ---------------------------------------------------------------------------
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  listeners.forEach(l => {
+    try { l(); } catch (e) {
+      if (__DEV__) console.warn('[notificationStore] listener threw:', e);
+    }
+  });
+}
+
 export const notificationStore = {
+  /** Suscribirse a cambios. Retorna función para des-suscribirse. */
+  subscribe(fn: Listener): () => void {
+    listeners.add(fn);
+    return () => { listeners.delete(fn); };
+  },
+
   async getAll(): Promise<StoredNotification[]> {
     const raw = await AsyncStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
@@ -68,22 +93,39 @@ export const notificationStore = {
     // Keep only the latest MAX_NOTIFICATIONS
     if (items.length > MAX_NOTIFICATIONS) items.length = MAX_NOTIFICATIONS;
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    notify();
     return newItem;
   },
 
   async markAsRead(id: string): Promise<void> {
     const items = await this.getAll();
     const item = items.find(i => i.id === id);
-    if (item) {
+    if (item && !item.read) {
       item.read = true;
       await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+      notify();
     }
   },
 
   async markAllAsRead(): Promise<void> {
     const items = await this.getAll();
+    const hadUnread = items.some(i => !i.read);
+    if (!hadUnread) return;
     items.forEach(i => { i.read = true; });
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    notify();
+  },
+
+  /** Elimina una notificación individual del store local. NO se sincroniza
+   *  al backend (la persistencia backend es para "no perder push si app
+   *  cerrada"; un delete local solo afecta este device — coherente con
+   *  Mail/Slack pattern). */
+  async removeById(id: string): Promise<void> {
+    const items = await this.getAll();
+    const filtered = items.filter(i => i.id !== id);
+    if (filtered.length === items.length) return;
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+    notify();
   },
 
   async getUnreadCount(): Promise<number> {
@@ -93,5 +135,6 @@ export const notificationStore = {
 
   async clear(): Promise<void> {
     await AsyncStorage.removeItem(STORAGE_KEY);
+    notify();
   },
 };

--- a/libs/HandySuites.Application/Notifications/Interfaces/IRealtimePushService.cs
+++ b/libs/HandySuites.Application/Notifications/Interfaces/IRealtimePushService.cs
@@ -8,4 +8,12 @@ public interface IRealtimePushService
 {
     Task SendToUserAsync(int userId, object payload);
     Task SendToUsersAsync(IEnumerable<int> userIds, object payload);
+
+    /// <summary>
+    /// Emite un evento SignalR específico (event name custom) a un usuario.
+    /// Útil para eventos distintos del genérico "ReceiveNotification" —
+    /// ej. "RutaAssigned" para que el cliente mobile dispare un sync de
+    /// WatermelonDB y la pantalla "Hoy" actualice sin pull.
+    /// </summary>
+    Task SendEventToUserAsync(int userId, string eventName, object payload);
 }


### PR DESCRIPTION
## Summary

Cuatro bugs reportados por el owner tras EAS Update OTA del PR #48, probando en producción con `vendedor2@jeyma.com`. Tres fixes de comportamiento + uno resuelto en cascada por arreglar el sync trigger.

### 1. Notificaciones in-app no son realtime
**Síntoma**: el push nativo llegaba al device pero la pantalla `/notificaciones` requería pull-to-refresh para mostrar la nueva entry.

**Fix**:
- `notificationStore` ahora es reactivo: subscribe pattern vanilla (sin Zustand). Cada mutator (`add` / `markAsRead` / `markAllAsRead` / `removeById` / `clear`) llama a `notify()` tras el `AsyncStorage.setItem`.
- `notificaciones.tsx` se suscribe al store en `useEffect` → recarga automática cuando llega push live, sync incremental o delete (sin pull-to-refresh manual).
- `useRealtime.ts` listener `ReceiveNotification` ahora también dispara `syncNotificationsFromBackend()` (dedup por `notificationHistoryId`).

### 2. Ruta nueva NO aparece en pantalla "Hoy"
**Síntoma**: admin asigna ruta a vendedor → mobile abre tab Inicio, solo ve "RUTA DE MARTES Cancelada". Pull-to-refresh tampoco la trae.

**Verificado en DB prod**: ruta 9 (`test`) estado=4 (`PendienteAceptar`) sí existe pero no se sincronizaba al mobile post-asignación.

**Fix**:
- `useOfflineRutaHoy` ahora filtra `estado NOT IN (Cancelada, Cerrada)`. Antes solo filtraba `activo=true` y la cancelada (que tiene `activo=true` no es soft-delete) seguía apareciendo.
- Backend nuevo evento SignalR `RutaAssigned` emitido en:
  - `POST /rutas` (crear ruta nueva)
  - `PUT /rutas/{id}` (cambio de usuario)
  - `POST /rutas/{id}/carga/enviar` (enviar a carga — el flow donde el owner detectó el bug)
- `useRealtime.ts` listeners `RutaAssigned` + `RutaCancelada` disparan `performSync()` + invalidan React Query (`'rutas'` / `'dashboard'`).
- `usePushNotifications`: push de tipo `route.*` dispara `performSync()` como fallback si SignalR está caído.
- `IRealtimePushService` extendido con `SendEventToUserAsync(userId, eventName, payload)` para emitir eventos custom además del genérico `ReceiveNotification`.

### 3. Eliminar notificación individual del stack
**Síntoma**: solo existía "Marcar todas como leídas". Owner pidió swipe-to-left con icono trash.

**Fix**:
- `notificationStore.removeById(id)` nuevo. NO se persiste al backend (el delete es solo local — coherente con Mail/Slack pattern; el cleanup 30d backend ya borra históricamente).
- `SwipeableNotifItem` con `PanResponder` + `Animated` (RN core, sin `react-native-gesture-handler` que no está instalado y agregarlo requeriría EAS build, no OTA).
  - Swipe a la izquierda revela botón trash rojo (`#dc2626`) con icono `Trash2`.
  - Swipe muy fuerte (>180px) auto-elimina con fade-out.
  - Tap fuera del trash con item revelado → cierra; segundo tap navega a deep link.

### 4. "Total a entregar = $0" — resuelto por sync arreglado
**Verificado en DB prod**: ruta 9 tiene 1 producto SALSA $17 en `RutasCarga` (`cantidad_entrega=0`, `cantidad_venta=1`) y **0 pedidos en `RutasPedidos`**. El cálculo backend `MontoTotalEntrega = Sum(pedidos.MontoTotal)` es correcto → 0 pedidos = $0.

La causa raíz es la misma del Bug 4: el sync no se disparaba post-asignación y mobile mostraba estado stale. Con SignalR + push trigger sync (D2/D4), mobile traerá los pedidos asignados en segundos → totales reflejarán bien.

## Tests

| Suite | Resultado |
|---|---|
| `dotnet test` main API | ✅ 500 passed, 1 skipped |
| `dotnet test` mobile API | ✅ 44 passed |
| Mobile `tsc --noEmit` | ✅ clean |
| Backend build | ✅ clean |
| `FakeRealtimePushService` (test stub) | ✅ actualizado con stub para `SendEventToUserAsync` |

## Pre-Push Deployment Checklist

- [x] Sin nuevas env vars en Railway/Vercel
- [x] **Sin nuevas migrations** (solo cambios de código)
- [x] Sin cambios CI/CD pipeline
- [x] Sin breaking API contract — `SendEventToUserAsync` es nuevo método; los existentes intactos
- [x] Path filters CI:
  - `apps/api/**` + `libs/**` → Railway redeploy api_main (SignalR `RutaAssigned` activo en backend)
  - `apps/mobile/**` → no toca este PR
  - `apps/mobile-app/**` → requiere EAS Update OTA manual post-merge
  - `apps/web/**` → no toca este PR

## Post-merge

1. **Railway redeploy** del api_main con los nuevos endpoints emitiendo `RutaAssigned`.
2. **EAS Update OTA mobile** — disparar manualmente con autorización explícita post-deploy:
