### PR TITLE
Fix 5 bugs QA producción: logout fantasma + i18n + carga race + push total carga + ruta vieja

### DIFF
--- a/apps/api/src/HandySuites.Api/Endpoints/RutaVendedorEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/RutaVendedorEndpoints.cs
@@ -145,9 +145,15 @@ public static class RutaVendedorEndpoints
             try
             {
                 var client = factory.CreateClient("MobileApi");
+                // Cuerpo del push: paradas + pedidos + 2 totales separados.
+                // Pedidos = pre-asignados a clientes; Carga = productos sueltos
+                // para venta libre. Reportado 2026-05-05: el body solo mostraba
+                // MontoTotalEntrega ($0 cuando solo había carga) y confundía al
+                // vendedor sobre qué llevaba realmente.
                 var body = $"Ruta: {resumen.RutaNombre}. {resumen.TotalParadas} parada{(resumen.TotalParadas == 1 ? "" : "s")}, "
                          + $"{resumen.TotalPedidos} pedido{(resumen.TotalPedidos == 1 ? "" : "s")}. "
-                         + $"Total a entregar: ${resumen.MontoTotalEntrega:0.00}. Toca para revisar y aceptar.";
+                         + $"Pedidos: ${resumen.MontoTotalEntrega:0.00} | Carga: ${resumen.MontoTotalCarga:0.00}. "
+                         + "Toca para revisar y aceptar.";
                 var resp = await client.PostAsJsonAsync("/api/internal/push-notify", new
                 {
                     tenantId,

--- a/apps/mobile-app/src/api/client.ts
+++ b/apps/mobile-app/src/api/client.ts
@@ -36,6 +36,20 @@ let failedQueue: Array<{
 
 export function setAccessToken(token: string | null) {
   _cachedAccessToken = token;
+  // Login fresh / refresh exitoso: limpiar state in-flight de la sesión
+  // vieja. Sin esto, una refreshPromise iniciada con el refresh_token
+  // viejo (cuando la sesión previa expiró) puede resolver con
+  // SESSION_REVOKED segundos después del login y disparar forceLogout —
+  // matando la sesión recién emitida. Reportado 2026-05-05 (Mazatlán
+  // 6:38pm): user veía logout automático ~1s post-login.
+  if (token) {
+    isRefreshing = false;
+    refreshPromise = null;
+    // Resolver requests en queue con el nuevo token (no rejectar — el
+    // login ya validó que el token es bueno).
+    failedQueue.forEach(({ resolve }) => resolve(token));
+    failedQueue = [];
+  }
 }
 
 export function getAccessToken(): string | null {
@@ -131,9 +145,21 @@ apiInstance.interceptors.response.use(
 
     if (error.response?.status === 401) {
       const errorCode = error.response.data?.code;
+      // Capturamos el token con el que se mandó la request original.
+      // Si entre el envío y recibir el 401, el user hizo login fresh,
+      // _cachedAccessToken cambió — el 401 corresponde a la sesión vieja
+      // y NO debe disparar forceLogout sobre la sesión nueva.
+      const tokenAtRequest = (originalRequest.headers?.Authorization as string | undefined)
+        ?.replace('Bearer ', '');
 
       // Device was revoked by admin — force logout with specific message
       if (errorCode === 'DEVICE_REVOKED' || errorCode === 'SESSION_REVOKED') {
+        // Guard: si el JWT actual ya es uno nuevo, ignorar — el revoke
+        // aplicaba a la sesión previa, ya superada por login fresh.
+        if (tokenAtRequest && _cachedAccessToken && tokenAtRequest !== _cachedAccessToken) {
+          if (__DEV__) console.log('[API] 401 SESSION_REVOKED on stale token — ignoring (user re-logged in)');
+          return Promise.reject(error);
+        }
         authEventEmitter.emit('deviceRevoked');
         return Promise.reject(error);
       }
@@ -160,6 +186,14 @@ apiInstance.interceptors.response.use(
         } catch (e) {
           // fall through
           if (__DEV__) console.warn('[API]', e);
+        }
+
+        // Guard: si el cliente ya tiene un token válido distinto del que
+        // falló (login fresh ocurrió mientras hacíamos refresh), no
+        // forzamos logout — la sesión nueva es válida.
+        if (tokenAtRequest && _cachedAccessToken && tokenAtRequest !== _cachedAccessToken) {
+          if (__DEV__) console.log('[API] refresh fail on stale token — ignoring (user re-logged in)');
+          return Promise.reject(error);
         }
 
         processQueueError(new Error('Token refresh failed'));

--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -52,8 +52,11 @@ export function VendedorDashboard() {
       Q.where('usuario_id', userId), Q.where('activo', true),
       Q.where('fecha', Q.gte(windowStart)),
       Q.where('fecha', Q.lt(windowEnd)),
-      // Excluir terminales (Cancelada=3, Cerrada=6) — alineado con useOfflineRutaHoy.
-      Q.where('estado', Q.notIn([3, 6])),
+      // Excluir terminales/no-accionables: Completada=2, Cancelada=3, Cerrada=6 —
+      // alineado con useOfflineRutaHoy. Las completadas van al historial; si el
+      // dashboard las mostraba y el vendedor recibía notif de ruta nueva, el
+      // tap abría la vieja completada en vez de la nueva (reportado 2026-05-05).
+      Q.where('estado', Q.notIn([2, 3, 6])),
     ).fetch().then(async (rutas: any[]) => {
       const r = rutas[0];
       if (!r) { setRouteStats({ total: 0, atendidas: 0, routeName: '', routeEstado: 0 }); return; }

--- a/apps/mobile-app/src/hooks/useOfflineRoutes.ts
+++ b/apps/mobile-app/src/hooks/useOfflineRoutes.ts
@@ -56,11 +56,14 @@ export function useOfflineRutaHoy() {
         Q.where('activo', true),
         Q.where('fecha', Q.gte(windowStart)),
         Q.where('fecha', Q.lt(windowEnd)),
-        // Excluir estados terminales: Cancelada (3), Cerrada (6). Reportado
-        // 2026-05-05: vendedor2 veía solo "RUTA DE MARTES Cancelada" en
-        // pantalla "Hoy" mientras la nueva ruta asignada no aparecía. La
-        // ruta cancelada ya no es accionable y solo confunde.
-        Q.where('estado', Q.notIn([3, 6])),
+        // Excluir estados terminales/no-accionables:
+        // - Completada (2): vendedor terminó todas las paradas; va al historial
+        // - Cancelada (3): admin la canceló
+        // - Cerrada (6): admin cerró formalmente
+        // Reportado 2026-05-05: tras completar una ruta y recibir la siguiente,
+        // tap en notif abría la completada (no la nueva). Filtrar Completada
+        // hace que useOfflineRutaHoy solo retorne rutas accionables.
+        Q.where('estado', Q.notIn([2, 3, 6])),
       )
       .observe();
   }, [user?.id, tz]);

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1823,6 +1823,7 @@
       "backToRoutes": "Back to routes",
       "startRoute": "Start route",
       "sendToLoad": "Send to load",
+      "sendToLoadConfirm": "Confirm sending this route to the seller? The seller will receive a push notification and will be able to accept the route. Once sent, you won't be able to edit stops, orders, or load.",
       "completeRoute": "Complete route",
       "closeRoute": "Close route",
       "viewClosure": "View closure",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1823,6 +1823,7 @@
       "backToRoutes": "Volver a rutas",
       "startRoute": "Iniciar ruta",
       "sendToLoad": "Enviar a carga",
+      "sendToLoadConfirm": "¿Confirmas enviar esta ruta al vendedor? El vendedor recibirá una notificación push y podrá aceptar la ruta. Una vez enviada no podrás editar paradas, pedidos ni carga.",
       "completeRoute": "Completar ruta",
       "closeRoute": "Cerrar ruta",
       "viewClosure": "Ver cierre",

--- a/libs/HandySuites.Application/Rutas/Services/RutaVendedorService.cs
+++ b/libs/HandySuites.Application/Rutas/Services/RutaVendedorService.cs
@@ -893,7 +893,13 @@ public class RutaVendedorService
         public int TotalParadas { get; set; }
         public int TotalPedidos { get; set; }
         public int TotalProductosCarga { get; set; }
+        /// <summary>Suma del valor monetario de los pedidos asignados a la ruta.</summary>
         public double MontoTotalEntrega { get; set; }
+        /// <summary>Suma del valor monetario de los productos sueltos cargados
+        /// para venta libre en ruta (CantidadTotal × PrecioUnitario por producto).
+        /// Reportado 2026-05-05: el push notif solo mostraba MontoTotalEntrega,
+        /// confundía al vendedor cuando solo había carga sin pedidos pre-asignados.</summary>
+        public double MontoTotalCarga { get; set; }
     }
 
     public async Task<EnviarACargaResumen> EnviarACargaAsync(int rutaId)
@@ -935,6 +941,7 @@ public class RutaVendedorService
             TotalPedidos = pedidosAsignados.Count,
             TotalProductosCarga = carga.Count,
             MontoTotalEntrega = pedidosAsignados.Sum(p => p.MontoTotal),
+            MontoTotalCarga = carga.Sum(c => c.MontoTotal),
         };
     }
 

--- a/libs/HandySuites.Infrastructure/Repositories/Rutas/RutaVendedorRepository.cs
+++ b/libs/HandySuites.Infrastructure/Repositories/Rutas/RutaVendedorRepository.cs
@@ -591,32 +591,59 @@ public class RutaVendedorRepository : IRutaVendedorRepository
             }
         }
 
-        var existente = await _db.RutasCarga
-            .FirstOrDefaultAsync(c => c.RutaId == rutaId && c.ProductoId == productoId && c.TenantId == tenantId && c.Activo);
+        // Upsert con retry: si entre el FirstOrDefault y SaveChanges otra
+        // request crea el mismo (rutaId, productoId), atrapamos el 23505
+        // (UNIQUE violation IX_RutasCarga_ruta_id_producto_id) y reintenta
+        // en la 2da iteración como UPDATE — la constraint UNIQUE garantiza
+        // serialización efectiva y la fila ya existirá.
+        // Reportado 2026-05-05 (post EAS Update OTA): admin asignaba mismo
+        // producto 2x consecutivo, segundo POST fallaba con 500.
+        const int maxRetries = 2;
+        for (int attempt = 1; attempt <= maxRetries; attempt++)
+        {
+            var existente = await _db.RutasCarga
+                .FirstOrDefaultAsync(c => c.RutaId == rutaId && c.ProductoId == productoId && c.TenantId == tenantId && c.Activo);
 
-        if (existente != null)
-        {
-            existente.CantidadVenta = cantidad;
-            existente.PrecioUnitario = precio > 0 ? precio : existente.PrecioUnitario;
-            existente.CantidadTotal = existente.CantidadEntrega + cantidad;
-            existente.ActualizadoEn = DateTime.UtcNow;
-        }
-        else
-        {
-            _db.RutasCarga.Add(new RutaCarga
+            if (existente != null)
             {
-                RutaId = rutaId,
-                ProductoId = productoId,
-                TenantId = tenantId,
-                CantidadVenta = cantidad,
-                CantidadEntrega = 0,
-                CantidadTotal = cantidad,
-                PrecioUnitario = precio,
-                CreadoEn = DateTime.UtcNow
-            });
-        }
+                existente.CantidadVenta = cantidad;
+                existente.PrecioUnitario = precio > 0 ? precio : existente.PrecioUnitario;
+                existente.CantidadTotal = existente.CantidadEntrega + cantidad;
+                existente.ActualizadoEn = DateTime.UtcNow;
+            }
+            else
+            {
+                _db.RutasCarga.Add(new RutaCarga
+                {
+                    RutaId = rutaId,
+                    ProductoId = productoId,
+                    TenantId = tenantId,
+                    CantidadVenta = cantidad,
+                    CantidadEntrega = 0,
+                    CantidadTotal = cantidad,
+                    PrecioUnitario = precio,
+                    CreadoEn = DateTime.UtcNow
+                });
+            }
 
-        await _db.SaveChangesAsync();
+            try
+            {
+                await _db.SaveChangesAsync();
+                return;
+            }
+            catch (DbUpdateException ex) when (
+                attempt < maxRetries
+                && ex.InnerException is Npgsql.PostgresException pg
+                && pg.SqlState == "23505"
+                && pg.ConstraintName == "IX_RutasCarga_ruta_id_producto_id")
+            {
+                // Otra request creó el mismo (rutaId, productoId) en paralelo.
+                // Detach el entity local para que la próxima iteración haga
+                // FirstOrDefault → encuentre la fila → UPDATE.
+                foreach (var entry in _db.ChangeTracker.Entries<RutaCarga>().ToList())
+                    entry.State = EntityState.Detached;
+            }
+        }
     }
 
     public async Task RemoverProductoCargaAsync(int rutaId, int productoId, int tenantId)


### PR DESCRIPTION
## Summary

Hotfix multi-area para 5 bugs reportados por owner probando en producción tras EAS Update OTA del PR #50.

### 1. Logout fantasma ~1s post-login (Mazatlán 6:38pm UTC-7)
**Síntoma**: tras 2 ciclos abrir/cerrar app, en el 3er login la sesión se cierra sola ~1s después. Re-intentar → backend rate-limit "demasiados intentos".

**Causa**: variables module-scope (`isRefreshing`, `refreshPromise`, `failedQueue`) en `apps/mobile-app/src/api/client.ts` sobreviven al login. Cuando el user llega al login porque sesión previa expiró, hay una `tryRefreshToken` in-flight con refresh token viejo. Login fresh emite JWT nuevo → segundos después el refresh viejo termina con `SESSION_REVOKED` → dispara `forceLogout` → mata la sesión nueva.

**Fix** (`apps/mobile-app/src/api/client.ts`):
- `setAccessToken(token)` cuando `token != null` resetea `isRefreshing`, `refreshPromise`, resuelve `failedQueue` con el nuevo token.
- Interceptor 401 captura `tokenAtRequest` del header. Si difiere de `_cachedAccessToken` actual (login fresh ocurrió mid-flight), ignora `SESSION_REVOKED` y refresh-fail — no dispara `forceLogout` sobre la sesión nueva.

### 2. i18n key cruda `routes.detail.sendToLoadConfirm`
**Causa**: la key no existía en `apps/web/messages/{es,en}.json`. El componente usa `t('detail.sendToLoadConfirm', { defaultValue: '...' })` pero next-intl v4+ ya no soporta `defaultValue` inline.

**Fix**: agregada la key con copy completo en es.json y en.json.

### 3+6. Duplicate constraint `IX_RutasCarga_ruta_id_producto_id` (23505)
**Síntoma**: POST `/rutas/{id}/carga/productos` falla con 500 al asignar mismo producto 2x consecutivo.

**Causa**: race condition entre `FirstOrDefault` e `Insert` en `RutaVendedorRepository.AsignarProductoVentaAsync`. Si dos requests paralelas pasan el check como null, ambas hacen Add → la segunda viola UNIQUE.

**Fix** (`libs/HandySuites.Infrastructure/Repositories/Rutas/RutaVendedorRepository.cs`):
- For-loop con `maxRetries=2`. Catch `DbUpdateException` con `Npgsql.PostgresException.SqlState=="23505"` + `ConstraintName="IX_RutasCarga_ruta_id_producto_id"`.
- Detach entries y reintenta — la 2da iteración encuentra la fila existente y hace UPDATE.

### 4. Push notif sin total carga
**Síntoma**: el body solo decía "Total a entregar: $X" (suma de pedidos asignados). Cuando la ruta solo tenía carga (productos para venta libre) sin pedidos pre-asignados, mostraba $0 — confundía al vendedor.

**Fix**:
- `EnviarACargaResumen.MontoTotalCarga` = `carga.Sum(c => c.MontoTotal)` (libs/HandySuites.Application/Rutas/Services/RutaVendedorService.cs).
- `NotifyMobileRouteSentToLoad` body con dos líneas: **"Pedidos: $X | Carga: $Y"** (apps/api/src/HandySuites.Api/Endpoints/RutaVendedorEndpoints.cs).

### 5. Click en notif vieja abre ruta completada
**Causa**: `useOfflineRutaHoy` y `VendedorDashboard.tsx` filtraban `Q.notIn([3, 6])` (Cancelada, Cerrada) pero permitían Completada (estado=2). Una ruta completada del día seguía visible; al tap en push de ruta nueva, el deep-link genérico `/(tabs)/ruta` cargaba `rutas[0]` no determinista.

**Fix**: `Q.notIn([2, 3, 6])` en ambos archivos. Las completadas pasan al historial (`historial-rutas.tsx` ya existe).

## Tests

| Suite | Resultado |
|---|---|
| `dotnet test` main API | ✅ 500 passed, 1 skipped |
| `dotnet test` mobile API | ✅ 44 passed |
| Mobile `tsc --noEmit` | ✅ clean |
| Backend build | ✅ clean |

## Validación E2E (curl contra api_main local rebuilt desde branch)

**Bug 3+6**: 2 POSTs paralelos del mismo `(rutaId, productoId)` → ambas responden 200 + DB con 1 sola fila (cantidad acumulada via UPDATE). Sin error 23505.

**Bug 4**: POST `/rutas/{id}/carga/enviar` para ruta con 1 producto $122.50 (sin pedidos) → response incluye `montoTotalCarga: 122.5`. `NotificationHistory` persistido con body:
> "Ruta: X. 0 paradas, 0 pedidos. Pedidos: $0.00 | Carga: $122.50. Toca para revisar y aceptar."

**Bugs 1, 2, 5**: validados por code review + type-check + xUnit. Verificación visual final post-deploy:
- Bug 1: race timing — fix defensivo (early-exit guards).
- Bug 2: trivial — agregada key faltante.
- Bug 5: trivial — agregar `2` al `Q.notIn`.

## Pre-Push Deployment Checklist

- [x] **Sin nuevas migrations**, **sin nuevas env vars**, **sin breaking API contract**
- [x] Path filters CI:
  - `apps/api/**` + `libs/**` → Railway redeploy api_main (Bug 3+6, Bug 4)
  - `apps/web/**` → Vercel redeploy (Bug 2)
  - `apps/mobile-app/**` → requiere EAS Update OTA manual post-merge (Bug 1, Bug 5)

## Post-merge

1. **Railway redeploy** del api_main con retry on 23505 + push body con `MontoTotalCarga`.
2. **Vercel redeploy** del frontend con `routes.detail.sendToLoadConfirm` traducido.
3. **EAS Update OTA mobile** (con autorización explícita post-deploy):
