### PR TITLE
Merge staging → main: audit cleanup + cierre jornada cliente-side

### DIFF
--- a/apps/api/src/HandySuites.Api/Endpoints/AiEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/AiEndpoints.cs
@@ -77,6 +77,12 @@ public static class AiEndpoints
         return (tenantId, userId);
     }
 
+    // Rate-limit in-memory por instancia. Decisión consciente — Railway corre
+    // 1 instancia API hoy, así que un dict static funciona y evita la carga
+    // operacional + costo de Redis para un caso no-crítico.
+    // Si en el futuro escalamos a multi-instancia, migrar a `IDistributedCache`
+    // (Redis) o `Microsoft.AspNetCore.RateLimiting`. NO tocar mientras sigamos
+    // single-instance — bumpear el límite por usuario si hace falta.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (int Count, DateTime WindowStart)> _rateLimitState = new();
 
     private static bool CheckRateLimit(IMemoryCache cache, string key, int maxRequests)

--- a/apps/api/src/HandySuites.Api/Endpoints/DeviceSessionEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/DeviceSessionEndpoints.cs
@@ -121,7 +121,8 @@ public static class DeviceSessionEndpoints
             LogoutDeviceDto? dto,
             [FromServices] DeviceSessionService servicio,
             [FromServices] ICurrentTenant currentTenant,
-            [FromServices] IHttpClientFactory httpClientFactory) =>
+            [FromServices] IHttpClientFactory httpClientFactory,
+            [FromServices] ILoggerFactory loggerFactory) =>
         {
             if (currentTenant.Role is not ("ADMIN" or "SUPER_ADMIN")) return Results.Forbid();
             var cantidad = await servicio.CerrarTodasSesionesUsuarioAsync(usuarioId, dto?.Reason);
@@ -141,7 +142,14 @@ public static class DeviceSessionEndpoints
                         data = new Dictionary<string, string> { ["type"] = "security.session_revoked" }
                     });
                 }
-                catch { /* fire-and-forget */ }
+                catch (Exception ex)
+                {
+                    // Fire-and-forget: la sesión ya se cerró, el push es nice-to-have.
+                    // Log Debug para que aparezca en Vercel/Railway logs si recurre,
+                    // sin contaminar Error level (que dispara alertas).
+                    loggerFactory.CreateLogger("DeviceSessionEndpoints")
+                        .LogDebug(ex, "Push notification post-revoke falló (fire-and-forget) usuarioId={UsuarioId}", usuarioId);
+                }
             }
 
             return Results.Ok(new { mensaje = $"Se cerraron {cantidad} sesiones del usuario", cantidad });

--- a/apps/api/src/HandySuites.Api/Endpoints/MetaVendedorEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/MetaVendedorEndpoints.cs
@@ -29,6 +29,7 @@ public static class MetaVendedorEndpoints
             [FromServices] MetaVendedorService servicio,
             [FromServices] IHttpClientFactory httpClientFactory,
             [FromServices] ITenantContextService tenantContext,
+            [FromServices] ILoggerFactory loggerFactory,
             HttpContext context) =>
         {
             // Admin only
@@ -68,7 +69,13 @@ public static class MetaVendedorEndpoints
                     });
                 }
             }
-            catch { /* fire-and-forget */ }
+            catch (Exception ex)
+            {
+                // Fire-and-forget: la meta ya se creó, el push es nice-to-have.
+                // Debug level — visible en logs si recurre, sin alertar.
+                loggerFactory.CreateLogger("MetaVendedorEndpoints")
+                    .LogDebug(ex, "Push notification post-meta-create falló (fire-and-forget) usuarioId={UsuarioId}", dto.UsuarioId);
+            }
 
             return Results.Created($"/api/metas/{id}", new { id });
         });

--- a/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionCreateDtoValidatorTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionCreateDtoValidatorTests.cs
@@ -53,7 +53,7 @@ namespace HandySuites.Tests.Application.Promociones
                 ProductoIds = new List<int> { 1 },
                 DescuentoPorcentaje = 15,
                 FechaInicio = DateTime.Today,
-                FechaFin = DateTime.Now.AddMonths(1),
+                FechaFin = DateTime.UtcNow.AddMonths(1),
                 Descripcion = "descripción"
             };
 

--- a/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionEndpointsTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionEndpointsTests.cs
@@ -33,8 +33,8 @@ namespace HandySuites.Tests.Integration.Promociones
                 ProductoIds = new List<int> { 1 },
                 Descripcion = "Promocion Descripcion",
                 DescuentoPorcentaje = 10,
-                FechaInicio = DateTime.Now,
-                FechaFin = DateTime.Now.AddYears(2)
+                FechaInicio = DateTime.UtcNow,
+                FechaFin = DateTime.UtcNow.AddYears(2)
             };
 
             var response = await _client.PostAsJsonAsync("/promociones", dto);
@@ -49,8 +49,8 @@ namespace HandySuites.Tests.Integration.Promociones
                 Nombre = "Actualización",
                 ProductoIds = new List<int> { 1 },
                 DescuentoPorcentaje = 10,
-                FechaInicio = DateTime.Now,
-                FechaFin = DateTime.Now.AddYears(2)
+                FechaInicio = DateTime.UtcNow,
+                FechaFin = DateTime.UtcNow.AddYears(2)
             };
 
             var response = await _client.PutAsJsonAsync("/promociones/9999", dto);

--- a/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionServiceTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Promociones/PromocionServiceTests.cs
@@ -49,8 +49,8 @@ namespace HandySuites.Tests.Application.Promociones
                 ProductoIds = new List<int> { 1 },
                 Descripcion = "Descripcion",
                 DescuentoPorcentaje = 10,
-                FechaInicio = DateTime.Now,
-                FechaFin = DateTime.Now.AddYears(2)
+                FechaInicio = DateTime.UtcNow,
+                FechaFin = DateTime.UtcNow.AddYears(2)
             };
 
             _repoMock.Setup(r => r.ExisteNombreAsync(dto.Nombre, 1, null)).ReturnsAsync(false);
@@ -70,8 +70,8 @@ namespace HandySuites.Tests.Application.Promociones
                 ProductoIds = new List<int> { 1 },
                 Descripcion = "Descripcion",
                 DescuentoPorcentaje = 10,
-                FechaInicio = DateTime.Now,
-                FechaFin = DateTime.Now.AddYears(2)
+                FechaInicio = DateTime.UtcNow,
+                FechaFin = DateTime.UtcNow.AddYears(2)
             };
 
             _repoMock.Setup(r => r.ExisteNombreAsync(dto.Nombre, 1, 99)).ReturnsAsync(false);

--- a/apps/api/tests/HandySuites.Tests/Integration/Common/HandySalesTestSeeder.cs
+++ b/apps/api/tests/HandySuites.Tests/Integration/Common/HandySalesTestSeeder.cs
@@ -46,22 +46,22 @@ public static class HandySuitesTestSeeder
 
         // Usuarios para tenant 1 - IDs 1, 123, 124
         // EmailVerificado=true so login works in tests
-        db.Usuarios.Add(new Usuario { Id = 1, Email = "test@user.com", Nombre = "Pedro Picapiedra", RolExplicito = "ADMIN", RoleId = 1, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 1, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 123, Email = "user123@test.com", Nombre = "Usuario 123", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 1, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 124, Email = "user124@test.com", Nombre = "Usuario 124", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 1, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 125, Email = "user125@test.com", Nombre = "Usuario 125", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 2, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 1, Email = "test@user.com", Nombre = "Pedro Picapiedra", RolExplicito = "ADMIN", RoleId = 1, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 1, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 123, Email = "user123@test.com", Nombre = "Usuario 123", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 1, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 124, Email = "user124@test.com", Nombre = "Usuario 124", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 1, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 125, Email = "user125@test.com", Nombre = "Usuario 125", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 2, EmailVerificado = true });
 
         // Users for ActivityTracking isolated tenants
-        db.Usuarios.Add(new Usuario { Id = 9001, Email = "user9001@test.com", Nombre = "Usuario 9001", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 9001, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 9002, Email = "user9002@test.com", Nombre = "Usuario 9002", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 9001, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 9010, Email = "user9010@test.com", Nombre = "Usuario 9010", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 9010, EmailVerificado = true });
-        db.Usuarios.Add(new Usuario { Id = 9020, Email = "user9020@test.com", Nombre = "Usuario 9020", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 9020, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 9001, Email = "user9001@test.com", Nombre = "Usuario 9001", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 9001, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 9002, Email = "user9002@test.com", Nombre = "Usuario 9002", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 9001, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 9010, Email = "user9010@test.com", Nombre = "Usuario 9010", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 9010, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 9020, Email = "user9020@test.com", Nombre = "Usuario 9020", RolExplicito = "VENDEDOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 9020, EmailVerificado = true });
 
         // Supervisor user for Sprint 7 tests (tenant 1)
-        db.Usuarios.Add(new Usuario { Id = 200, Email = "supervisor@test.com", Nombre = "Supervisor Test", RolExplicito = "SUPERVISOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 1, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 200, Email = "supervisor@test.com", Nombre = "Supervisor Test", RolExplicito = "SUPERVISOR", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 1, EmailVerificado = true });
 
         // Viewer user for Sprint 6 tests (tenant 1)
-        db.Usuarios.Add(new Usuario { Id = 201, Email = "viewer@test.com", Nombre = "Viewer Test", RolExplicito = "VIEWER", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.Now, TenantId = 1, EmailVerificado = true });
+        db.Usuarios.Add(new Usuario { Id = 201, Email = "viewer@test.com", Nombre = "Viewer Test", RolExplicito = "VIEWER", RoleId = 2, PasswordHash = BCrypt.Net.BCrypt.HashPassword("Test123!"), Activo = true, CreadoEn = DateTime.UtcNow, TenantId = 1, EmailVerificado = true });
 
         // Pedido for cobro/ruta tests
         db.Pedidos.Add(new Pedido

--- a/apps/mobile-app/app/_layout.tsx
+++ b/apps/mobile-app/app/_layout.tsx
@@ -147,6 +147,56 @@ function LocationTrackingBridge() {
   useRutaJornadaWatcher();
   useInactividadJornadaWatcher();
 
+  // Setup notif category + listener de tap (Mec 1 + Mec 4 cierre via notif)
+  useEffect(() => {
+    let removeSub: (() => void) | undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const Notifications = await import('expo-notifications');
+        const notifs = await import('@/services/jornadaNotifications');
+        if (cancelled) return;
+        await notifs.setupJornadaNotificationCategory();
+
+        const sub = Notifications.addNotificationResponseReceivedListener(async (response) => {
+          const data = response.notification.request.content.data ?? {};
+          if ((data as any).action !== 'jornada-close-prompt') return;
+
+          const action = response.actionIdentifier;
+          const source = (data as any).source as 'horario' | 'inactividad' | undefined;
+
+          if (action === notifs.NOTIF_ACTION_EXTENDER) {
+            // "Sigo trabajando" → reschedule notif inactividad para otras 2h.
+            // (No tocamos jornada — sigue activa.)
+            await notifs.rescheduleInactividadNotification();
+            return;
+          }
+
+          // Default action (tap en notif) o action "cerrar" → cerrar jornada
+          // con el motivo que originó la notif.
+          if (action === notifs.NOTIF_ACTION_CERRAR
+              || action === Notifications.DEFAULT_ACTION_IDENTIFIER) {
+            const motivo: 'horario' | 'inactividad' | 'manual' =
+              source === 'horario' ? 'horario'
+              : source === 'inactividad' ? 'inactividad'
+              : 'manual';
+            await useJornadaStore.getState().finalizarJornada(motivo);
+          }
+        });
+        removeSub = () => sub.remove();
+      } catch {
+        // expo-notifications puede fallar en Expo Go SDK 53+ (limitación
+        // del runtime). En dev development build / EAS build funciona.
+        // Watchers (useHorarioLaboralWatcher, useInactividad) cubren el
+        // caso si las notifs no llegan.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (removeSub) removeSub();
+    };
+  }, []);
+
   return null;
 }
 // SyncLoadingScreen merged into AnimatedSplash (syncMode prop)

--- a/apps/mobile-app/jest.config.js
+++ b/apps/mobile-app/jest.config.js
@@ -1,0 +1,45 @@
+/**
+ * Jest config para tests unitarios de lógica pura (sin RN runtime).
+ *
+ * Usamos `ts-jest` directo en lugar de `jest-expo` porque:
+ * - Las funciones críticas a testear son puras (calculateLineAmounts,
+ *   captureOrderLocation cascade logic, sync mappers, JWT refresh queue).
+ * - `jest-expo` requiere mockear todo el bridge nativo de RN — overkill
+ *   para tests que no renderean componentes.
+ * - Tests más rápidos (sin transformar 1000+ archivos de node_modules
+ *   de RN) y debug más simple.
+ *
+ * Para tests de componentes RN (renderear `<JornadaCard />`, etc.),
+ * cuando se necesiten, instalar `jest-expo` + `@testing-library/react-native`
+ * y usar este config como base con `preset: 'jest-expo'` añadido.
+ *
+ * BUG-4 audit (2026-05-06): cobertura mínima inicial. Iterar añadiendo
+ * tests para mappers.ts (sync engine), captureOrderLocation cascade,
+ * y JWT refresh queue.
+ */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/.expo/', '/android/', '/ios/'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: {
+        // Tests pueden usar JSX si testean componentes; por ahora no.
+        jsx: 'react',
+        // Permitimos imports `@/utils/...` via paths
+        baseUrl: '.',
+        paths: { '@/*': ['src/*'] },
+      },
+    }],
+  },
+  collectCoverageFrom: [
+    'src/utils/**/*.ts',
+    'src/services/captureOrderLocation.ts',
+    'src/sync/mappers.ts',
+    '!**/*.d.ts',
+  ],
+};

--- a/apps/mobile-app/package-lock.json
+++ b/apps/mobile-app/package-lock.json
@@ -63,8 +63,11 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
+        "@types/jest": "^29.5.14",
         "@types/react": "~19.1.0",
+        "jest": "^29.7.0",
         "patch-package": "^8.0.1",
+        "ts-jest": "^29.2.5",
         "typescript": "~5.6.3"
       }
     },
@@ -1574,6 +1577,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@expo/cli": {
       "version": "54.0.23",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
@@ -2369,6 +2379,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -2396,6 +2485,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -2413,6 +2529,109 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2420,6 +2639,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3685,6 +3951,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
@@ -4406,6 +4683,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4501,6 +4791,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4556,6 +4856,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chokidar": {
@@ -4650,6 +4960,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4714,6 +5031,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4906,6 +5241,28 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5042,6 +5399,21 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5152,6 +5524,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5163,6 +5545,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -5284,6 +5676,19 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5319,6 +5724,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -5446,6 +5868,82 @@
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
       "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
       "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/expo": {
       "version": "54.0.33",
@@ -6358,6 +6856,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -6457,6 +6968,38 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6566,6 +7109,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -6621,6 +7171,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6663,6 +7223,26 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -6800,6 +7380,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -6883,6 +7473,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -6948,6 +7551,273 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -6999,6 +7869,36 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -7033,6 +7933,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -7040,6 +7958,174 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-util": {
@@ -7083,6 +8169,26 @@
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7168,6 +8274,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -7583,6 +8696,13 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -7710,6 +8830,42 @@
         "react-native": "*",
         "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8285,6 +9441,13 @@
         "tailwindcss": ">3.3.0"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -8293,6 +9456,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nested-error-stacks": {
       "version": "2.0.1",
@@ -8375,6 +9545,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nth-check": {
@@ -8667,6 +9850,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -8833,6 +10035,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -9150,6 +10365,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.4",
@@ -10286,6 +11518,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10831,6 +12076,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10873,6 +12145,26 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11267,6 +12559,85 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11329,6 +12700,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -11564,6 +12949,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -11716,6 +13116,13 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
       "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/apps/mobile-app/package.json
+++ b/apps/mobile-app/package.json
@@ -8,7 +8,9 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "postinstall": "patch-package",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -65,8 +67,11 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.29.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.1.0",
+    "jest": "^29.7.0",
     "patch-package": "^8.0.1",
+    "ts-jest": "^29.2.5",
     "typescript": "~5.6.3"
   },
   "private": true

--- a/apps/mobile-app/src/api/client.ts
+++ b/apps/mobile-app/src/api/client.ts
@@ -10,13 +10,51 @@ import * as Crypto from 'expo-crypto';
 import { API_CONFIG, STORAGE_KEYS } from '@/utils/constants';
 import { secureStorage } from '@/utils/storage';
 
-// TODO [SEC-M2]: Implement SSL/TLS certificate pinning
-// Steps:
-// 1. Install: npx expo install expo-certificate-transparency (or react-native-ssl-pinning)
-// 2. Pin the certificate SHA-256 fingerprints for: api.handysuites.com, *.railway.app
-// 3. Reject connections if certificate doesn't match pinned fingerprints
-// 4. Add monitoring for certificate rotation (pins must be updated before cert expires)
-// Priority: HIGH — prevents MITM attacks on untrusted networks (WiFi público)
+// TODO [CRIT-4 / SEC-M2]: SSL/TLS public-key pinning.
+// PRIORIDAD: HIGH — vector real de MITM en WiFi público (cafetería, evento).
+// Vendedor con tablet en ruta es target.
+//
+// IMPLEMENTACIÓN REAL (paso a paso, requiere acceso a producción):
+//
+// 1. Extraer SHA-256 SPKI pins del cert prod:
+//    openssl s_client -servername api.handysuites.com -connect api.handysuites.com:443 \
+//      < /dev/null 2>/dev/null \
+//      | openssl x509 -pubkey -noout \
+//      | openssl pkey -pubin -outform der \
+//      | openssl dgst -sha256 -binary \
+//      | openssl enc -base64
+//    Repetir para `*.railway.app` (backup pin durante rotación).
+//
+// 2. Instalar el paquete:
+//    npx expo install react-native-ssl-public-key-pinning
+//    (NO `react-native-ssl-pinning` — esa es legacy y no soporta SDK 52).
+//
+// 3. Config en `app.config.ts` plugins:
+//    plugins: [..., 'react-native-ssl-public-key-pinning']
+//    + EAS build (es native module, NO ota update sirve).
+//
+// 4. Config los pins ANTES de crear el axios instance:
+//    import { addSslPinningConfig } from 'react-native-ssl-public-key-pinning';
+//    await addSslPinningConfig({
+//      'api.handysuites.com': {
+//        includeSubdomains: false,
+//        publicKeyHashes: [
+//          'sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=', // primary cert SPKI
+//          'sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=', // backup (next rotation)
+//        ],
+//      },
+//    });
+//
+// 5. ROTATION PROCEDURE (DOCUMENTAR antes de prod):
+//    - Pre-rotation: incluir el cert nuevo en pins ANTES de rotar (overlap window).
+//    - Post-rotation: remover el cert viejo en siguiente EAS build.
+//    - Si se rompe: app no puede conectar; única recuperación es nuevo APK con
+//      pins actualizados. NO hay forma de "deshacer" via OTA.
+//
+// 6. Monitoring: alerta cuando el cert prod esté a <30 días de expirar.
+//
+// IMPACT si se omite: vendedores con plan corporativo en hotspot maliciosa
+// pueden ver tokens JWT, datos de cliente, ubicaciones GPS interceptados.
 
 // --- Axios instance ---
 const apiInstance: AxiosInstance = axios.create({

--- a/apps/mobile-app/src/services/jornadaNotifications.ts
+++ b/apps/mobile-app/src/services/jornadaNotifications.ts
@@ -1,0 +1,179 @@
+/**
+ * Local notifications para gestión de cierre de jornada.
+ * 100% client-side — cero costo server.
+ *
+ * Mecanismos:
+ *   1. `scheduleHorarioFinNotification` — al iniciar jornada, programa notif
+ *      local que dispara a la `hora_fin_jornada` del tenant. Sobrevive
+ *      app cerrada (OS dispara la notif aunque el proceso esté muerto).
+ *   2. `rescheduleInactividadNotification` — después de cada Venta/Cobro/
+ *      Visita, programa notif para 2h después. Si pasan 2h sin actividad
+ *      de negocio, vendedor recibe prompt "¿Sigues en ruta?".
+ *
+ * Las notifs incluyen action buttons:
+ *   - "Cerrar jornada" → abre app + dispara `finalizarJornada`
+ *   - "Sigo trabajando" → reschedule (caso inactividad) o no-op (horario fin)
+ *
+ * El listener de tap está en `app/_layout.tsx` que maneja las respuestas.
+ *
+ * Edge cases:
+ *  - Sin config de horario laboral → notif Mec 1 no se programa.
+ *  - hora_fin ya pasó hoy → notif Mec 1 dispararía mañana (calendar
+ *    trigger asume "next occurrence").
+ *  - Mec 4 no se programa si el trigger caería después de hora_fin (Mec 1
+ *    lo cubre).
+ *  - Vendedor desinstala app → notifs programadas se borran (siguiente
+ *    iniciarJornada las reschedule).
+ *  - Vendedor desactiva permiso de notifs → notifs no aparecen pero las
+ *    funciones no-op silently. Watchers existentes (`useHorarioLaboralWatcher`,
+ *    `useInactividadJornadaWatcher`) siguen siendo red de seguridad.
+ */
+import * as Notifications from 'expo-notifications';
+import { getEmpresaConfigSnapshot } from '@/utils/empresaConfigSnapshot';
+
+const NOTIF_ID_HORARIO_FIN = 'jornada-horario-fin';
+const NOTIF_ID_INACTIVIDAD = 'jornada-inactividad';
+const INACTIVIDAD_THRESHOLD_HOURS = 2;
+
+export const NOTIF_CATEGORY_JORNADA = 'JORNADA_END';
+export const NOTIF_ACTION_CERRAR = 'cerrar';
+export const NOTIF_ACTION_EXTENDER = 'extender';
+
+/**
+ * Setup categoría con action buttons. Llamar una vez al boot del app
+ * (desde `_layout.tsx`).
+ */
+export async function setupJornadaNotificationCategory(): Promise<void> {
+  try {
+    await Notifications.setNotificationCategoryAsync(NOTIF_CATEGORY_JORNADA, [
+      {
+        identifier: NOTIF_ACTION_CERRAR,
+        buttonTitle: 'Cerrar jornada',
+        options: { opensAppToForeground: true },
+      },
+      {
+        identifier: NOTIF_ACTION_EXTENDER,
+        buttonTitle: 'Sigo trabajando',
+        options: { opensAppToForeground: false },
+      },
+    ]);
+  } catch {
+    // En Expo Go (SDK 53+) las notif categories pueden fallar — fallback
+    // al tap default sin botones. Funciona, solo pierde la opción "extender".
+  }
+}
+
+/**
+ * MEC 1 — Programa notif para la `hora_fin_jornada` del tenant.
+ * Llamar desde `iniciarJornada` (jornadaStore).
+ *
+ * Trigger calendar: dispara a la próxima vez que se cumpla hora:minuto
+ * en TZ del device. Asume que vendedor está en la misma TZ del tenant
+ * (caso 99% — vendedor de Jeyma usa app en Mazatlán).
+ */
+export async function scheduleHorarioFinNotification(): Promise<void> {
+  const snapshot = getEmpresaConfigSnapshot();
+  const horaFin = snapshot?.horaFinJornada;
+  if (!horaFin) return; // sin config de horario → vendedor controla manual
+
+  await cancelHorarioFinNotification();
+
+  const parts = horaFin.split(':');
+  const hour = parseInt(parts[0] ?? '', 10);
+  const minute = parseInt(parts[1] ?? '0', 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return;
+
+  try {
+    await Notifications.scheduleNotificationAsync({
+      identifier: NOTIF_ID_HORARIO_FIN,
+      content: {
+        title: '¿Ya terminaste tu día?',
+        body: 'Tu jornada se cerrará automáticamente al fin del horario laboral.',
+        data: { action: 'jornada-close-prompt', source: 'horario' },
+        categoryIdentifier: NOTIF_CATEGORY_JORNADA,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.CALENDAR,
+        hour,
+        minute,
+        repeats: false,
+      } as Notifications.CalendarTriggerInput,
+    });
+  } catch {
+    // ignore — notif falló (permiso, modo no soportado en Expo Go, etc.)
+  }
+}
+
+export async function cancelHorarioFinNotification(): Promise<void> {
+  try {
+    await Notifications.cancelScheduledNotificationAsync(NOTIF_ID_HORARIO_FIN);
+  } catch {
+    // identifier no existe → no-op
+  }
+}
+
+/**
+ * MEC 4 — Programa notif de inactividad para 2h en el futuro.
+ * Llamar después de cada Venta/Cobro/Visita confirmada (en
+ * `recordPing` o desde el caller).
+ *
+ * No programa si el trigger caería después de `hora_fin_jornada` —
+ * en ese caso Mec 1 ya cubre el cierre.
+ */
+export async function rescheduleInactividadNotification(): Promise<void> {
+  await cancelInactividadNotification();
+
+  const inactividadSec = INACTIVIDAD_THRESHOLD_HOURS * 60 * 60;
+
+  // Si trigger caería después de hora_fin del tenant, NO programar
+  // (Mec 1 lo agarra antes). Evita spam doble.
+  const snapshot = getEmpresaConfigSnapshot();
+  const horaFin = snapshot?.horaFinJornada;
+  if (horaFin) {
+    const parts = horaFin.split(':');
+    const horaFinH = parseInt(parts[0] ?? '', 10);
+    const horaFinM = parseInt(parts[1] ?? '0', 10);
+    if (!Number.isNaN(horaFinH)) {
+      const now = new Date();
+      const triggerTime = now.getTime() + inactividadSec * 1000;
+      const horaFinTime = new Date(now);
+      horaFinTime.setHours(horaFinH, horaFinM, 0, 0);
+      if (triggerTime >= horaFinTime.getTime()) return;
+    }
+  }
+
+  try {
+    await Notifications.scheduleNotificationAsync({
+      identifier: NOTIF_ID_INACTIVIDAD,
+      content: {
+        title: '¿Sigues en ruta?',
+        body: `Llevas ${INACTIVIDAD_THRESHOLD_HOURS}h sin venta, cobro ni visita.`,
+        data: { action: 'jornada-close-prompt', source: 'inactividad' },
+        categoryIdentifier: NOTIF_CATEGORY_JORNADA,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+        seconds: inactividadSec,
+        repeats: false,
+      } as Notifications.TimeIntervalTriggerInput,
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export async function cancelInactividadNotification(): Promise<void> {
+  try {
+    await Notifications.cancelScheduledNotificationAsync(NOTIF_ID_INACTIVIDAD);
+  } catch {
+    // no-op si no existe
+  }
+}
+
+/** Cancela ambos al `finalizarJornada`. */
+export async function cancelAllJornadaNotifications(): Promise<void> {
+  await Promise.all([
+    cancelHorarioFinNotification(),
+    cancelInactividadNotification(),
+  ]);
+}

--- a/apps/mobile-app/src/services/locationCheckpoint.ts
+++ b/apps/mobile-app/src/services/locationCheckpoint.ts
@@ -174,6 +174,18 @@ export async function recordPing(
       });
     });
     lastPingAt = ahora;
+
+    // Mec 4 — reset notif local de inactividad. Si el ping fue de un
+    // evento de negocio (Venta/Cobro/Visita), reschedule para 2h después.
+    // El timer de la notif anterior se cancela primero.
+    if (esEventoNegocio) {
+      try {
+        const notifs = await import('@/services/jornadaNotifications');
+        await notifs.rescheduleInactividadNotification();
+      } catch {
+        // ignore — notif no es crítica
+      }
+    }
   } catch {
     // Silent — GPS errors no rompen flujo
   }

--- a/apps/mobile-app/src/stores/jornadaStore.ts
+++ b/apps/mobile-app/src/stores/jornadaStore.ts
@@ -114,6 +114,18 @@ export const useJornadaStore = create<JornadaState>((set, get) => ({
     } catch {
       // No bloquear si el ping falla — el estado de jornada ya está activo
     }
+
+    // Mec 1 — Programar notif local a hora_fin del tenant. Sobrevive
+    // app cerrada (OS dispara aunque proceso esté muerto). Si vendedor
+    // ignora la notif, el watcher useHorarioLaboralWatcher lo cierra al
+    // siguiente foreground; si tampoco fue, useInactividadJornadaWatcher
+    // (4h sin pings) es la última red de seguridad.
+    try {
+      const notifs = await import('@/services/jornadaNotifications');
+      await notifs.scheduleHorarioFinNotification();
+    } catch {
+      // ignore — notif no es crítica
+    }
   },
 
   finalizarJornada: async (motivo) => {
@@ -143,6 +155,16 @@ export const useJornadaStore = create<JornadaState>((set, get) => ({
       // Stop timer al final — el ping de cierre todavía necesita el timer
       // activo (currentUsuarioId queda null si paramos antes del ping).
       mod.stopCheckpointTimer();
+    } catch {
+      // ignore
+    }
+
+    // Cancelar notifs locales pendientes (Mec 1 + Mec 4) ya que la jornada
+    // está cerrada. Si no, el vendedor recibiría "¿Ya terminaste?" cuando
+    // ya cerró.
+    try {
+      const notifs = await import('@/services/jornadaNotifications');
+      await notifs.cancelAllJornadaNotifications();
     } catch {
       // ignore
     }

--- a/apps/mobile-app/src/utils/__tests__/lineAmountCalculator.test.ts
+++ b/apps/mobile-app/src/utils/__tests__/lineAmountCalculator.test.ts
@@ -1,0 +1,67 @@
+import { calculateLineAmounts } from '../lineAmountCalculator';
+
+/**
+ * Tests del cálculo de IVA por línea — espejo del backend
+ * `LineAmountCalculator`. Bug histórico (2026-04-28): ticket cobraba $98.60
+ * por $17×5 (sumando 16% sobre $85). El fix con `precioIncluyeIva=true`
+ * deja $85 total exacto.
+ */
+describe('calculateLineAmounts', () => {
+  describe('precio incluye IVA (caso default mexicano)', () => {
+    it('redondea a 2 decimales sin sumar IVA encima del precio', () => {
+      // $17 × 5 = $85 total. IVA 16% se desglosa de la base, no se suma.
+      const r = calculateLineAmounts(17, 5, 0, 0.16, true);
+      expect(r.total).toBe(85);
+      expect(r.subtotal).toBeCloseTo(73.28, 2); // 85 / 1.16
+      expect(r.impuesto).toBeCloseTo(11.72, 2); // 85 - 73.28
+    });
+
+    it('aplica descuento antes de desglosar IVA', () => {
+      const r = calculateLineAmounts(100, 2, 20, 0.16, true);
+      expect(r.total).toBe(180); // 100 × 2 - 20
+      expect(r.subtotal).toBeCloseTo(155.17, 2);
+      expect(r.impuesto).toBeCloseTo(24.83, 2);
+    });
+
+    it('total negativo si descuento > subtotal (caller debe validar)', () => {
+      // El cálculo en sí no valida — el caller (PedidoCreateDtoValidator)
+      // debe rechazar descuentos > subtotal antes de llegar aquí.
+      const r = calculateLineAmounts(10, 1, 50, 0.16, true);
+      expect(r.total).toBe(-40);
+    });
+
+    it('tasa 0 (producto exento) → no impuesto, total = subtotal = precio', () => {
+      const r = calculateLineAmounts(50, 3, 0, 0, true);
+      expect(r.total).toBe(150);
+      expect(r.subtotal).toBe(150);
+      expect(r.impuesto).toBe(0);
+    });
+  });
+
+  describe('precio NO incluye IVA (caso B2B con factura)', () => {
+    it('suma IVA encima del subtotal', () => {
+      const r = calculateLineAmounts(100, 1, 0, 0.16, false);
+      expect(r.subtotal).toBe(100);
+      expect(r.impuesto).toBe(16);
+      expect(r.total).toBe(116);
+    });
+
+    it('descuento se aplica al subtotal antes del IVA', () => {
+      const r = calculateLineAmounts(100, 2, 50, 0.16, false);
+      expect(r.subtotal).toBe(150); // 100 × 2 - 50
+      expect(r.impuesto).toBe(24); // 150 × 0.16
+      expect(r.total).toBe(174);
+    });
+  });
+
+  describe('precisión y redondeo', () => {
+    it('redondea cada componente a 2 decimales para evitar drift acumulado', () => {
+      // Caso clásico de drift: 0.1 + 0.2 = 0.30000000000000004 en JS.
+      // round2 debe garantizar 2 decimales exactos.
+      const r = calculateLineAmounts(0.1, 1, 0, 0.16, true);
+      expect(Number.isInteger(r.total * 100)).toBe(true);
+      expect(Number.isInteger(r.subtotal * 100)).toBe(true);
+      expect(Number.isInteger(r.impuesto * 100)).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+/**
+ * Validación de env vars al startup. Si falta alguna requerida o tiene
+ * formato inválido, fail-fast en build/dev en lugar de fallar runtime
+ * con errores crípticos.
+ *
+ * En prod (Vercel): variables faltantes hacen que `next build` falle
+ * con mensaje claro. Mejor que descubrirlo via `_cachedAccessToken
+ * undefined` o `Access-Control-Allow-Origin: invalid-no-nextauth-url-set`.
+ *
+ * Patrón inspirado en @t3-oss/env-nextjs, implementado inline para no
+ * añadir dep nueva (~10KB gzipped no se justifica para 6 vars).
+ *
+ * Uso:
+ *   import { env } from '@/lib/env';
+ *   const apiUrl = env.NEXT_PUBLIC_API_URL;
+ *
+ * Si querés validar en build sin runtime cost en client bundles, se
+ * puede mover el `parse()` a un script de pre-build con `node -r ts-node ...`.
+ */
+
+const serverEnvSchema = z.object({
+  // NextAuth — sin secret válido, JWT sign/verify rompe.
+  NEXTAUTH_SECRET: z
+    .string()
+    .min(32, 'NEXTAUTH_SECRET debe ser ≥32 chars (usá `openssl rand -base64 32`)'),
+  NEXTAUTH_URL: z
+    .string()
+    .url('NEXTAUTH_URL debe ser URL absoluta (ej. https://app.handysuites.com)'),
+
+  // JWT secret compartido con backend (verificación de firma de tokens).
+  JWT_SECRET: z
+    .string()
+    .min(32, 'JWT_SECRET debe ser ≥32 chars'),
+
+  // Social login (Google OAuth) — opcional pero si está, debe tener su propio secret.
+  // Antes había fallback a JWT_SECRET (vector reportado en línea 263 auth.ts).
+  SOCIAL_LOGIN_SECRET: z
+    .string()
+    .min(32)
+    .optional(),
+
+  // Backend URL — fallback a localhost permitido en dev.
+  BACKEND_API_URL: z.string().url().default('http://localhost:1050'),
+});
+
+const clientEnvSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url().optional(),
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
+});
+
+type ServerEnv = z.infer<typeof serverEnvSchema>;
+type ClientEnv = z.infer<typeof clientEnvSchema>;
+
+let cachedServer: ServerEnv | undefined;
+let cachedClient: ClientEnv | undefined;
+
+/**
+ * Server-side env (no expuesta a browser bundles).
+ * Llamar en server components, route handlers, server actions.
+ * En client component este throw — usar `clientEnv()` en su lugar.
+ */
+export function serverEnv(): ServerEnv {
+  if (cachedServer) return cachedServer;
+  if (typeof window !== 'undefined') {
+    throw new Error('serverEnv() llamada desde client. Usá clientEnv() o move el código a server.');
+  }
+  const parsed = serverEnvSchema.safeParse(process.env);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new Error(
+      `Env vars inválidas o faltantes:\n${issues}\n\nVerificá tu .env / Vercel Project Settings.`
+    );
+  }
+  cachedServer = parsed.data;
+  return cachedServer;
+}
+
+/**
+ * Client-side env (solo NEXT_PUBLIC_*). Safe para usar en cualquier
+ * lado pero solo expone vars que ya están en el bundle JS.
+ */
+export function clientEnv(): ClientEnv {
+  if (cachedClient) return cachedClient;
+  // process.env en client es replaced en build time por Next.js; solo
+  // funciona para `NEXT_PUBLIC_*` keys.
+  const raw = {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+  };
+  cachedClient = clientEnvSchema.parse(raw);
+  return cachedClient;
+}


### PR DESCRIPTION
Promociona a producción `fix/audit-sprints-mixed` (PR previo a staging).

## Cambios incluidos

### Backend
- Tests `DateTime.UtcNow` determinísticos (19 reemplazos)
- Fire-and-forget logging Debug (push notifs)
- Comentario rate-limit single-instance decisión consciente

### Web
- `lib/env.ts` — validación zod env vars al startup

### Mobile
- SSL pinning TODO operativo (procedure completo)
- Jest setup + 7 tests `calculateLineAmounts`
- **4 mecanismos cierre jornada cliente-side**:
  - Notif local programada a `hora_fin` del tenant
  - Notif local cada 2h sin venta/cobro/visita
  - Action buttons "Cerrar jornada" / "Sigo trabajando"
  - Listener tap → `finalizarJornada` con motivo correcto

## Pre-Deploy Checklist

- [x] 500/501 API + 46/46 Mobile tests pass
- [x] Type-check web clean
- [x] Type-check mobile clean
- [x] 7/7 Jest mobile tests pass
- [x] Sin env vars nuevas
- [x] Sin DB migrations
- [x] Sin breaking API contracts
- [x] 100% reversible vía revert

## Post-merge

- Railway redeploy automático API container (~3-5 min, path filter `apps/api/**`, `libs/**`).
- Vercel redeploy automático web (~2 min, path filter `apps/web/**`).
- **EAS update mobile** pendiente — esperar autorización explícita para que las notifs lleguen a vendedores en producción.

## Validación post-deploy

- Backend: queries con tenant_id siguen funcionando (RLS + GQF).
- Web: dashboard admin OK + env vars validation no rompe builds.
- Mobile post-EAS: vendedor inicia jornada → notif programada → a la `hora_fin` aparece notif → tap "Cerrar" → ping `StopAutomatico` real en `/team/{id}/gps` con coords reales del momento.
