### PR TITLE
fix(mobile): captura GPS en createVentaDirectaOffline (CRIT-2 audit)

### DIFF
--- a/apps/mobile-app/src/db/actions.ts
+++ b/apps/mobile-app/src/db/actions.ts
@@ -269,6 +269,42 @@ export async function createVentaDirectaOffline(
   // v16: cálculo branched per-item (ver comentario en createPedidoOffline).
   const { subtotal, descuentoTotal, impuesto, total } = calculateOrderTotals(items);
 
+  // CRIT-2 fix (audit 2026-05-06): captura GPS antes de la transacción WDB.
+  // Antes esta función se olvidaba el bloque que `createPedidoOffline` SÍ
+  // tenía → todos los pedidos de venta directa llegaban al backend con
+  // `latitud=null/longitud=null` y desaparecían de GPS Activity (filtra
+  // `WHERE Latitud IS NOT NULL`). Era la causa raíz que estábamos
+  // enmascarando server-side con el `SaveChangesAsync` interceptor que
+  // rellenaba desde Cliente.coords. Ahora con captura device-fresh, el
+  // mapa muestra la ubicación REAL del vendedor (no la dirección fija
+  // del cliente).
+  let capturedLat: number | null = null;
+  let capturedLng: number | null = null;
+  let gpsCaptured = false;
+  try {
+    const cliente = await database.get<Cliente>('clientes').find(clienteId);
+    const captured = await captureOrderLocation({
+      latitud: (cliente as any).latitud,
+      longitud: (cliente as any).longitud,
+    });
+    if (captured) {
+      capturedLat = captured.latitude;
+      capturedLng = captured.longitude;
+      gpsCaptured = true;
+    }
+  } catch {
+    // Cliente no encontrado o error en captura — venta directa se crea sin coords.
+  }
+
+  if (!gpsCaptured) {
+    Toast.show({
+      type: 'info',
+      text1: 'Venta registrada',
+      text2: 'Sin ubicación GPS — activa el GPS para mejor seguimiento.',
+      visibilityTime: 5000,
+    });
+  }
+
   return database.write(async () => {
     const pedido = await database.get<Pedido>('pedidos').create((record: any) => {
       record.serverId = null;
@@ -284,6 +320,8 @@ export async function createVentaDirectaOffline(
       record.impuesto = impuesto;
       record.total = total;
       record.notas = notas || null;
+      record.latitud = capturedLat;
+      record.longitud = capturedLng;
       record.activo = true;
       record.version = 1;
       record.updatedAt = new Date();


### PR DESCRIPTION
Bug raíz que estaba siendo enmascarado server-side: `createVentaDirectaOffline` se olvidaba el bloque de captura GPS que `createPedidoOffline` SÍ tenía desde el commit b557740d. Resultado: todos los pedidos hechos vía venta directa llegaban al backend con `latitud=null/longitud=null` y desaparecían de `/team/{id}/gps` (filtra `WHERE Latitud IS NOT NULL`).

Para enmascarar lo veníamos rellenando server-side en el `SaveChangesAsync` interceptor del DbContext desde Cliente.coords (PR #55 — workaround #2 del audit). Eso "funcionaba" pero el mapa mostraba la dirección fija de cada cliente en vez de la ubicación REAL del vendedor. Mucha pérdida de información para el caso GPS Activity.

Fix: copiar el bloque de [`actions.ts:160-196`](apps/mobile-app/src/db/actions.ts#L160-L196) (cascada device-fresh → lastKnown → cliente coords → null + Toast info si todos fallan), sentando coords device-fresh en `record.latitud/longitud` antes del SaveChanges.

Resultado: ventas directas nuevas llegan con coords reales del vendedor en el momento exacto. La timeline GPS muestra el track real del recorrido.

NOTA EAS UPDATE: este cambio es mobile-only y requiere `eas update` post-merge a main para que vendedores en producción lo reciban OTA. NO ejecutar `eas update` automático — esperar autorización explícita del owner (proyecto memory: feedback_no_auto_eas_build).

Tests: type-check mobile clean. Sin tests Jest porque el proyecto aún no tiene Jest setup (BUG-4 audit, en otro sprint). Validación manual via emulador post-EAS-update.