### PR TITLE
fix(backend): auto-fill Pedido coords desde Cliente en SaveChangesAsy…

### DIFF
--- a/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
+++ b/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
@@ -124,6 +124,54 @@ public class HandySuitesDbContext : DbContext
             }
         }
 
+        // Auto-fill `Pedido.Latitud/Longitud` desde `Cliente` cuando el caller
+        // no las provee (mobile build viejo, GPS off, flujo de venta directa
+        // que no captura, etc.). Single chokepoint EF Core 8 idiomático
+        // (`ChangeTracker` en `SaveChangesAsync` override) — corre uniforme
+        // para sync, venta directa, web admin y cualquier endpoint futuro.
+        //
+        // Si el caller pasa coords reales (más precisas, GPS device-fresh)
+        // se preservan. Sólo se rellena cuando ambas vienen null y el cliente
+        // tiene coords. La pantalla GPS Activity filtra `WHERE Latitud IS NOT
+        // NULL`, así garantizamos que cada pedido aparezca con su link "Ver
+        // pedido #X" en el timeline. Reportado prod 2026-05-06: pedidos de
+        // Rodrigo (Jeyma, venta directa) llegaban sin coords y no se veían
+        // en `/team/{id}/gps`. La migration `BackfillPedidoCoordsFromCliente`
+        // (5 mayo) hizo el backfill histórico una vez; este interceptor
+        // mantiene la propiedad invariante hacia adelante.
+        var pedidosNuevosSinCoords = ChangeTracker.Entries<Pedido>()
+            .Where(e => e.State == EntityState.Added
+                     && e.Entity.Latitud == null
+                     && e.Entity.Longitud == null
+                     && e.Entity.ClienteId > 0)
+            .ToList();
+
+        if (pedidosNuevosSinCoords.Count > 0)
+        {
+            var clienteIds = pedidosNuevosSinCoords
+                .Select(e => e.Entity.ClienteId)
+                .Distinct()
+                .ToList();
+
+            // 1 query batch — si N pedidos refieren a M ≤ N clientes, traemos
+            // sólo los M clientes con coords no-null. Diccionario en memoria.
+            var coordsPorCliente = await Clientes.AsNoTracking()
+                .Where(c => clienteIds.Contains(c.Id)
+                         && c.Latitud != null
+                         && c.Longitud != null)
+                .Select(c => new { c.Id, c.Latitud, c.Longitud })
+                .ToDictionaryAsync(c => c.Id, cancellationToken);
+
+            foreach (var entry in pedidosNuevosSinCoords)
+            {
+                if (coordsPorCliente.TryGetValue(entry.Entity.ClienteId, out var coords))
+                {
+                    entry.Entity.Latitud = coords.Latitud;
+                    entry.Entity.Longitud = coords.Longitud;
+                }
+            }
+        }
+
         return await base.SaveChangesAsync(cancellationToken);
     }
 


### PR DESCRIPTION
…nc interceptor

Single chokepoint EF Core 8 idiomático para garantizar que todo Pedido nuevo tenga ubicación cuando el caller no la provee — corre uniforme para sync mobile, venta directa, web admin y cualquier endpoint futuro.

Bug raíz: la pantalla `/team/{id}/gps` filtra `WHERE Latitud IS NOT NULL` para plotear en mapa Leaflet. Pedidos creados desde mobile flujo "venta directa" llegaban con `latitud=null/longitud=null` porque `createVentaDirectaOffline` (mobile) no llama a `captureOrderLocation` (sólo `createPedidoOffline` lo hace, gap del commit b557740d). Resultado: los 13 pedidos de Rodrigo (Jeyma) hoy 6 mayo no aparecían con su link "Ver pedido #X" en el timeline GPS.

La migration `BackfillPedidoCoordsFromCliente` (5 mayo) hizo el backfill histórico una vez, pero al ser one-shot no cubre pedidos nuevos. Agregar un worker periódico es workaround — el patrón EF Core es interceptar `SaveChangesAsync` en el DbContext y poblar ahí.

Implementación:
- Override existente de `SaveChangesAsync` en `HandySalesDbContext.cs` ya maneja `AuditableEntity` (CreadoEn, soft delete). Agregamos un segundo bloque que detecta `Pedido` en estado `Added` con `Latitud == null && Longitud == null && ClienteId > 0`.
- 1 query batch a `Clientes` por todos los `ClienteId` distintos del batch, filtrando los que tienen coords. Diccionario en memoria.
- Por cada Pedido nuevo sin coords, busca su cliente en el dict y copia lat/lng. Si el cliente tampoco tiene coords, se queda null (genuinamente sin ubicación).

Características:
- Coords del caller (mobile que SÍ captura GPS device-fresh, más precisas) se preservan — sólo se rellena cuando ambas vienen null.
- Idiomático EF Core 8 (Microsoft Learn confirma este patrón con 3 ejemplos: TaggedBy, soft delete, audit fields).
- Single chokepoint — no hace falta tocar SyncRepository, MobileVentaDirectaEndpoints, ni PedidoRepository individualmente.
- 500 API + 44 Mobile tests pass.