### PR TITLE
Merge staging → main: TZ tenant systemic

### DIFF
--- a/apps/api/src/HandySuites.Api/Automations/Handlers/ClienteInactivoVisitaHandler.cs
+++ b/apps/api/src/HandySuites.Api/Automations/Handlers/ClienteInactivoVisitaHandler.cs
@@ -47,7 +47,15 @@ public class ClienteInactivoVisitaHandler : IAutomationHandler
             return new AutomationResult(true, M("result.todosClientesVisitados", lang));
 
         // ── Auto-schedule visits for next business day ──
-        var nextBusinessDay = GetNextBusinessDay(DateTime.UtcNow);
+        // Cálculo del siguiente día hábil en TZ tenant — antes usaba calendario
+        // UTC, lo que en TZ negativas dejaba la visita un día antes (sábado real).
+        TimeZoneInfo tzInfo;
+        try { tzInfo = TimeZoneInfo.FindSystemTimeZoneById(tenantTz); }
+        catch { tzInfo = TimeZoneInfo.Utc; }
+        var nextBusinessDay = GetNextBusinessDayInTenantTz(DateTime.UtcNow, tzInfo);
+        // "Hoy o después" en TZ tenant para detectar visitas ya agendadas.
+        var hoyTenantLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzInfo).Date;
+        var hoyTenantUtc = TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(hoyTenantLocal, DateTimeKind.Unspecified), tzInfo);
         var visitasCreadas = 0;
 
         foreach (var cliente in clientesInactivos)
@@ -59,7 +67,7 @@ public class ClienteInactivoVisitaHandler : IAutomationHandler
             var yaAgendada = await context.Db.ClienteVisitas
                 .AnyAsync(v => v.TenantId == context.TenantId
                     && v.ClienteId == cliente.Id
-                    && v.FechaProgramada >= DateTime.UtcNow.Date
+                    && v.FechaProgramada >= hoyTenantUtc
                     && v.Resultado == ResultadoVisita.Pendiente, ct);
 
             if (yaAgendada) continue;
@@ -150,8 +158,10 @@ public class ClienteInactivoVisitaHandler : IAutomationHandler
             var vendedor = c.VendedorId.HasValue
                 ? System.Net.WebUtility.HtmlEncode(vendedorDict.GetValueOrDefault(c.VendedorId.Value, M("misc.sinAsignar", lang)))
                 : "<span style=\"color:#9ca3af;\">Sin asignar</span>";
+            // Render fecha en TZ tenant para que el email muestre el día calendario correcto.
+            var nextBusinessDayLocal = TimeZoneInfo.ConvertTimeFromUtc(nextBusinessDay, tzInfo);
             var agendada = c.VendedorId.HasValue
-                ? $"<span style=\"color:#16a34a;font-weight:600;\">{nextBusinessDay:dd/MM/yyyy}</span>"
+                ? $"<span style=\"color:#16a34a;font-weight:600;\">{nextBusinessDayLocal:dd/MM/yyyy}</span>"
                 : "<span style=\"color:#9ca3af;\">—</span>";
             return new[] { System.Net.WebUtility.HtmlEncode(c.Nombre), ultimaVisita, vendedor, agendada };
         }).ToList();
@@ -174,14 +184,16 @@ public class ClienteInactivoVisitaHandler : IAutomationHandler
     }
 
     /// <summary>
-    /// Returns the next business day (Monday–Friday), skipping weekends.
-    /// Sets time to 9:00 AM UTC as a reasonable default.
+    /// Returns the next business day (Monday–Friday) in the tenant's timezone,
+    /// at 9:00 AM local, converted to UTC for storage.
     /// </summary>
-    private static DateTime GetNextBusinessDay(DateTime from)
+    private static DateTime GetNextBusinessDayInTenantTz(DateTime fromUtc, TimeZoneInfo tzInfo)
     {
-        var next = from.Date.AddDays(1);
+        var localToday = TimeZoneInfo.ConvertTimeFromUtc(fromUtc, tzInfo).Date;
+        var next = localToday.AddDays(1);
         while (next.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
             next = next.AddDays(1);
-        return next.AddHours(9); // 9 AM UTC ≈ 3 AM CST, will display in tenant TZ
+        var localNineAm = DateTime.SpecifyKind(next.AddHours(9), DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(localNineAm, tzInfo);
     }
 }

--- a/apps/api/src/HandySuites.Api/Configuration/ServiceRegistrationExtensions.cs
+++ b/apps/api/src/HandySuites.Api/Configuration/ServiceRegistrationExtensions.cs
@@ -169,6 +169,8 @@ public static class ServiceRegistrationExtensions
 
         services.AddScoped<JwtTokenGenerator>();
         services.AddScoped<ICurrentTenant, CurrentTenant>();
+        services.AddScoped<HandySuites.Application.Common.Interfaces.ITenantTimeZoneService,
+                            HandySuites.Infrastructure.Common.TenantTimeZoneService>();
         services.AddScoped<AuthService>();
 
         services.AddScoped<IClienteRepository, ClienteRepository>();

--- a/apps/api/src/HandySuites.Api/Endpoints/DashboardEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/DashboardEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Infrastructure.Persistence;
 using HandySuites.Shared.Multitenancy;
 using HandySuites.Application.Tenants.DTOs;
@@ -56,7 +57,8 @@ public static class DashboardEndpoints
 
     private static async Task<IResult> GetDashboardMetrics(
         [FromServices] HandySuitesDbContext context,
-        [FromServices] ICurrentTenant currentTenant)
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] ITenantTimeZoneService tenantTz)
     {
         try
         {
@@ -66,30 +68,38 @@ public static class DashboardEndpoints
                 .Where(u => u.TenantId == tenantId && u.Activo)
                 .CountAsync();
 
-            // ActivityLogs queries — graceful fallback if table doesn't exist yet
+            // ActivityLogs queries — graceful fallback if table doesn't exist yet.
+            // Ventanas calculadas en TZ tenant (no UTC) para que "hoy/semana/mes"
+            // alineen con el día calendario del tenant, no del servidor.
             int todayActivities = 0, weekActivities = 0, monthlyLogins = 0, activeUsersToday = 0, recentErrors = 0;
             try
             {
-                var today = DateTime.UtcNow.Date;
-                var startOfWeek = today.AddDays(-(int)today.DayOfWeek);
-                var startOfMonth = new DateTime(today.Year, today.Month, 1);
+                var todayTenant = await tenantTz.GetTenantTodayAsync();
+                var weekStartTenant = todayTenant.AddDays(-(int)todayTenant.DayOfWeek);
+                var monthStartTenant = new DateOnly(todayTenant.Year, todayTenant.Month, 1);
+                var sevenDaysAgoTenant = todayTenant.AddDays(-7);
+
+                var todayUtc = await tenantTz.ConvertTenantDateToUtcAsync(todayTenant);
+                var weekStartUtc = await tenantTz.ConvertTenantDateToUtcAsync(weekStartTenant);
+                var monthStartUtc = await tenantTz.ConvertTenantDateToUtcAsync(monthStartTenant);
+                var sevenDaysAgoUtc = await tenantTz.ConvertTenantDateToUtcAsync(sevenDaysAgoTenant);
 
                 todayActivities = await context.ActivityLogs
-                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= today)
+                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= todayUtc)
                     .CountAsync();
 
                 weekActivities = await context.ActivityLogs
-                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= startOfWeek)
+                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= weekStartUtc)
                     .CountAsync();
 
                 monthlyLogins = await context.ActivityLogs
                     .Where(a => a.TenantId == tenantId
                         && a.ActivityType == "login"
-                        && a.CreatedAt >= startOfMonth)
+                        && a.CreatedAt >= monthStartUtc)
                     .CountAsync();
 
                 activeUsersToday = await context.ActivityLogs
-                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= today)
+                    .Where(a => a.TenantId == tenantId && a.CreatedAt >= todayUtc)
                     .Select(a => a.UserId)
                     .Distinct()
                     .CountAsync();
@@ -97,7 +107,7 @@ public static class DashboardEndpoints
                 recentErrors = await context.ActivityLogs
                     .Where(a => a.TenantId == tenantId
                         && a.ActivityStatus == "failed"
-                        && a.CreatedAt >= today.AddDays(-7))
+                        && a.CreatedAt >= sevenDaysAgoUtc)
                     .CountAsync();
             }
             catch
@@ -182,16 +192,32 @@ public static class DashboardEndpoints
     private static async Task<IResult> GetActivityChart(
         [FromServices] HandySuitesDbContext context,
         [FromServices] ICurrentTenant currentTenant,
+        [FromServices] ITenantTimeZoneService tenantTz,
         [FromQuery] int days = 7)
     {
         try
         {
             var tenantId = currentTenant.TenantId;
-            var startDate = DateTime.UtcNow.Date.AddDays(-days);
+            var todayTenant = await tenantTz.GetTenantTodayAsync();
+            var startTenant = todayTenant.AddDays(-days);
+            var startUtc = await tenantTz.ConvertTenantDateToUtcAsync(startTenant);
+            var tzInfo = await tenantTz.GetTenantTimeZoneAsync();
 
-            var activityData = await context.ActivityLogs
-                .Where(a => a.TenantId == tenantId && a.CreatedAt >= startDate)
-                .GroupBy(a => a.CreatedAt.Date)
+            // Pull raw rows then group por día calendario tenant en memoria
+            // (CreatedAt.Date en SQL agrupa por UTC, lo cual mete pings de
+            // 17:00 Mazatlán al "día siguiente" UTC).
+            var rawRows = await context.ActivityLogs
+                .Where(a => a.TenantId == tenantId && a.CreatedAt >= startUtc)
+                .Select(a => new { a.CreatedAt, a.ActivityType, a.ActivityStatus, a.UserId })
+                .ToListAsync();
+
+            DateOnly TenantDayOf(DateTime utc) => DateOnly.FromDateTime(
+                TimeZoneInfo.ConvertTimeFromUtc(
+                    utc.Kind == DateTimeKind.Utc ? utc : DateTime.SpecifyKind(utc, DateTimeKind.Utc),
+                    tzInfo));
+
+            var activityData = rawRows
+                .GroupBy(a => TenantDayOf(a.CreatedAt))
                 .Select(g => new
                 {
                     date = g.Key,
@@ -200,16 +226,14 @@ public static class DashboardEndpoints
                     errors = g.Count(x => x.ActivityStatus == "failed"),
                     uniqueUsers = g.Select(x => x.UserId).Distinct().Count()
                 })
-                .OrderBy(x => x.date)
-                .ToListAsync();
+                .ToList();
 
-            // Llenar los días faltantes con ceros
             var chartData = new List<object>();
             for (int i = days; i >= 0; i--)
             {
-                var date = DateTime.UtcNow.Date.AddDays(-i);
+                var date = todayTenant.AddDays(-i);
                 var dayData = activityData.FirstOrDefault(a => a.date == date);
-                
+
                 chartData.Add(new
                 {
                     date = date.ToString("MMM dd"),
@@ -226,10 +250,11 @@ public static class DashboardEndpoints
         catch
         {
             // activity_logs table may not exist yet — return empty chart
+            var todayTenant = await tenantTz.GetTenantTodayAsync();
             var emptyChart = new List<object>();
             for (int i = days; i >= 0; i--)
             {
-                var d = DateTime.UtcNow.Date.AddDays(-i);
+                var d = todayTenant.AddDays(-i);
                 emptyChart.Add(new { date = d.ToString("MMM dd"), fullDate = d, totalActivities = 0, logins = 0, errors = 0, uniqueUsers = 0 });
             }
             return Results.Ok(new { chartData = emptyChart });
@@ -239,6 +264,7 @@ public static class DashboardEndpoints
     private static async Task<IResult> GetMyPerformance(
         [FromServices] HandySuitesDbContext context,
         [FromServices] ICurrentTenant currentTenant,
+        [FromServices] ITenantTimeZoneService tenantTz,
         [FromQuery] string? startDate = null,
         [FromQuery] string? endDate = null)
     {
@@ -248,9 +274,14 @@ public static class DashboardEndpoints
                 return Results.Unauthorized();
 
             var tenantId = currentTenant.TenantId;
-            var today = DateTime.UtcNow.Date;
-            var desde = startDate != null ? DateTime.Parse(startDate) : today.AddDays(-30);
-            var hasta = endDate != null ? DateTime.Parse(endDate) : today.AddDays(1);
+            var todayTenant = await tenantTz.GetTenantTodayAsync();
+            // Bordes de filtro en TZ tenant. `desde/hasta` son DateTime UTC
+            // que representan medianoche del día calendario tenant
+            // (ConvertTenantDateToUtcAsync hace la conversión).
+            var desdeTenantDate = startDate != null ? DateOnly.Parse(startDate) : todayTenant.AddDays(-30);
+            var hastaTenantDate = endDate != null ? DateOnly.Parse(endDate) : todayTenant.AddDays(1);
+            var desde = await tenantTz.ConvertTenantDateToUtcAsync(desdeTenantDate);
+            var hasta = await tenantTz.ConvertTenantDateToUtcAsync(hastaTenantDate);
 
             // Mis pedidos (proyección para evitar columnas faltantes en DB)
             var pedidosPeriodo = await context.Pedidos
@@ -305,7 +336,10 @@ public static class DashboardEndpoints
                 // Rutas
                 rutasTotal = misRutas.Count,
                 rutasCompletadas = misRutas.Count(r => r.Estado == EstadoRuta.Completada || r.Estado == EstadoRuta.Cerrada),
-                rutasHoy = misRutas.Count(r => r.Fecha.Date == today),
+                // "rutasHoy" compara contra día calendario tenant, no UTC.
+                // Se asume que `Fecha` se almacena a medianoche UTC del día
+                // tenant, así que basta comparar la parte de fecha.
+                rutasHoy = misRutas.Count(r => DateOnly.FromDateTime(r.Fecha) == todayTenant),
 
                 // Clientes
                 clientesAsignados = misClientes,

--- a/apps/api/src/HandySuites.Api/Endpoints/SupervisorEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/SupervisorEndpoints.cs
@@ -1,3 +1,4 @@
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.DeviceSessions.Interfaces;
 using HandySuites.Application.Usuarios.DTOs;
 using HandySuites.Application.Usuarios.Interfaces;
@@ -162,13 +163,20 @@ public static class SupervisorEndpoints
         // GET /api/supervisores/dashboard
         group.MapGet("/dashboard", async (
             ICurrentTenant tenant,
+            ITenantTimeZoneService tenantTzSvc,
             HandySuitesDbContext db) =>
         {
             if (!tenant.IsSupervisor)
                 return Results.Forbid();
 
             var supervisorId = int.Parse(tenant.UserId);
-            var hoy = DateTime.UtcNow.Date;
+            // Ventanas en TZ tenant — antes "hoy" y "mes" usaban UTC del servidor.
+            var hoyTenant = await tenantTzSvc.GetTenantTodayAsync();
+            var (hoyStartUtc, hoyEndUtc) = await tenantTzSvc.GetTenantDayWindowUtcAsync(hoyTenant);
+            var mesStart = new DateOnly(hoyTenant.Year, hoyTenant.Month, 1);
+            var mesEnd = mesStart.AddMonths(1);
+            var mesStartUtc = await tenantTzSvc.ConvertTenantDateToUtcAsync(mesStart);
+            var mesEndUtc = await tenantTzSvc.ConvertTenantDateToUtcAsync(mesEnd);
 
             var subordinadoIds = await db.Usuarios
                 .AsNoTracking()
@@ -184,7 +192,7 @@ public static class SupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Date == hoy
+                         && p.FechaPedido >= hoyStartUtc && p.FechaPedido < hoyEndUtc
                          && p.Activo)
                 .CountAsync();
 
@@ -192,8 +200,7 @@ public static class SupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Month == hoy.Month
-                         && p.FechaPedido.Year == hoy.Year
+                         && p.FechaPedido >= mesStartUtc && p.FechaPedido < mesEndUtc
                          && p.Activo)
                 .CountAsync();
 
@@ -209,8 +216,7 @@ public static class SupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Month == hoy.Month
-                         && p.FechaPedido.Year == hoy.Year
+                         && p.FechaPedido >= mesStartUtc && p.FechaPedido < mesEndUtc
                          && p.Activo)
                 .SumAsync(p => (decimal?)p.Total) ?? 0;
 

--- a/apps/api/src/HandySuites.Api/Endpoints/TeamLocationEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/TeamLocationEndpoints.cs
@@ -1,3 +1,4 @@
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.Tracking.Interfaces;
 using HandySuites.Domain.Common;
 using HandySuites.Domain.Entities;
@@ -155,16 +156,21 @@ public static class TeamLocationEndpoints
         [FromServices] HandySuitesDbContext db,
         [FromServices] ICurrentTenant currentUser,
         [FromServices] IUbicacionVendedorRepository ubicacionRepo,
-        [FromServices] ISubscriptionFeatureGuard featureGuard)
+        [FromServices] ISubscriptionFeatureGuard featureGuard,
+        [FromServices] ITenantTimeZoneService tenantTz)
     {
         var role = currentUser.Role;
         if (role != RoleNames.Admin && role != RoleNames.Supervisor && role != RoleNames.SuperAdmin)
             return Results.Forbid();
 
         var tenantId = currentUser.TenantId;
-        var fecha = (dia ?? DateTime.UtcNow).Date;
-        var inicio = fecha;
-        var fin = fecha.AddDays(1);
+        // Window calculado en TZ del tenant. Reportado 2026-05-06: vendedor en
+        // Mazatlán (UTC-7) veía pings del 5 mayo 17:19 (=00:19 UTC del 6) como
+        // si fueran "hoy" porque el server filtraba con DateTime.UtcNow.Date.
+        var fechaTenant = dia.HasValue
+            ? DateOnly.FromDateTime(dia.Value)
+            : await tenantTz.GetTenantTodayAsync();
+        var (inicio, fin) = await tenantTz.GetTenantDayWindowUtcAsync(fechaTenant);
 
         var visitas = await db.ClienteVisitas.AsNoTracking()
             .Where(v => v.TenantId == tenantId
@@ -227,7 +233,7 @@ public static class TeamLocationEndpoints
         // Pings de tracking continuo (Fase B). Solo si el plan tiene la feature.
         var hasTracking = await featureGuard.HasFeatureAsync(tenantId, "tracking_vendedor");
         var trackingPings = hasTracking
-            ? (await ubicacionRepo.ObtenerRecorridoDelDiaAsync(tenantId, id, DateOnly.FromDateTime(fecha)))
+            ? (await ubicacionRepo.ObtenerRecorridoEntreAsync(tenantId, id, inicio, fin))
                 .Select(p => new
                 {
                     tipo = p.Tipo == TipoPingUbicacion.Checkpoint ? "checkpoint"
@@ -254,7 +260,7 @@ public static class TeamLocationEndpoints
             .OrderBy(x => x.cuando)
             .ToList();
 
-        return Results.Ok(new { dia = fecha, usuarioId = id, eventos = todos });
+        return Results.Ok(new { dia = fechaTenant, usuarioId = id, eventos = todos });
     }
 
     private record RawActivity(int UsuarioId, double Lat, double Lng, DateTime Cuando, string Fuente, int? ClienteId, int Id);

--- a/apps/api/tests/HandySuites.Tests/Application/Tracking/UbicacionVendedorServiceTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Tracking/UbicacionVendedorServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.Tracking.DTOs;
 using HandySuites.Application.Tracking.Interfaces;
 using HandySuites.Application.Tracking.Services;
@@ -17,17 +18,22 @@ public class UbicacionVendedorServiceTests
     private readonly Mock<IUbicacionVendedorRepository> _repo = new();
     private readonly Mock<ISubscriptionFeatureGuard> _guard = new();
     private readonly Mock<ICurrentTenant> _tenant = new();
+    private readonly Mock<ITenantTimeZoneService> _tz = new();
     private readonly UbicacionVendedorService _service;
 
     public UbicacionVendedorServiceTests()
     {
         _tenant.SetupGet(t => t.TenantId).Returns(Tenant);
         _tenant.SetupGet(t => t.UserId).Returns(UserId);
+        // TZ tenant default: UTC. Tests que validen el ajuste TZ del campo
+        // DiaServicio pueden setupear otra zona.
+        _tz.Setup(t => t.GetTenantTimeZoneAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TimeZoneInfo.Utc);
         // Default: no última ubicación previa (vendedor nuevo). Tests que
         // necesitan validar velocity check pueden override este setup.
         _repo.Setup(r => r.ObtenerUltimasAsync(Tenant, It.IsAny<List<int>?>()))
             .ReturnsAsync(new List<UltimaUbicacionDto>());
-        _service = new UbicacionVendedorService(_repo.Object, _guard.Object, _tenant.Object);
+        _service = new UbicacionVendedorService(_repo.Object, _guard.Object, _tenant.Object, _tz.Object);
     }
 
     [Fact]

--- a/apps/api/tests/HandySuites.Tests/Infrastructure/ActivityTracking/ActivityTrackingRepositoryTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Infrastructure/ActivityTracking/ActivityTrackingRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Domain.Entities;
 using HandySuites.Infrastructure.ActivityTracking.Repositories;
 using HandySuites.Infrastructure.Persistence;
@@ -16,7 +17,31 @@ namespace HandySuites.Tests.Infrastructure.ActivityTracking
         {
             var scope = factory.Services.CreateScope();
             _context = scope.ServiceProvider.GetRequiredService<HandySuitesDbContext>();
-            _repository = new ActivityTrackingRepository(_context);
+            // Forzamos stub UTC: el real `TenantTimeZoneService` requiere
+            // `ICurrentTenant` en scope (HTTP context), que el test fixture
+            // no provee.
+            _repository = new ActivityTrackingRepository(_context, new FixedUtcTenantTimeZoneService());
+        }
+
+        // Stub UTC para tests cuando el container no registra el servicio real.
+        private sealed class FixedUtcTenantTimeZoneService : ITenantTimeZoneService
+        {
+            public Task<TimeZoneInfo> GetTenantTimeZoneAsync(System.Threading.CancellationToken ct = default)
+                => Task.FromResult(TimeZoneInfo.Utc);
+            public Task<TimeZoneInfo> GetTimeZoneForTenantAsync(int tenantId, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(TimeZoneInfo.Utc);
+            public Task<DateOnly> GetTenantTodayAsync(System.Threading.CancellationToken ct = default)
+                => Task.FromResult(DateOnly.FromDateTime(DateTime.UtcNow));
+            public Task<(DateTime InicioUtc, DateTime FinUtc)> GetTenantDayWindowUtcAsync(DateOnly? dia = null, System.Threading.CancellationToken ct = default)
+            {
+                var d = dia ?? DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = d.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+                return Task.FromResult((start, start.AddDays(1)));
+            }
+            public Task<DateTime> ConvertTenantDateToUtcAsync(DateOnly tenantDate, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(tenantDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+            public Task<DateOnly> GetTenantDayFromUtcAsync(DateTime utcInstant, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(DateOnly.FromDateTime(utcInstant));
         }
 
         [Fact]

--- a/apps/mobile/HandySuites.Mobile.Api/Configuration/ServiceRegistrationExtensions.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Configuration/ServiceRegistrationExtensions.cs
@@ -110,6 +110,8 @@ public static class ServiceRegistrationExtensions
         // Core Services
         services.AddScoped<JwtTokenGenerator>();
         services.AddScoped<ICurrentTenant, CurrentTenant>();
+        services.AddScoped<HandySuites.Application.Common.Interfaces.ITenantTimeZoneService,
+                            HandySuites.Infrastructure.Common.TenantTimeZoneService>();
         services.AddScoped<MobileAuthService>();
 
         // TOTP verification (compartido con web API). El mobile NO genera

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileSupervisorEndpoints.cs
@@ -1,3 +1,4 @@
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.Usuarios.DTOs;
 using HandySuites.Domain.Common;
 using HandySuites.Infrastructure.Persistence;
@@ -90,13 +91,22 @@ public static class MobileSupervisorEndpoints
         // GET /api/mobile/supervisor/dashboard
         group.MapGet("/dashboard", async (
             ICurrentTenant tenant,
+            ITenantTimeZoneService tenantTzSvc,
             HandySuitesDbContext db) =>
         {
             if (!tenant.IsSupervisor && !tenant.IsAdmin && !tenant.IsSuperAdmin)
                 return Results.Forbid();
 
             var supervisorId = int.Parse(tenant.UserId);
-            var hoy = DateTime.UtcNow.Date;
+            // Ventanas en TZ tenant — antes "hoy" y "mes" filtraban por
+            // calendario UTC del servidor, lo que excluía pedidos de TZ
+            // negativas en rangos al límite del día/mes.
+            var hoyTenant = await tenantTzSvc.GetTenantTodayAsync();
+            var (hoyStartUtc, hoyEndUtc) = await tenantTzSvc.GetTenantDayWindowUtcAsync(hoyTenant);
+            var mesStart = new DateOnly(hoyTenant.Year, hoyTenant.Month, 1);
+            var mesEnd = mesStart.AddMonths(1);
+            var mesStartUtc = await tenantTzSvc.ConvertTenantDateToUtcAsync(mesStart);
+            var mesEndUtc = await tenantTzSvc.ConvertTenantDateToUtcAsync(mesEnd);
 
             List<int> allIds;
             if (tenant.IsAdmin || tenant.IsSuperAdmin)
@@ -117,7 +127,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Date == hoy
+                         && p.FechaPedido >= hoyStartUtc && p.FechaPedido < hoyEndUtc
                          && p.Activo)
                 .CountAsync();
 
@@ -125,8 +135,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Month == hoy.Month
-                         && p.FechaPedido.Year == hoy.Year
+                         && p.FechaPedido >= mesStartUtc && p.FechaPedido < mesEndUtc
                          && p.Activo)
                 .CountAsync();
 
@@ -142,8 +151,7 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Month == hoy.Month
-                         && p.FechaPedido.Year == hoy.Year
+                         && p.FechaPedido >= mesStartUtc && p.FechaPedido < mesEndUtc
                          && p.Activo)
                 .SumAsync(p => (decimal?)p.Total) ?? 0;
 
@@ -151,7 +159,8 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(v => allIds.Contains(v.UsuarioId)
                          && v.TenantId == tenant.TenantId
-                         && v.FechaHoraInicio != null && v.FechaHoraInicio.Value.Date == hoy
+                         && v.FechaHoraInicio != null
+                         && v.FechaHoraInicio >= hoyStartUtc && v.FechaHoraInicio < hoyEndUtc
                          && v.EliminadoEn == null)
                 .CountAsync();
 
@@ -159,7 +168,8 @@ public static class MobileSupervisorEndpoints
                 .AsNoTracking()
                 .Where(v => allIds.Contains(v.UsuarioId)
                          && v.TenantId == tenant.TenantId
-                         && v.FechaHoraInicio != null && v.FechaHoraInicio.Value.Date == hoy
+                         && v.FechaHoraInicio != null
+                         && v.FechaHoraInicio >= hoyStartUtc && v.FechaHoraInicio < hoyEndUtc
                          && v.FechaHoraFin != null
                          && v.EliminadoEn == null)
                 .CountAsync();
@@ -248,13 +258,15 @@ public static class MobileSupervisorEndpoints
         // GET /api/mobile/supervisor/actividad
         group.MapGet("/actividad", async (
             ICurrentTenant tenant,
+            ITenantTimeZoneService tenantTzSvc,
             HandySuitesDbContext db) =>
         {
             if (!tenant.IsSupervisor && !tenant.IsAdmin && !tenant.IsSuperAdmin)
                 return Results.Forbid();
 
             var supervisorId = int.Parse(tenant.UserId);
-            var hoy = DateTime.UtcNow.Date;
+            // Ventana "hoy" en TZ tenant — antes filtraba por UTC.
+            var (hoyStartUtc, hoyEndUtc) = await tenantTzSvc.GetTenantDayWindowUtcAsync();
 
             List<int> allIds;
             if (tenant.IsAdmin || tenant.IsSuperAdmin)
@@ -277,7 +289,7 @@ public static class MobileSupervisorEndpoints
                 .Include(p => p.Cliente)
                 .Where(p => allIds.Contains(p.UsuarioId)
                          && p.TenantId == tenant.TenantId
-                         && p.FechaPedido.Date == hoy
+                         && p.FechaPedido >= hoyStartUtc && p.FechaPedido < hoyEndUtc
                          && p.Activo)
                 .OrderByDescending(p => p.CreadoEn)
                 .Take(20)
@@ -299,7 +311,8 @@ public static class MobileSupervisorEndpoints
                 .Include(v => v.Cliente)
                 .Where(v => allIds.Contains(v.UsuarioId)
                          && v.TenantId == tenant.TenantId
-                         && v.FechaHoraInicio != null && v.FechaHoraInicio.Value.Date == hoy
+                         && v.FechaHoraInicio != null
+                         && v.FechaHoraInicio >= hoyStartUtc && v.FechaHoraInicio < hoyEndUtc
                          && v.EliminadoEn == null)
                 .OrderByDescending(v => v.FechaHoraInicio)
                 .Take(20)
@@ -321,7 +334,7 @@ public static class MobileSupervisorEndpoints
                 .Include(c => c.Cliente)
                 .Where(c => allIds.Contains(c.UsuarioId)
                          && c.TenantId == tenant.TenantId
-                         && c.FechaCobro.Date == hoy
+                         && c.FechaCobro >= hoyStartUtc && c.FechaCobro < hoyEndUtc
                          && c.Activo)
                 .OrderByDescending(c => c.CreadoEn)
                 .Take(10)

--- a/apps/web/src/app/(dashboard)/cobranza/page.tsx
+++ b/apps/web/src/app/(dashboard)/cobranza/page.tsx
@@ -69,11 +69,16 @@ type CobroFormData = z.infer<typeof cobroSchema>;
 
 // fmtDate moved inside component to use locale-aware useFormatters hook
 
-function defaultDates() {
-  const h = new Date();
-  const d = new Date(h);
-  d.setMonth(d.getMonth() - 1);
-  return { desde: d.toISOString().slice(0, 10), hasta: h.toISOString().slice(0, 10) };
+/**
+ * Calcula `defaultDates` y `DATE_PRESETS` ANCLADOS al día calendario del tenant.
+ * Antes usaban `new Date()` (TZ del browser), causando que un admin en CDMX
+ * abriendo el panel de un tenant Mazatlán filtrara con un día desfasado.
+ */
+function defaultDatesFromTenantToday(today: string) {
+  const [y, m, d] = today.split('-').map(Number);
+  const past = new Date(Date.UTC(y ?? 0, (m ?? 1) - 1, d ?? 1, 12, 0, 0));
+  past.setUTCMonth(past.getUTCMonth() - 1);
+  return { desde: past.toISOString().slice(0, 10), hasta: today };
 }
 
 const metodoPagoColors: Record<number, string> = {
@@ -85,28 +90,30 @@ const metodoPagoColors: Record<number, string> = {
   5: 'bg-surface-3 text-foreground/80',
 };
 
-const iso = (d: Date) => d.toISOString().slice(0, 10);
+function buildDatePresets(today: string): { label: string; calc: () => { desde: string; hasta: string } }[] {
+  const [y, m, d] = today.split('-').map(Number);
+  const todayUtc = new Date(Date.UTC(y ?? 0, (m ?? 1) - 1, d ?? 1, 12, 0, 0));
+  const isoOf = (date: Date) => date.toISOString().slice(0, 10);
 
-const DATE_PRESETS: { label: string; calc: () => { desde: string; hasta: string } }[] = [
-  { label: 'today', calc: () => { const t = iso(new Date()); return { desde: t, hasta: t }; } },
-  { label: 'thisWeek', calc: () => {
-    const now = new Date();
-    const day = now.getDay();
-    const mon = new Date(now);
-    mon.setDate(now.getDate() - (day === 0 ? 6 : day - 1));
-    return { desde: iso(mon), hasta: iso(now) };
-  }},
-  { label: 'thisMonth', calc: () => {
-    const now = new Date();
-    return { desde: iso(new Date(now.getFullYear(), now.getMonth(), 1)), hasta: iso(now) };
-  }},
-  { label: 'last90Days', calc: () => {
-    const now = new Date();
-    const past = new Date(now);
-    past.setDate(past.getDate() - 90);
-    return { desde: iso(past), hasta: iso(now) };
-  }},
-];
+  return [
+    { label: 'today', calc: () => ({ desde: today, hasta: today }) },
+    { label: 'thisWeek', calc: () => {
+      const day = todayUtc.getUTCDay();
+      const mon = new Date(todayUtc);
+      mon.setUTCDate(todayUtc.getUTCDate() - (day === 0 ? 6 : day - 1));
+      return { desde: isoOf(mon), hasta: today };
+    }},
+    { label: 'thisMonth', calc: () => {
+      const first = new Date(Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), 1, 12, 0, 0));
+      return { desde: isoOf(first), hasta: today };
+    }},
+    { label: 'last90Days', calc: () => {
+      const past = new Date(todayUtc);
+      past.setUTCDate(past.getUTCDate() - 90);
+      return { desde: isoOf(past), hasta: today };
+    }},
+  ];
+}
 
 type Tab = 'cobros' | 'saldos';
 
@@ -115,13 +122,15 @@ type Tab = 'cobros' | 'saldos';
 export default function CobranzaPage() {
   const t = useTranslations('collections');
   const tc = useTranslations('common');
-  const { formatCurrency, formatDate } = useFormatters();
+  const { formatCurrency, formatDate, tenantToday } = useFormatters();
   const fmtDate = (d: string) => formatDate(d, { day: '2-digit', month: 'short', year: 'numeric' });
   const drawerEstadoCuentaRef = useRef<DrawerHandle>(null);
   const drawerNewCobroRef = useRef<DrawerHandle>(null);
 
   const [tab, setTab] = useState<Tab>('saldos');
-  const [dates, setDates] = useState(defaultDates);
+  const [dates, setDates] = useState(() => defaultDatesFromTenantToday(tenantToday()));
+  // Presets recompiled when tenant TZ/day changes (rare).
+  const DATE_PRESETS = useMemo(() => buildDatePresets(tenantToday()), [tenantToday]);
   const [resumen, setResumen] = useState<ResumenCartera | null>(null);
 
   // Cobros

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -77,11 +77,19 @@ const activityIcons: Record<string, React.ElementType> = {
   export: FileDown,
 };
 
-function getDateRange(periodo: 'semana' | 'mes' | 'trimestre') {
-  const hasta = new Date().toISOString().slice(0, 10);
-  const desdeDate = new Date();
-  desdeDate.setDate(desdeDate.getDate() - (periodo === 'semana' ? 7 : periodo === 'mes' ? 30 : 90));
-  const desde = desdeDate.toISOString().slice(0, 10);
+/**
+ * Calcula el rango YYYY-MM-DD usando el día calendario en TZ del tenant.
+ * `today` se inyecta desde `useFormatters().tenantToday()` para que la consulta
+ * coincida con lo que ve el admin en su zona (Mazatlán/CDMX/etc) en lugar
+ * del calendario UTC del browser.
+ */
+function getDateRange(periodo: 'semana' | 'mes' | 'trimestre', today: string) {
+  const hasta = today;
+  const [y, m, d] = today.split('-').map(Number);
+  const days = periodo === 'semana' ? 7 : periodo === 'mes' ? 30 : 90;
+  const desdeUtcNoon = new Date(Date.UTC((y ?? 0), (m ?? 1) - 1, (d ?? 1), 12, 0, 0));
+  desdeUtcNoon.setUTCDate(desdeUtcNoon.getUTCDate() - days);
+  const desde = desdeUtcNoon.toISOString().slice(0, 10);
   return { desde, hasta };
 }
 
@@ -131,7 +139,7 @@ export default function DashboardPage() {
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const { on, off } = useSignalR();
-  const { formatCurrency, formatNumber, formatDate } = useFormatters();
+  const { formatCurrency, formatNumber, formatDate, tenantToday } = useFormatters();
 
   // Listen for real-time updates via SignalR (debounced)
   useEffect(() => {
@@ -224,16 +232,20 @@ export default function DashboardPage() {
       }));
     }
     // Semana (7 days) or Mes (30 days): fill missing days
+    // Anclamos en "hoy" tenant (no browser local) para que el chart muestre
+    // el mismo día calendario que ven los usuarios del tenant.
     const days = periodo === 'semana' ? 7 : 30;
     const salesMap = new Map(ventasDiarias.map(p => [p.fecha, Number(p.totalVentas)]));
     const result: { day: string; value: number }[] = [];
+    const today = tenantToday();
+    const [ty, tm, td] = today.split('-').map(Number);
     for (let i = days - 1; i >= 0; i--) {
-      const d = new Date();
-      d.setDate(d.getDate() - i);
-      const key = d.toISOString().slice(0, 10);
+      const baseUtcNoon = new Date(Date.UTC(ty ?? 0, (tm ?? 1) - 1, td ?? 1, 12, 0, 0));
+      baseUtcNoon.setUTCDate(baseUtcNoon.getUTCDate() - i);
+      const key = baseUtcNoon.toISOString().slice(0, 10);
       const label = periodo === 'semana'
-        ? formatDate(d, { weekday: 'short' })
-        : formatDate(d, { day: 'numeric' });
+        ? formatDate(baseUtcNoon, { weekday: 'short' })
+        : formatDate(baseUtcNoon, { day: 'numeric' });
       result.push({ day: label, value: salesMap.get(key) ?? 0 });
     }
     return result;
@@ -241,7 +253,7 @@ export default function DashboardPage() {
   const maxChartValue = Math.max(...chartData.map(d => d.value), 1);
 
   // Date range for display
-  const { desde, hasta } = getDateRange(periodo);
+  const { desde, hasta } = getDateRange(periodo, tenantToday());
 
   // Export hook
   const { exportPDF, exporting } = useReportExport({
@@ -268,7 +280,9 @@ export default function DashboardPage() {
           try {
             const userId = parseInt(session?.user?.id ?? '0');
             if (userId) {
-              const today = new Date().toISOString().slice(0, 10);
+              // Día calendario tenant (no UTC), para no excluir metas vigentes
+              // del último/primer minuto del día en TZ del browser ≠ tenant.
+              const today = tenantToday();
               const metas = await metaVendedorService.getAll(userId);
               const activa = metas.find(m => m.activo && m.fechaInicio <= today && m.fechaFin >= today) ?? null;
               setMetaActiva(activa);
@@ -278,7 +292,7 @@ export default function DashboardPage() {
           }
         } else {
           // Admin/Supervisor: load real data from APIs
-          const { desde: d, hasta: h } = getDateRange(periodo);
+          const { desde: d, hasta: h } = getDateRange(periodo, tenantToday());
 
           const [ejResult, vpResult, actResult] = await Promise.allSettled([
             getDashboardEjecutivo({ periodo }),

--- a/apps/web/src/app/(dashboard)/metas/page.tsx
+++ b/apps/web/src/app/(dashboard)/metas/page.tsx
@@ -68,12 +68,18 @@ type MetaFormData = z.infer<typeof metaSchema>;
 
 // ─── Helpers ───────────────────────────────────────────
 
-
-const todayStr = () => new Date().toISOString().slice(0, 10);
-const nextMonthStr = () => {
-  const d = new Date();
-  d.setMonth(d.getMonth() + 1);
-  return d.toISOString().slice(0, 10);
+/**
+ * "Hoy" y "+1 mes" calculados sobre el día calendario del tenant
+ * (se inyecta `today` desde `useFormatters().tenantToday()`).
+ * Antes ambas funciones usaban `new Date()` (browser local), generando
+ * defaults de form un día desfasado para tenants en TZ negativa.
+ */
+const todayStrFromTenantToday = (today: string) => today;
+const nextMonthStrFromTenantToday = (today: string) => {
+  const [y, m, d] = today.split('-').map(Number);
+  const utc = new Date(Date.UTC((y ?? 0), (m ?? 1) - 1, (d ?? 1), 12, 0, 0));
+  utc.setUTCMonth(utc.getUTCMonth() + 1);
+  return utc.toISOString().slice(0, 10);
 };
 
 // ─── Page ──────────────────────────────────────────────
@@ -81,7 +87,9 @@ export default function MetasPage() {
   const t = useTranslations('goals');
   const tc = useTranslations('common');
   const showApiError = useApiErrorToast();
-  const { formatDate, formatNumber } = useFormatters();
+  const { formatDate, formatNumber, tenantToday } = useFormatters();
+  const todayStr = () => todayStrFromTenantToday(tenantToday());
+  const nextMonthStr = () => nextMonthStrFromTenantToday(tenantToday());
   const { data: session } = useSession();
 
   const TIPO_OPTIONS = [

--- a/apps/web/src/app/(dashboard)/routes/page.tsx
+++ b/apps/web/src/app/(dashboard)/routes/page.tsx
@@ -70,7 +70,7 @@ export default function RoutesPage() {
   const tc = useTranslations('common');
   const showApiError = useApiErrorToast();
   const router = useRouter();
-  const { formatDateOnly } = useFormatters();
+  const { formatDateOnly, tenantToday } = useFormatters();
   const { data: session } = useSession();
   const isAdmin = session?.user?.role === 'ADMIN' || session?.user?.role === 'SUPER_ADMIN';
 
@@ -343,7 +343,10 @@ export default function RoutesPage() {
 
   // Create/Edit handlers
   const handleOpenCreate = () => {
-    const todayString = new Date().toISOString().split('T')[0];
+    // Default `fecha` al día calendario tenant. Antes usaba UTC del browser
+    // (`new Date().toISOString()`) lo que en TZ negativa preseleccionaba el
+    // día siguiente.
+    const todayString = tenantToday();
     resetForm({
       nombre: '',
       usuarioId: 0,

--- a/apps/web/src/components/calendar/CalendarGrid.tsx
+++ b/apps/web/src/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslations } from "next-intl";
 import { Visit } from "@/types/calendar";
+import { useFormatters } from "@/hooks/useFormatters";
 
 interface CalendarGridProps {
   currentDate: Date;
@@ -29,22 +30,29 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
   className = "",
 }) => {
   const tcal = useTranslations("visits.calendar");
-  const getDaysForView = (): DayInfo[] => {
-    const today = new Date();
+  // "Hoy" en TZ tenant — antes el highlight `isToday` dependía del browser,
+  // por lo que un admin CDMX viendo un tenant Mazatlán cruzando medianoche
+  // Mazatlán (=1am CDMX) marcaba el día siguiente.
+  const { tenantToday } = useFormatters();
+  const todayKey = tenantToday();
 
+  const ymd = (d: Date): string =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+  const getDaysForView = (): DayInfo[] => {
     switch (viewMode) {
       case "month":
-        return getMonthDays(currentDate, today);
+        return getMonthDays(currentDate);
       case "week":
-        return getWeekDays(currentDate, today);
+        return getWeekDays(currentDate);
       case "day":
-        return [getDayInfo(currentDate, today)];
+        return [getDayInfo(currentDate)];
       default:
         return [];
     }
   };
 
-  const getMonthDays = (date: Date, today: Date): DayInfo[] => {
+  const getMonthDays = (date: Date): DayInfo[] => {
     const year = date.getFullYear();
     const month = date.getMonth();
     const firstDay = new Date(year, month, 1);
@@ -60,7 +68,7 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
       days.push({
         date: prevDate,
         isCurrentMonth: false,
-        isToday: prevDate.toDateString() === today.toDateString(),
+        isToday: ymd(prevDate) === todayKey,
       });
     }
 
@@ -70,7 +78,7 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
       days.push({
         date: dayDate,
         isCurrentMonth: true,
-        isToday: dayDate.toDateString() === today.toDateString(),
+        isToday: ymd(dayDate) === todayKey,
       });
     }
 
@@ -81,14 +89,14 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
       days.push({
         date: nextDate,
         isCurrentMonth: false,
-        isToday: nextDate.toDateString() === today.toDateString(),
+        isToday: ymd(nextDate) === todayKey,
       });
     }
 
     return days;
   };
 
-  const getWeekDays = (date: Date, today: Date): DayInfo[] => {
+  const getWeekDays = (date: Date): DayInfo[] => {
     const startOfWeek = new Date(date);
     startOfWeek.setDate(date.getDate() - date.getDay() + 1); // Lunes
 
@@ -99,17 +107,17 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
       days.push({
         date: dayDate,
         isCurrentMonth: true,
-        isToday: dayDate.toDateString() === today.toDateString(),
+        isToday: ymd(dayDate) === todayKey,
       });
     }
 
     return days;
   };
 
-  const getDayInfo = (date: Date, today: Date): DayInfo => ({
+  const getDayInfo = (date: Date): DayInfo => ({
     date: new Date(date),
     isCurrentMonth: true,
-    isToday: date.toDateString() === today.toDateString(),
+    isToday: ymd(date) === todayKey,
   });
 
   const getVisitsForDate = (date: Date): Visit[] => {

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Visit } from "@/types/calendar";
+import { useFormatters } from "@/hooks/useFormatters";
 
 interface CalendarViewProps {
   visits: Visit[];
@@ -20,6 +21,11 @@ export const CalendarView: React.FC<CalendarViewProps> = ({
   selectedUser,
 }) => {
   const tcal = useTranslations("visits.calendar");
+  // "Hoy" en TZ tenant — el highlight `isToday` antes dependía del browser.
+  const { tenantToday } = useFormatters();
+  const todayKey = tenantToday();
+  const ymd = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   const [viewMode] = useState<"month" | "week" | "day">("month");
 
   const getDaysInMonth = (date: Date) => {
@@ -120,8 +126,7 @@ export const CalendarView: React.FC<CalendarViewProps> = ({
           {/* Días del calendario */}
           {days.map((dayInfo, index) => {
             const dayVisits = getVisitsForDate(dayInfo.date);
-            const isToday =
-              dayInfo.date.toDateString() === new Date().toDateString();
+            const isToday = ymd(dayInfo.date) === todayKey;
 
             return (
               <div

--- a/apps/web/src/components/orders/OrderList.tsx
+++ b/apps/web/src/components/orders/OrderList.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Order } from '@/types/orders';
 import { Plus, Package } from 'lucide-react';
+import { useFormatters } from '@/hooks/useFormatters';
 
 interface OrderListProps {
   orders: Order[];
@@ -28,6 +29,10 @@ export const OrderList: React.FC<OrderListProps> = ({
   className = '',
 }) => {
   const t = useTranslations('orders.list');
+  // Día calendario en TZ tenant — antes los presets ("hoy", "esta semana")
+  // dependían de la TZ del browser, descartando órdenes legítimas en TZ
+  // negativa al cruce de medianoche.
+  const { tenantToday } = useFormatters();
   // Estados para filtros
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
@@ -35,42 +40,48 @@ export const OrderList: React.FC<OrderListProps> = ({
   const [dateFilter, setDateFilter] = useState('');
   const [clientFilter, setClientFilter] = useState('');
 
-  // Función para filtrar por fecha
+  // Función para filtrar por fecha (anclada en día tenant)
   const filterByDate = (order: Order, filter: string) => {
     if (!filter) return true;
 
-    const orderDate = new Date(order.orderDate);
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
+    const orderKey = (typeof order.orderDate === 'string'
+      ? order.orderDate
+      : new Date(order.orderDate).toISOString()
+    ).slice(0, 10);
+    const todayKey = tenantToday();
+    const [ty, tm, td] = todayKey.split('-').map(Number);
+    const todayUtcNoon = new Date(Date.UTC(ty ?? 0, (tm ?? 1) - 1, td ?? 1, 12, 0, 0));
+    const ymdOf = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 
     switch (filter) {
       case 'today':
-        return orderDate.toDateString() === today.toDateString();
-      case 'yesterday':
-        return orderDate.toDateString() === yesterday.toDateString();
-      case 'this_week':
-        const weekStart = new Date(today);
-        weekStart.setDate(today.getDate() - today.getDay());
-        return orderDate >= weekStart;
-      case 'last_week':
-        const lastWeekStart = new Date(today);
-        lastWeekStart.setDate(today.getDate() - today.getDay() - 7);
+        return orderKey === todayKey;
+      case 'yesterday': {
+        const y = new Date(todayUtcNoon);
+        y.setUTCDate(y.getUTCDate() - 1);
+        return orderKey === ymdOf(y);
+      }
+      case 'this_week': {
+        const weekStart = new Date(todayUtcNoon);
+        weekStart.setUTCDate(todayUtcNoon.getUTCDate() - todayUtcNoon.getUTCDay());
+        return orderKey >= ymdOf(weekStart);
+      }
+      case 'last_week': {
+        const lastWeekStart = new Date(todayUtcNoon);
+        lastWeekStart.setUTCDate(todayUtcNoon.getUTCDate() - todayUtcNoon.getUTCDay() - 7);
         const lastWeekEnd = new Date(lastWeekStart);
-        lastWeekEnd.setDate(lastWeekStart.getDate() + 6);
-        return orderDate >= lastWeekStart && orderDate <= lastWeekEnd;
-      case 'this_month':
-        return (
-          orderDate.getMonth() === today.getMonth() &&
-          orderDate.getFullYear() === today.getFullYear()
-        );
-      case 'last_month':
-        const lastMonth = new Date(today);
-        lastMonth.setMonth(today.getMonth() - 1);
-        return (
-          orderDate.getMonth() === lastMonth.getMonth() &&
-          orderDate.getFullYear() === lastMonth.getFullYear()
-        );
+        lastWeekEnd.setUTCDate(lastWeekStart.getUTCDate() + 6);
+        return orderKey >= ymdOf(lastWeekStart) && orderKey <= ymdOf(lastWeekEnd);
+      }
+      case 'this_month': {
+        return orderKey.slice(0, 7) === todayKey.slice(0, 7);
+      }
+      case 'last_month': {
+        const lm = new Date(todayUtcNoon);
+        lm.setUTCMonth(todayUtcNoon.getUTCMonth() - 1);
+        return orderKey.slice(0, 7) === `${lm.getUTCFullYear()}-${String(lm.getUTCMonth() + 1).padStart(2, '0')}`;
+      }
       default:
         return true;
     }

--- a/apps/web/src/components/visits/VisitList.tsx
+++ b/apps/web/src/components/visits/VisitList.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ClienteVisitaListaDto, ResultadoVisita } from '@/types/visits';
 import { Plus, MapPin } from 'lucide-react';
+import { useFormatters } from '@/hooks/useFormatters';
 
 interface VisitListProps {
   visits: ClienteVisitaListaDto[];
@@ -28,55 +29,60 @@ export const VisitList: React.FC<VisitListProps> = ({
   className = '',
 }) => {
   const t = useTranslations('visits.list');
+  // Día calendario en TZ tenant — antes los presets ("hoy", etc.) usaban
+  // TZ del browser, lo que dejaba fuera visitas legítimas en cruce de
+  // medianoche para tenants con TZ negativa.
+  const { tenantToday } = useFormatters();
   // Estados para filtros
   const [searchTerm, setSearchTerm] = useState('');
   const [tipoFilter, setTipoFilter] = useState('');
   const [resultadoFilter, setResultadoFilter] = useState('');
   const [dateFilter, setDateFilter] = useState('');
 
-  // Función para filtrar por fecha
+  // Función para filtrar por fecha (anclada en día tenant)
   const filterByDate = (visit: ClienteVisitaListaDto, filter: string) => {
     if (!filter) return true;
 
-    const visitDate = visit.fechaProgramada
-      ? new Date(visit.fechaProgramada)
-      : visit.fechaHoraInicio
-      ? new Date(visit.fechaHoraInicio)
-      : null;
+    const sourceDate = visit.fechaProgramada ?? visit.fechaHoraInicio;
+    if (!sourceDate) return true;
 
-    if (!visitDate) return true;
-
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
+    const visitKey = (typeof sourceDate === 'string'
+      ? sourceDate
+      : new Date(sourceDate).toISOString()
+    ).slice(0, 10);
+    const todayKey = tenantToday();
+    const [ty, tm, td] = todayKey.split('-').map(Number);
+    const todayUtcNoon = new Date(Date.UTC(ty ?? 0, (tm ?? 1) - 1, td ?? 1, 12, 0, 0));
+    const ymdOf = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 
     switch (filter) {
       case 'today':
-        return visitDate.toDateString() === today.toDateString();
-      case 'yesterday':
-        return visitDate.toDateString() === yesterday.toDateString();
-      case 'this_week':
-        const weekStart = new Date(today);
-        weekStart.setDate(today.getDate() - today.getDay());
-        return visitDate >= weekStart;
-      case 'last_week':
-        const lastWeekStart = new Date(today);
-        lastWeekStart.setDate(today.getDate() - today.getDay() - 7);
+        return visitKey === todayKey;
+      case 'yesterday': {
+        const y = new Date(todayUtcNoon);
+        y.setUTCDate(y.getUTCDate() - 1);
+        return visitKey === ymdOf(y);
+      }
+      case 'this_week': {
+        const weekStart = new Date(todayUtcNoon);
+        weekStart.setUTCDate(todayUtcNoon.getUTCDate() - todayUtcNoon.getUTCDay());
+        return visitKey >= ymdOf(weekStart);
+      }
+      case 'last_week': {
+        const lastWeekStart = new Date(todayUtcNoon);
+        lastWeekStart.setUTCDate(todayUtcNoon.getUTCDate() - todayUtcNoon.getUTCDay() - 7);
         const lastWeekEnd = new Date(lastWeekStart);
-        lastWeekEnd.setDate(lastWeekStart.getDate() + 6);
-        return visitDate >= lastWeekStart && visitDate <= lastWeekEnd;
+        lastWeekEnd.setUTCDate(lastWeekStart.getUTCDate() + 6);
+        return visitKey >= ymdOf(lastWeekStart) && visitKey <= ymdOf(lastWeekEnd);
+      }
       case 'this_month':
-        return (
-          visitDate.getMonth() === today.getMonth() &&
-          visitDate.getFullYear() === today.getFullYear()
-        );
-      case 'last_month':
-        const lastMonth = new Date(today);
-        lastMonth.setMonth(today.getMonth() - 1);
-        return (
-          visitDate.getMonth() === lastMonth.getMonth() &&
-          visitDate.getFullYear() === lastMonth.getFullYear()
-        );
+        return visitKey.slice(0, 7) === todayKey.slice(0, 7);
+      case 'last_month': {
+        const lm = new Date(todayUtcNoon);
+        lm.setUTCMonth(todayUtcNoon.getUTCMonth() - 1);
+        return visitKey.slice(0, 7) === `${lm.getUTCFullYear()}-${String(lm.getUTCMonth() + 1).padStart(2, '0')}`;
+      }
       default:
         return true;
     }

--- a/apps/web/src/hooks/useFormatters.ts
+++ b/apps/web/src/hooks/useFormatters.ts
@@ -1,6 +1,14 @@
 import { useCallback } from 'react';
 import { useCompany } from '@/contexts/CompanyContext';
-import { formatDate, formatDateOnly, formatCurrency, formatNumber } from '@/lib/formatters';
+import {
+  formatDate,
+  formatDateOnly,
+  formatCurrency,
+  formatNumber,
+  tenantToday,
+  tenantStartOfDayUtc,
+  tenantStartOfWeek,
+} from '@/lib/formatters';
 
 /**
  * Hook that provides tenant-aware formatting functions.
@@ -32,10 +40,25 @@ export function useFormatters() {
     [settings]
   );
 
+  /** YYYY-MM-DD del día calendario en TZ tenant. */
+  const today = useCallback(() => tenantToday(settings), [settings]);
+
+  /** Date (UTC instant) que representa la medianoche del día tenant. */
+  const startOfDayUtc = useCallback(
+    (day?: Date | string) => tenantStartOfDayUtc(day, settings),
+    [settings]
+  );
+
+  /** YYYY-MM-DD del lunes que abre la semana del tenant. */
+  const startOfWeek = useCallback(() => tenantStartOfWeek(settings), [settings]);
+
   return {
     formatDate: fmtDate,
     formatDateOnly: fmtDateOnly,
     formatCurrency: fmtCurrency,
     formatNumber: fmtNumber,
+    tenantToday: today,
+    tenantStartOfDayUtc: startOfDayUtc,
+    tenantStartOfWeek: startOfWeek,
   };
 }

--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -101,3 +101,70 @@ export function formatNumber(
   const locale = getLocale(settings);
   return value.toLocaleString(locale);
 }
+
+/**
+ * Returns the current calendar date *in the tenant's timezone* as YYYY-MM-DD.
+ * Antes muchos pages usaban `new Date()` (TZ del browser) lo que generaba
+ * inconsistencias entre clientes en diferentes zonas vs el tenant configurado.
+ */
+export function tenantToday(settings: FormatSettings | null): string {
+  const tz = settings?.timezone || 'America/Mexico_City';
+  // sv-SE → ISO 8601 (YYYY-MM-DD HH:mm:ss). Tomamos la parte de fecha.
+  const formatted = new Date().toLocaleString('sv-SE', { timeZone: tz });
+  return formatted.split(' ')[0] ?? '';
+}
+
+/**
+ * Returns the UTC instant corresponding to the start of a tenant calendar day.
+ * Day param can be a Date or YYYY-MM-DD string. If undefined, uses tenant today.
+ */
+export function tenantStartOfDayUtc(
+  day: Date | string | undefined,
+  settings: FormatSettings | null
+): Date {
+  const tz = settings?.timezone || 'America/Mexico_City';
+  const dayStr = typeof day === 'string'
+    ? day
+    : day
+      ? day.toLocaleString('sv-SE', { timeZone: tz }).split(' ')[0]
+      : tenantToday(settings);
+
+  // Estrategia: construye una fecha "en la TZ del tenant a las 00:00" usando
+  // un offset calculado para esa fecha (DST-aware). `Intl.DateTimeFormat` con
+  // `timeZoneName: 'shortOffset'` da el offset GMT±HH:MM exacto.
+  const probe = new Date(`${dayStr}T00:00:00Z`);
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    timeZoneName: 'shortOffset',
+  });
+  const parts = dtf.formatToParts(probe);
+  const offsetPart = parts.find((p) => p.type === 'timeZoneName')?.value ?? 'GMT+0';
+  // shortOffset format: "GMT-7" or "GMT-07:00" or "GMT"
+  const m = offsetPart.match(/GMT(?:([+-])(\d{1,2})(?::?(\d{2}))?)?/);
+  let offsetMinutes = 0;
+  if (m && m[1]) {
+    const sign = m[1] === '-' ? -1 : 1;
+    const hh = parseInt(m[2] ?? '0', 10);
+    const mm = parseInt(m[3] ?? '0', 10);
+    offsetMinutes = sign * (hh * 60 + mm);
+  }
+  // local 00:00 in tenant TZ → UTC = local - offsetMinutes
+  return new Date(probe.getTime() - offsetMinutes * 60_000);
+}
+
+/**
+ * Returns YYYY-MM-DD for the Monday-aligned start of the tenant's current week.
+ * Lunes como inicio de semana (es-MX/MX común). Cambiar a domingo = día 0
+ * si tu app usa esa convención.
+ */
+export function tenantStartOfWeek(settings: FormatSettings | null): string {
+  const today = tenantToday(settings);
+  const [y, m, d] = today.split('-').map(Number);
+  if (!y || !m || !d) return today;
+  const noon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  // 0 = Sunday … 6 = Saturday → lunes-aligned: (dow + 6) % 7
+  const dow = noon.getUTCDay();
+  const diff = (dow + 6) % 7;
+  noon.setUTCDate(noon.getUTCDate() - diff);
+  return noon.toISOString().slice(0, 10);
+}

--- a/apps/web/src/stores/useRouteStore.ts
+++ b/apps/web/src/stores/useRouteStore.ts
@@ -149,7 +149,13 @@ interface RouteStore {
 
   // Actions - Statistics
   updateStatistics: (stats: Partial<RouteStatistics>) => void;
-  calculateStatistics: () => void;
+  /**
+   * Recalcula estadísticas usando el día calendario del tenant.
+   * `tenantTodayDate` opcional: pasar `tenantToday()` desde `useFormatters`
+   * para que "rutas de hoy" filtre por el día calendario tenant en lugar
+   * del día calendario del browser.
+   */
+  calculateStatistics: (tenantTodayDate?: string) => void;
 
   // Computed
   getFilteredRoutes: () => Route[];
@@ -357,15 +363,19 @@ const useRouteStore = create<RouteStore>()(
             state.statistics = { ...state.statistics, ...stats };
           }),
 
-        calculateStatistics: () =>
+        calculateStatistics: (tenantTodayDate?: string) =>
           set(state => {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
+            // Si recibimos `tenantTodayDate` (YYYY-MM-DD) usamos ese día como
+            // "hoy"; sino caemos al browser local (legacy). Compara extrayendo
+            // la parte de fecha del campo `date` para evitar drifts por TZ.
+            const todayKey = tenantTodayDate ?? (() => {
+              const t = new Date();
+              return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
+            })();
 
             const todayRoutes = state.routes.filter(r => {
-              const routeDate = new Date(r.date);
-              routeDate.setHours(0, 0, 0, 0);
-              return routeDate.getTime() === today.getTime();
+              const dateStr = typeof r.date === 'string' ? r.date : new Date(r.date).toISOString();
+              return dateStr.slice(0, 10) === todayKey;
             });
 
             const activeRoutes = todayRoutes.filter(

--- a/libs/HandySuites.Application/Common/Interfaces/ITenantTimeZoneService.cs
+++ b/libs/HandySuites.Application/Common/Interfaces/ITenantTimeZoneService.cs
@@ -1,0 +1,51 @@
+using HandySuites.Domain.Entities;
+
+namespace HandySuites.Application.Common.Interfaces;
+
+/// <summary>
+/// Helper para alinear cálculos de fecha (hoy, esta semana, etc.) con la
+/// zona horaria configurada por el tenant en <c>CompanySetting.Timezone</c>
+/// (ej. <c>America/Mazatlan</c>, <c>America/Mexico_City</c>).
+///
+/// Reportado 2026-05-06: vendedor en Mazatlán (UTC-7) veía pings del 5 mayo
+/// 17:19 (=00:19 UTC del 6) como si fueran de "hoy" porque el server filtraba
+/// con <c>DateTime.UtcNow.Date</c> sin convertir a TZ tenant.
+///
+/// Uso típico (filtro "hoy" para una query):
+/// <code>
+/// var (inicioUtc, finUtc) = await _tenantTz.GetTenantDayWindowUtcAsync();
+/// var ventas = await db.Pedidos
+///     .Where(p => p.TenantId == tenantId &amp;&amp;
+///                 p.CreadoEn &gt;= inicioUtc &amp;&amp; p.CreadoEn &lt; finUtc)
+///     .ToListAsync();
+/// </code>
+/// </summary>
+public interface ITenantTimeZoneService
+{
+    /// <summary>Resuelve el TZ del tenant actual (cache scoped). Default
+    /// <c>America/Mexico_City</c> si no está configurado o el id no es válido.</summary>
+    Task<TimeZoneInfo> GetTenantTimeZoneAsync(CancellationToken ct = default);
+
+    /// <summary>Resuelve el TZ de un tenant específico (útil para code que no
+    /// está scoped al tenant del request, e.g. background jobs por tenant).</summary>
+    Task<TimeZoneInfo> GetTimeZoneForTenantAsync(int tenantId, CancellationToken ct = default);
+
+    /// <summary>Fecha "hoy" en TZ del tenant actual. Para Mazatlán a las
+    /// 00:43 hora local del 6 mayo (= 7:43 UTC), retorna <c>2026-05-06</c>
+    /// — NO el día UTC.</summary>
+    Task<DateOnly> GetTenantTodayAsync(CancellationToken ct = default);
+
+    /// <summary>Convierte una fecha tenant a window UTC <c>[inicio, fin)</c>
+    /// para usar en filtros EF. Si <paramref name="dia"/> es null, usa "hoy"
+    /// del tenant.</summary>
+    Task<(DateTime InicioUtc, DateTime FinUtc)> GetTenantDayWindowUtcAsync(
+        DateOnly? dia = null, CancellationToken ct = default);
+
+    /// <summary>Convierte una fecha calendario tenant a un instante UTC que
+    /// representa <c>00:00:00</c> en TZ tenant. Útil para `CapturadoEn >= X`.</summary>
+    Task<DateTime> ConvertTenantDateToUtcAsync(DateOnly tenantDate, CancellationToken ct = default);
+
+    /// <summary>Convierte un instante UTC al `DateOnly` del día calendario
+    /// en TZ tenant. Útil para almacenar `DiaServicio`.</summary>
+    Task<DateOnly> GetTenantDayFromUtcAsync(DateTime utcInstant, CancellationToken ct = default);
+}

--- a/libs/HandySuites.Application/Tracking/Interfaces/IUbicacionVendedorRepository.cs
+++ b/libs/HandySuites.Application/Tracking/Interfaces/IUbicacionVendedorRepository.cs
@@ -18,8 +18,14 @@ public interface IUbicacionVendedorRepository
     /// </summary>
     Task<List<UltimaUbicacionDto>> ObtenerUltimasAsync(int tenantId, List<int>? usuarioIds = null);
 
-    /// <summary>Recorrido del día completo (todos los pings ordenados temporalmente).</summary>
-    Task<List<UbicacionVendedorDto>> ObtenerRecorridoDelDiaAsync(int tenantId, int usuarioId, DateOnly dia);
+    /// <summary>Recorrido entre <paramref name="inicioUtc"/> y <paramref name="finUtc"/>
+    /// (todos los pings ordenados temporalmente). El caller es responsable de
+    /// calcular el window en TZ tenant — usar <c>ITenantTimeZoneService.GetTenantDayWindowUtcAsync</c>.
+    /// Filtra por <c>CapturadoEn</c> (UTC) en lugar de <c>DiaServicio</c> para
+    /// evitar dependencia del campo, que históricamente se almacenó en UTC y
+    /// puede no coincidir con el día calendario tenant.</summary>
+    Task<List<UbicacionVendedorDto>> ObtenerRecorridoEntreAsync(
+        int tenantId, int usuarioId, DateTime inicioUtc, DateTime finUtc);
 }
 
 public interface ISubscriptionFeatureGuard

--- a/libs/HandySuites.Application/Tracking/Services/UbicacionVendedorService.cs
+++ b/libs/HandySuites.Application/Tracking/Services/UbicacionVendedorService.cs
@@ -1,3 +1,4 @@
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.Tracking.DTOs;
 using HandySuites.Application.Tracking.Interfaces;
 using HandySuites.Domain.Entities;
@@ -33,15 +34,18 @@ public class UbicacionVendedorService
     private readonly IUbicacionVendedorRepository _repo;
     private readonly ISubscriptionFeatureGuard _guard;
     private readonly ICurrentTenant _tenant;
+    private readonly ITenantTimeZoneService _tenantTz;
 
     public UbicacionVendedorService(
         IUbicacionVendedorRepository repo,
         ISubscriptionFeatureGuard guard,
-        ICurrentTenant tenant)
+        ICurrentTenant tenant,
+        ITenantTimeZoneService tenantTz)
     {
         _repo = repo;
         _guard = guard;
         _tenant = tenant;
+        _tenantTz = tenantTz;
     }
 
     /// <summary>
@@ -113,6 +117,16 @@ public class UbicacionVendedorService
         if (accepted.Count == 0)
             return new UbicacionBatchResultDto { Aceptados = 0, Duplicados = request.Pings.Count };
 
+        // DiaServicio se calcula en TZ del tenant (no UTC) para que las queries
+        // por "día calendario tenant" funcionen correctamente. Reportado
+        // 2026-05-06: ping de 17:19 Mazatlán (=00:19 UTC del día siguiente)
+        // se almacenaba con DiaServicio = día UTC (incorrecto).
+        var tenantTzInfo = await _tenantTz.GetTenantTimeZoneAsync();
+        DateOnly DiaServicioParaUtc(DateTime utc) =>
+            DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(
+                utc.Kind == DateTimeKind.Utc ? utc : DateTime.SpecifyKind(utc, DateTimeKind.Utc),
+                tenantTzInfo));
+
         var entidades = accepted
             .Select(p => new UbicacionVendedor
             {
@@ -124,7 +138,7 @@ public class UbicacionVendedorService
                 Tipo = p.Tipo,
                 CapturadoEn = p.CapturadoEn,
                 ReferenciaId = p.ReferenciaId,
-                DiaServicio = DateOnly.FromDateTime(p.CapturadoEn),
+                DiaServicio = DiaServicioParaUtc(p.CapturadoEn),
                 Activo = true,
                 CreadoEn = ahora,
                 CreadoPor = _tenant.UserId,
@@ -162,6 +176,7 @@ public class UbicacionVendedorService
     public Task<List<UltimaUbicacionDto>> ObtenerUltimasAsync(List<int>? usuarioIds = null)
         => _repo.ObtenerUltimasAsync(_tenant.TenantId, usuarioIds);
 
-    public Task<List<UbicacionVendedorDto>> ObtenerRecorridoDelDiaAsync(int usuarioId, DateOnly dia)
-        => _repo.ObtenerRecorridoDelDiaAsync(_tenant.TenantId, usuarioId, dia);
+    public Task<List<UbicacionVendedorDto>> ObtenerRecorridoEntreAsync(
+        int usuarioId, DateTime inicioUtc, DateTime finUtc)
+        => _repo.ObtenerRecorridoEntreAsync(_tenant.TenantId, usuarioId, inicioUtc, finUtc);
 }

--- a/libs/HandySuites.Infrastructure/ActivityTracking/Repositories/ActivityTrackingRepository.cs
+++ b/libs/HandySuites.Infrastructure/ActivityTracking/Repositories/ActivityTrackingRepository.cs
@@ -1,4 +1,5 @@
 using HandySuites.Application.ActivityTracking.Interfaces;
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Domain.Entities;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -8,10 +9,12 @@ namespace HandySuites.Infrastructure.ActivityTracking.Repositories;
 public class ActivityTrackingRepository : IActivityTrackingRepository
 {
     private readonly HandySuitesDbContext _context;
+    private readonly ITenantTimeZoneService _tenantTz;
 
-    public ActivityTrackingRepository(HandySuitesDbContext context)
+    public ActivityTrackingRepository(HandySuitesDbContext context, ITenantTimeZoneService tenantTz)
     {
         _context = context;
+        _tenantTz = tenantTz;
     }
 
     public async Task<ActivityLog> CreateActivityLogAsync(ActivityLog activityLog)
@@ -145,11 +148,25 @@ public class ActivityTrackingRepository : IActivityTrackingRepository
 
     public async Task<IEnumerable<object>> GetActivityChartDataAsync(int tenantId, int days = 7)
     {
-        var startDate = DateTime.UtcNow.Date.AddDays(-days);
+        // Ventana y agrupamiento en TZ tenant. SQL agrupa por UTC, así que
+        // traemos rows crudos y agrupamos por día tenant en memoria.
+        var todayTenant = await _tenantTz.GetTenantTodayAsync();
+        var startTenant = todayTenant.AddDays(-days);
+        var startUtc = await _tenantTz.ConvertTenantDateToUtcAsync(startTenant);
+        var tzInfo = await _tenantTz.GetTimeZoneForTenantAsync(tenantId);
 
-        var activityData = await _context.ActivityLogs
-            .Where(a => a.TenantId == tenantId && a.CreatedAt >= startDate)
-            .GroupBy(a => a.CreatedAt.Date)
+        var rawRows = await _context.ActivityLogs
+            .Where(a => a.TenantId == tenantId && a.CreatedAt >= startUtc)
+            .Select(a => new { a.CreatedAt, a.ActivityType, a.ActivityStatus, a.UserId })
+            .ToListAsync();
+
+        DateOnly TenantDayOf(DateTime utc) => DateOnly.FromDateTime(
+            TimeZoneInfo.ConvertTimeFromUtc(
+                utc.Kind == DateTimeKind.Utc ? utc : DateTime.SpecifyKind(utc, DateTimeKind.Utc),
+                tzInfo));
+
+        var activityData = rawRows
+            .GroupBy(a => TenantDayOf(a.CreatedAt))
             .Select(g => new
             {
                 date = g.Key,
@@ -158,16 +175,14 @@ public class ActivityTrackingRepository : IActivityTrackingRepository
                 errors = g.Count(x => x.ActivityStatus == "failed"),
                 uniqueUsers = g.Select(x => x.UserId).Distinct().Count()
             })
-            .OrderBy(x => x.date)
-            .ToListAsync();
+            .ToList();
 
-        // Llenar los días faltantes con ceros
         var chartData = new List<object>();
         for (int i = days; i >= 0; i--)
         {
-            var date = DateTime.UtcNow.Date.AddDays(-i);
+            var date = todayTenant.AddDays(-i);
             var dayData = activityData.FirstOrDefault(a => a.date == date);
-            
+
             chartData.Add(new
             {
                 date = date.ToString("MMM dd"),

--- a/libs/HandySuites.Infrastructure/Ai/Services/AiActionDetector.cs
+++ b/libs/HandySuites.Infrastructure/Ai/Services/AiActionDetector.cs
@@ -1,5 +1,6 @@
 using HandySuites.Application.Ai.DTOs;
 using HandySuites.Application.Ai.Interfaces;
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Domain.Entities;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -13,6 +14,7 @@ public class AiActionDetector : IAiActionDetector
     private readonly HandySuitesDbContext _db;
     private readonly IMemoryCache _cache;
     private readonly ILogger<AiActionDetector> _logger;
+    private readonly ITenantTimeZoneService _tenantTz;
 
     private const int MaxActions = 2;
     private const int ActionCreditCost = 2;
@@ -21,11 +23,13 @@ public class AiActionDetector : IAiActionDetector
     public AiActionDetector(
         HandySuitesDbContext db,
         IMemoryCache cache,
-        ILogger<AiActionDetector> logger)
+        ILogger<AiActionDetector> logger,
+        ITenantTimeZoneService tenantTz)
     {
         _db = db;
         _cache = cache;
         _logger = logger;
+        _tenantTz = tenantTz;
     }
 
     public async Task<List<AiSuggestedAction>> DetectActionsAsync(
@@ -106,12 +110,23 @@ public class AiActionDetector : IAiActionDetector
 
         if (clientesSinVisita.Count == 0) return;
 
-        var visitDtos = clientesSinVisita.Select((c, i) => new
+        // FechaProgramada en TZ tenant (no UTC del servidor) — antes "mañana
+        // 9am" se convertía a una hora rara para tenants en TZ negativa.
+        var hoyTenant = await _tenantTz.GetTenantTodayAsync();
+        var tzInfo = await _tenantTz.GetTenantTimeZoneAsync();
+        var visitDtos = clientesSinVisita.Select((c, i) =>
         {
-            ClienteId = c.Id,
-            FechaProgramada = DateTime.UtcNow.Date.AddDays(i < 3 ? 1 : 2).AddHours(9 + i),
-            TipoVisita = 0, // Rutina
-            Notas = "Visita programada por asistente IA"
+            var diaTenant = hoyTenant.AddDays(i < 3 ? 1 : 2);
+            var localDateTime = diaTenant.ToDateTime(new TimeOnly(9 + i, 0));
+            var localUnspecified = DateTime.SpecifyKind(localDateTime, DateTimeKind.Unspecified);
+            var fechaUtc = TimeZoneInfo.ConvertTimeToUtc(localUnspecified, tzInfo);
+            return new
+            {
+                ClienteId = c.Id,
+                FechaProgramada = fechaUtc,
+                TipoVisita = 0, // Rutina
+                Notas = "Visita programada por asistente IA"
+            };
         }).ToList();
 
         var clientNames = string.Join(", ", clientesSinVisita.Take(3).Select(c => c.Nombre));
@@ -189,8 +204,12 @@ public class AiActionDetector : IAiActionDetector
         var metaSugerida = Math.Ceiling(ventasUltimos30d * 1.1m / 100) * 100; // Round up to nearest 100
         if (metaSugerida < 1000) metaSugerida = 5000; // Minimum meaningful goal
 
-        var startOfNextMonth = new DateTime(now.Year, now.Month, 1).AddMonths(1);
-        var endOfNextMonth = startOfNextMonth.AddMonths(1).AddDays(-1);
+        // "Próximo mes" se calcula en calendario tenant — antes usaba mes UTC.
+        var hoyTenant = await _tenantTz.GetTenantTodayAsync();
+        var nextMonthTenant = new DateOnly(hoyTenant.Year, hoyTenant.Month, 1).AddMonths(1);
+        var endNextMonthTenant = nextMonthTenant.AddMonths(1).AddDays(-1);
+        var startOfNextMonth = await _tenantTz.ConvertTenantDateToUtcAsync(nextMonthTenant);
+        var endOfNextMonth = await _tenantTz.ConvertTenantDateToUtcAsync(endNextMonthTenant);
 
         var metaDto = new
         {
@@ -218,10 +237,12 @@ public class AiActionDetector : IAiActionDetector
     {
         if (actions.Count >= MaxActions) return;
 
-        // Check if user has a route for today/tomorrow
-        var today = DateTime.UtcNow.Date;
+        // "Hoy/mañana" en TZ tenant — antes usaba UTC del servidor.
+        var hoyTenant = await _tenantTz.GetTenantTodayAsync();
+        var todayUtc = await _tenantTz.ConvertTenantDateToUtcAsync(hoyTenant);
+        var dayAfterTomorrowUtc = await _tenantTz.ConvertTenantDateToUtcAsync(hoyTenant.AddDays(2));
         var hasRouteToday = await _db.RutasVendedor
-            .AnyAsync(r => r.UsuarioId == userId && r.Fecha >= today && r.Fecha < today.AddDays(2));
+            .AnyAsync(r => r.UsuarioId == userId && r.Fecha >= todayUtc && r.Fecha < dayAfterTomorrowUtc);
 
         if (hasRouteToday) return;
 
@@ -238,11 +259,12 @@ public class AiActionDetector : IAiActionDetector
 
         if (clientesParaRuta.Count < 2) return;
 
-        var tomorrow = today.AddDays(1);
+        var tomorrowTenant = hoyTenant.AddDays(1);
+        var tomorrow = await _tenantTz.ConvertTenantDateToUtcAsync(tomorrowTenant);
         var rutaDto = new
         {
             UsuarioId = userId,
-            Nombre = $"Ruta IA — {tomorrow:dd MMM yyyy}",
+            Nombre = $"Ruta IA — {tomorrowTenant:dd MMM yyyy}",
             Descripcion = "Ruta sugerida por asistente IA",
             Fecha = tomorrow,
             HoraInicioEstimada = new TimeSpan(9, 0, 0),
@@ -257,6 +279,7 @@ public class AiActionDetector : IAiActionDetector
         };
 
         var clientNames = string.Join(", ", clientesParaRuta.Take(3).Select(c => c.Nombre));
+        // tomorrowTenant declared above; rutaDto.Fecha is the UTC instant.
 
         actions.Add(new AiSuggestedAction(
             ActionId: Guid.NewGuid().ToString("N"),
@@ -303,10 +326,12 @@ public class AiActionDetector : IAiActionDetector
     {
         if (actions.Count >= MaxActions) return;
 
-        // Check if user already has a route for tomorrow
-        var tomorrow = DateTime.UtcNow.Date.AddDays(1);
+        // "Mañana" en TZ tenant — la ventana del día depende del calendario tenant.
+        var hoyTenant = await _tenantTz.GetTenantTodayAsync();
+        var tomorrow = await _tenantTz.ConvertTenantDateToUtcAsync(hoyTenant.AddDays(1));
+        var dayAfterTomorrow = await _tenantTz.ConvertTenantDateToUtcAsync(hoyTenant.AddDays(2));
         var hasRouteTomorrow = await _db.RutasVendedor
-            .AnyAsync(r => r.UsuarioId == userId && r.Fecha >= tomorrow && r.Fecha < tomorrow.AddDays(1));
+            .AnyAsync(r => r.UsuarioId == userId && r.Fecha >= tomorrow && r.Fecha < dayAfterTomorrow);
 
         if (hasRouteTomorrow) return;
 
@@ -379,10 +404,11 @@ public class AiActionDetector : IAiActionDetector
             current = nearest;
         }
 
+        var tomorrowTenant = hoyTenant.AddDays(1);
         var rutaDto = new
         {
             UsuarioId = userId,
-            Nombre = $"Ruta Optimizada IA — {tomorrow:dd MMM yyyy}",
+            Nombre = $"Ruta Optimizada IA — {tomorrowTenant:dd MMM yyyy}",
             Descripcion = "Ruta optimizada geográficamente por asistente IA",
             Fecha = tomorrow,
             HoraInicioEstimada = new TimeSpan(9, 0, 0),

--- a/libs/HandySuites.Infrastructure/Common/TenantTimeZoneService.cs
+++ b/libs/HandySuites.Infrastructure/Common/TenantTimeZoneService.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using HandySuites.Application.Common.Interfaces;
+using HandySuites.Infrastructure.Persistence;
+using HandySuites.Shared.Multitenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace HandySuites.Infrastructure.Common;
+
+/// <inheritdoc />
+public class TenantTimeZoneService : ITenantTimeZoneService
+{
+    /// <summary>Cache estático: el TZ del tenant cambia muy raramente
+    /// (admin lo configura 1 vez en setup). 1 lookup por tenant por proceso
+    /// es aceptable. Si el admin cambia el TZ, la app se reinicia (Railway
+    /// redeploy) y la cache se limpia. Para un cambio en caliente sin
+    /// redeploy, agregar un flush via SignalR si se necesita.</summary>
+    private static readonly ConcurrentDictionary<int, string> _tzCache = new();
+
+    private static readonly TimeZoneInfo _fallback;
+
+    static TenantTimeZoneService()
+    {
+        try { _fallback = TimeZoneInfo.FindSystemTimeZoneById("America/Mexico_City"); }
+        catch { _fallback = TimeZoneInfo.Utc; }
+    }
+
+    private readonly HandySuitesDbContext _db;
+    private readonly ICurrentTenant _currentTenant;
+
+    public TenantTimeZoneService(HandySuitesDbContext db, ICurrentTenant currentTenant)
+    {
+        _db = db;
+        _currentTenant = currentTenant;
+    }
+
+    public async Task<TimeZoneInfo> GetTenantTimeZoneAsync(CancellationToken ct = default)
+        => await GetTimeZoneForTenantAsync(_currentTenant.TenantId, ct);
+
+    public async Task<TimeZoneInfo> GetTimeZoneForTenantAsync(int tenantId, CancellationToken ct = default)
+    {
+        if (tenantId <= 0) return _fallback;
+        if (!_tzCache.TryGetValue(tenantId, out var tzId))
+        {
+            tzId = await _db.CompanySettings.AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(c => c.TenantId == tenantId)
+                .Select(c => c.Timezone)
+                .FirstOrDefaultAsync(ct) ?? "America/Mexico_City";
+            _tzCache[tenantId] = tzId;
+        }
+        try { return TimeZoneInfo.FindSystemTimeZoneById(tzId); }
+        catch { return _fallback; }
+    }
+
+    public async Task<DateOnly> GetTenantTodayAsync(CancellationToken ct = default)
+    {
+        var tz = await GetTenantTimeZoneAsync(ct);
+        var nowInTz = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz);
+        return DateOnly.FromDateTime(nowInTz);
+    }
+
+    public async Task<(DateTime InicioUtc, DateTime FinUtc)> GetTenantDayWindowUtcAsync(
+        DateOnly? dia = null, CancellationToken ct = default)
+    {
+        var tz = await GetTenantTimeZoneAsync(ct);
+        var fechaTenant = dia ?? DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));
+        var inicioLocalUnspec = DateTime.SpecifyKind(fechaTenant.ToDateTime(TimeOnly.MinValue), DateTimeKind.Unspecified);
+        var inicioUtc = TimeZoneInfo.ConvertTimeToUtc(inicioLocalUnspec, tz);
+        var finUtc = inicioUtc.AddDays(1);
+        return (inicioUtc, finUtc);
+    }
+
+    public async Task<DateTime> ConvertTenantDateToUtcAsync(DateOnly tenantDate, CancellationToken ct = default)
+    {
+        var tz = await GetTenantTimeZoneAsync(ct);
+        var localUnspec = DateTime.SpecifyKind(tenantDate.ToDateTime(TimeOnly.MinValue), DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(localUnspec, tz);
+    }
+
+    public async Task<DateOnly> GetTenantDayFromUtcAsync(DateTime utcInstant, CancellationToken ct = default)
+    {
+        var tz = await GetTenantTimeZoneAsync(ct);
+        // Defensive: si el instante viene sin Kind, asumir UTC.
+        var utc = utcInstant.Kind == DateTimeKind.Utc
+            ? utcInstant
+            : DateTime.SpecifyKind(utcInstant, DateTimeKind.Utc);
+        return DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(utc, tz));
+    }
+}

--- a/libs/HandySuites.Infrastructure/Repositories/Rutas/RutaVendedorRepository.cs
+++ b/libs/HandySuites.Infrastructure/Repositories/Rutas/RutaVendedorRepository.cs
@@ -1,3 +1,4 @@
+using HandySuites.Application.Common.Interfaces;
 using HandySuites.Application.Rutas.DTOs;
 using HandySuites.Application.Rutas.Interfaces;
 using HandySuites.Domain.Entities;
@@ -9,10 +10,12 @@ namespace HandySuites.Infrastructure.Repositories.Rutas;
 public class RutaVendedorRepository : IRutaVendedorRepository
 {
     private readonly HandySuitesDbContext _db;
+    private readonly ITenantTimeZoneService _tenantTz;
 
-    public RutaVendedorRepository(HandySuitesDbContext db)
+    public RutaVendedorRepository(HandySuitesDbContext db, ITenantTimeZoneService tenantTz)
     {
         _db = db;
+        _tenantTz = tenantTz;
     }
 
     public async Task<int> CrearAsync(RutaVendedor ruta)
@@ -190,7 +193,19 @@ public class RutaVendedorRepository : IRutaVendedorRepository
 
     public async Task<RutaVendedorDto?> ObtenerRutaDelDiaAsync(int tenantId, int usuarioId, DateTime? fecha = null)
     {
-        var fechaBusqueda = fecha?.Date ?? DateTime.Today;
+        // Día calendario en TZ tenant. `fecha` (si viene del caller) ya es UTC
+        // representando un día tenant; lo convertimos a DateOnly tenant. Si no
+        // viene, usamos "hoy" en TZ tenant.
+        DateOnly diaBusqueda;
+        if (fecha.HasValue)
+        {
+            diaBusqueda = await _tenantTz.GetTenantDayFromUtcAsync(fecha.Value);
+        }
+        else
+        {
+            diaBusqueda = await _tenantTz.GetTenantTodayAsync();
+        }
+        var (inicioUtc, finUtc) = await _tenantTz.GetTenantDayWindowUtcAsync(diaBusqueda);
 
         var ruta = await _db.RutasVendedor
             .AsNoTracking()
@@ -201,7 +216,7 @@ public class RutaVendedorRepository : IRutaVendedorRepository
             .FirstOrDefaultAsync(r =>
                 r.TenantId == tenantId &&
                 r.UsuarioId == usuarioId &&
-                r.Fecha.Date == fechaBusqueda &&
+                r.Fecha >= inicioUtc && r.Fecha < finUtc &&
                 r.Activo == true &&
                 !r.EsTemplate);
 
@@ -210,6 +225,9 @@ public class RutaVendedorRepository : IRutaVendedorRepository
 
     public async Task<List<RutaVendedorDto>> ObtenerRutasPendientesAsync(int tenantId, int usuarioId)
     {
+        // "Hoy" en TZ tenant (no día UTC del servidor).
+        var hoyTenant = await _tenantTz.GetTenantTodayAsync();
+        var (hoyInicioUtc, _) = await _tenantTz.GetTenantDayWindowUtcAsync(hoyTenant);
         var rutas = await _db.RutasVendedor
             .AsNoTracking()
             .Include(r => r.Usuario)
@@ -220,7 +238,7 @@ public class RutaVendedorRepository : IRutaVendedorRepository
                 r.TenantId == tenantId &&
                 r.UsuarioId == usuarioId &&
                 (r.Estado == EstadoRuta.Planificada || r.Estado == EstadoRuta.EnProgreso) &&
-                r.Fecha >= DateTime.Today &&
+                r.Fecha >= hoyInicioUtc &&
                 r.Activo == true &&
                 !r.EsTemplate)
             .OrderBy(r => r.Fecha)

--- a/libs/HandySuites.Infrastructure/Repositories/Tracking/UbicacionVendedorRepository.cs
+++ b/libs/HandySuites.Infrastructure/Repositories/Tracking/UbicacionVendedorRepository.cs
@@ -89,10 +89,14 @@ public class UbicacionVendedorRepository : IUbicacionVendedorRepository
     // Mapeo a UltimaUbicacionDto se hace en C# después del query.
     private record UltimaUbicacionRaw(int usuario_id, decimal latitud, decimal longitud, int tipo, DateTime capturado_en);
 
-    public Task<List<UbicacionVendedorDto>> ObtenerRecorridoDelDiaAsync(int tenantId, int usuarioId, DateOnly dia)
+    public Task<List<UbicacionVendedorDto>> ObtenerRecorridoEntreAsync(
+        int tenantId, int usuarioId, DateTime inicioUtc, DateTime finUtc)
     {
         return _db.UbicacionesVendedor.AsNoTracking()
-            .Where(u => u.TenantId == tenantId && u.UsuarioId == usuarioId && u.DiaServicio == dia)
+            .Where(u => u.TenantId == tenantId
+                     && u.UsuarioId == usuarioId
+                     && u.CapturadoEn >= inicioUtc
+                     && u.CapturadoEn < finUtc)
             .OrderBy(u => u.CapturadoEn)
             .Select(u => new UbicacionVendedorDto
             {


### PR DESCRIPTION
## Summary

Promociona a producción el fix sistémico de TZ tenant (PR #53).

Único cambio nuevo en staging vs main:
- `ddbba161` fix: TZ tenant systemic — todos los filtros de fecha respetan zona del tenant
- `858be0e1` Merge PR #53

## Pre-Deploy Checklist

- [x] Tests verdes (500 API + 44 Mobile)
- [x] Type-check web clean
- [x] Sin env vars nuevas
- [x] Sin DB migrations
- [x] Sin CI/CD changes
- [x] Breaking API interno (`ObtenerRecorridoDelDiaAsync` → `ObtenerRecorridoEntreAsync`) ya actualizado en consumer interno

## Bug que cierra

Reportado prod 2026-05-06 admin@jeyma.com: actividad GPS de Rodrigo del 5 mayo 5pm Mazatlán (=00:19 UTC del 6) aparecía como "hoy 6 may". Mismo patrón en dashboard, cobranza, calendar, listas, metas, etc. Fix systemic via `ITenantTimeZoneService` (backend) + `tenantToday/tenantStartOfDayUtc/tenantStartOfWeek` (frontend).

## Post-merge

- Railway redeploy automático (path filter `apps/api/**`, `apps/mobile/**`, `libs/**`).
- Vercel redeploy automático (path filter `apps/web/**`).
- No EAS update necesario (mobile-app no tocada).
