### PR TITLE
Fix mobile: pantalla "Hoy" filtraba rutas del día siguiente (window 48h → 24h)

### DIFF
--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -11,6 +11,7 @@ import { Card, LoadingSpinner, UserAvatar } from '@/components/ui';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { useTenantLocale, useUnreadNotificationCount } from '@/hooks';
 import { getGreetingForTz } from '@/utils/greeting';
+import { startOfDayInTz } from '@/utils/dateTz';
 import { MapPin } from 'lucide-react-native';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { performSync } from '@/sync/syncEngine';
@@ -40,12 +41,19 @@ export function VendedorDashboard() {
   useFocusEffect(useCallback(() => {
     const userId = Number(user?.id ?? 0);
     if (!userId) return;
-    const now = new Date();
-    const localMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    // Window simétrico de ±12h alrededor del midnight tenant TZ — alineado
+    // con useOfflineRutaHoy. Antes usaba device TZ + +36h, lo que mostraba
+    // rutas del día siguiente al vendedor (reportado 2026-05-05: aceptó
+    // por error la ruta del miércoles cuando aún era martes).
+    const tenantMidnight = startOfDayInTz(tz || 'America/Mexico_City').getTime();
+    const windowStart = tenantMidnight - 12 * 3600000;
+    const windowEnd = tenantMidnight + 12 * 3600000;
     database.get('rutas').query(
       Q.where('usuario_id', userId), Q.where('activo', true),
-      Q.where('fecha', Q.gte(localMidnight - 12 * 3600000)),
-      Q.where('fecha', Q.lt(localMidnight + 36 * 3600000))
+      Q.where('fecha', Q.gte(windowStart)),
+      Q.where('fecha', Q.lt(windowEnd)),
+      // Excluir terminales (Cancelada=3, Cerrada=6) — alineado con useOfflineRutaHoy.
+      Q.where('estado', Q.notIn([3, 6])),
     ).fetch().then(async (rutas: any[]) => {
       const r = rutas[0];
       if (!r) { setRouteStats({ total: 0, atendidas: 0, routeName: '', routeEstado: 0 }); return; }
@@ -57,7 +65,7 @@ export function VendedorDashboard() {
         routeEstado: r.estado ?? 0,
       });
     }).catch(() => {});
-  }, [user?.id]));
+  }, [user?.id, tz]));
 
   // Local WDB data (for other KPIs)
   const { data: todayVisits } = useOfflineTodayVisits();

--- a/apps/mobile-app/src/hooks/useOfflineRoutes.ts
+++ b/apps/mobile-app/src/hooks/useOfflineRoutes.ts
@@ -34,14 +34,20 @@ export function useOfflineRutaHoy() {
 
   const observable = useMemo(() => {
     if (!user?.id) return null;
-    // Window de ±12h alrededor del inicio de día en TZ tenant.
-    // Un ruta con fecha "2026-03-26T00:00:00Z" debe aparecer tanto en marzo 25
-    // local (Mexico UTC-6) como marzo 26 local. El ±12h cubre cualquier offset.
-    // Usar tenant TZ en vez de device TZ corrige el bug cuando vendedor tiene
-    // device en otra zona o tenant opera en TZ distinta a CDMX.
+    // Window simétrico de ±12h alrededor del inicio de día en TZ tenant.
+    // Una ruta con fecha "2026-05-06T00:00:00Z" representa "miércoles 6 mayo"
+    // en cualquier TZ (convención: fecha = día calendario @ 00:00 UTC).
+    // Para martes 5 mayo CDMX (tenantMidnight = 5 mayo 06:00 UTC):
+    //   window = [4 mayo 18:00 UTC, 5 mayo 18:00 UTC]
+    //   - MARTES (5 mayo 00:00 UTC) → dentro ✓
+    //   - MIERCOLES (6 mayo 00:00 UTC) → fuera ✓
+    // Bug previo (2026-05-05): el end era +36h en vez de +12h, lo cual
+    // incluía rutas del día siguiente y vendedor2 vio "RUTA DE MIERCOLES"
+    // en su pantalla "Hoy" cuando aún era martes — y aceptó la ruta por
+    // error pensando que era la de hoy.
     const tenantMidnight = startOfDayInTz(tz).getTime();
     const windowStart = tenantMidnight - 12 * 3600000;
-    const windowEnd = tenantMidnight + 36 * 3600000;
+    const windowEnd = tenantMidnight + 12 * 3600000;
 
     return database
       .get<Ruta>('rutas')


### PR DESCRIPTION
## Summary

Hotfix mobile-only para corregir el filtro temporal de la pantalla "Hoy" del vendedor. Tras el merge del PR #49 a producción y la prueba en QA, el owner detectó que vendedor2 vio "RUTA DE MIERCOLES" en su pantalla "Hoy" cuando aún era martes 5 mayo CDMX, y la aceptó por error.

## Causa raíz

`useOfflineRutaHoy` y la query directa en `VendedorDashboard.tsx` usaban un window asimétrico:

```ts
const windowStart = tenantMidnight - 12 * 3600000;
const windowEnd   = tenantMidnight + 36 * 3600000;  // ← 36h, no 12h
