### PR TITLE
feat(mobile/home): 3 ProgressCards en card "Ruta del día" (paradas/pe…

### DIFF
--- a/apps/mobile-app/app/(tabs)/ruta/index.tsx
+++ b/apps/mobile-app/app/(tabs)/ruta/index.tsx
@@ -35,6 +35,7 @@ import Cliente from '@/db/models/Cliente';
 import Producto from '@/db/models/Producto';
 import Pedido from '@/db/models/Pedido';
 import { Package } from 'lucide-react-native';
+import ProgressCard from '@/components/shared/ProgressCard';
 
 const STOP_DOT_COLORS: Record<number, string> = {
   0: '#e2e8f0', // Pendiente — gray
@@ -54,92 +55,6 @@ const STOP_STATUS_TEXT_COLORS: Record<number, string> = {
   2: '#16a34a', // green
   3: '#ef4444', // red
 };
-
-/**
- * Card de progreso para paradas/pedidos/productos. Si la ruta no tiene
- * elementos en esa categoría (`total === 0`), renderiza una versión gris
- * con caption explicativo en vez de "0 de 0 (NaN%)" — decisión UX owner
- * 2026-05-05: más informativo que ocultar y menos engañoso que mostrar 100%.
- */
-interface ProgressCardProps {
-  label: string;
-  current: number;
-  total: number;
-  color: string;
-  emptyCaption: string;
-}
-
-function ProgressCard({ label, current, total, color, emptyCaption }: ProgressCardProps) {
-  const isEmpty = total === 0;
-  const pct = isEmpty ? 0 : Math.min(100, (current / total) * 100);
-  const fillColor = isEmpty ? '#cbd5e1' : color;
-  const labelColor = isEmpty ? COLORS.textSecondary : COLORS.foreground;
-  return (
-    <View style={progressCardStyles.container}>
-      <View style={progressCardStyles.headerRow}>
-        <Text style={[progressCardStyles.label, { color: labelColor }]} numberOfLines={1}>
-          {label}
-        </Text>
-        <Text style={[progressCardStyles.count, { color: labelColor }]}>
-          {isEmpty ? '—' : `${current} / ${total}`}
-        </Text>
-      </View>
-      <View style={progressCardStyles.track}>
-        <View
-          style={[
-            progressCardStyles.fill,
-            { width: `${pct}%`, backgroundColor: fillColor },
-            isEmpty && progressCardStyles.trackEmpty,
-          ]}
-        />
-      </View>
-      {isEmpty && (
-        <Text style={progressCardStyles.emptyCaption}>{emptyCaption}</Text>
-      )}
-    </View>
-  );
-}
-
-const progressCardStyles = StyleSheet.create({
-  container: {
-    marginTop: 12,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 6,
-  },
-  label: {
-    fontSize: 13,
-    fontWeight: '600',
-    flex: 1,
-    marginRight: 8,
-  },
-  count: {
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  track: {
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: '#e5e7eb',
-    overflow: 'hidden',
-  },
-  fill: {
-    height: '100%',
-    borderRadius: 4,
-  },
-  trackEmpty: {
-    opacity: 0.6,
-  },
-  emptyCaption: {
-    fontSize: 11,
-    color: COLORS.textSecondary,
-    fontStyle: 'italic',
-    marginTop: 4,
-  },
-});
 
 export default function RutaScreen() {
   const insets = useSafeAreaInsets();

--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -4,11 +4,14 @@ import { useRouter } from 'expo-router';
 import { useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore, useJornadaStore } from '@/stores';
-import { useOfflineTodayVisits, useOfflineRutaHoy, useOfflineOrders, useOfflineCobros } from '@/hooks';
+import { useOfflineTodayVisits, useOfflineRutaHoy, useOfflineOrders, useOfflineCobros, useOfflineRutaPedidos, useOfflineRutaCarga } from '@/hooks';
 import { database } from '@/db/database';
 import { Q } from '@nozbe/watermelondb';
 import { Card, LoadingSpinner, UserAvatar, ConfirmModal } from '@/components/ui';
 import { StatusBadge } from '@/components/shared/StatusBadge';
+import ProgressCard from '@/components/shared/ProgressCard';
+import RutaCarga from '@/db/models/RutaCarga';
+import RutaPedido from '@/db/models/RutaPedido';
 import { useTenantLocale, useUnreadNotificationCount } from '@/hooks';
 import { getGreetingForTz } from '@/utils/greeting';
 import { startOfDayInTz } from '@/utils/dateTz';
@@ -85,6 +88,31 @@ export function VendedorDashboard() {
   const { data: pedidos } = useOfflineOrders();
   const { data: cobros } = useOfflineCobros();
 
+  // Carga (productos asignados al camión) y pedidos pre-asignados a la
+  // ruta — consumidos para los 3 ProgressCards del card "Ruta del día".
+  // Mismo patrón que app/(tabs)/ruta/index.tsx — el home muestra los
+  // 3 progresos para que el vendedor vea actividad real aún si la ruta
+  // se creó sin paradas (ej. ruta solo de venta directa con carga inicial).
+  const { data: pedidosCargados } = useOfflineRutaPedidos(route?.id ?? '');
+  const { data: cargaProductos } = useOfflineRutaCarga(route?.id ?? '');
+
+  const pedidosEntregados = useMemo(() => {
+    return ((pedidosCargados as RutaPedido[] | undefined) ?? [])
+      .filter((rp) => rp.estado === 1).length; // EstadoPedidoRuta.Entregado
+  }, [pedidosCargados]);
+  const totalPedidosCargados = (pedidosCargados as RutaPedido[] | undefined)?.length ?? 0;
+
+  const { cargaTotalUnidades, cargaConsumidasUnidades } = useMemo(() => {
+    const carga = (cargaProductos as RutaCarga[] | undefined) ?? [];
+    let total = 0;
+    let consumidas = 0;
+    for (const c of carga) {
+      total += c.cantidadTotal ?? 0;
+      consumidas += (c.cantidadVendida ?? 0) + (c.cantidadEntregada ?? 0);
+    }
+    return { cargaTotalUnidades: total, cargaConsumidasUnidades: consumidas };
+  }, [cargaProductos]);
+
   // Compute KPIs
   const visitasCompletadas = todayVisits?.filter((v) => v.checkOutAt != null).length ?? 0;
   const visitasConVenta = todayVisits?.length ?? 0;
@@ -108,7 +136,6 @@ export function VendedorDashboard() {
   }, []));
 
   const stats = routeStats;
-  const progress = stats.total > 0 ? (stats.atendidas / stats.total) * 100 : 0;
 
   // Additional KPIs — orders and sales today
   const pedidosHoy = useMemo(() => {
@@ -284,17 +311,33 @@ export function VendedorDashboard() {
               </View>
               <StatusBadge type="route" status={route.estado} />
             </View>
-            <View style={styles.progressSection}>
-              <View style={styles.progressTrack}>
-                <View style={[styles.progressFill, { width: `${progress}%` }]} />
-              </View>
-              <View style={styles.progressRow}>
-                <Text style={styles.progressText}>
-                  {stats.atendidas}/{stats.total} paradas
-                </Text>
-                <Text style={styles.progressPercent}>{Math.round(progress)}%</Text>
-              </View>
-            </View>
+            {/* 3 ProgressCards: Paradas / Pedidos / Productos. Idéntico
+                a /ruta — coherencia visual y mismo cómputo. Si la ruta
+                se creó sin paradas (caso reportado 2026-05-07 vendedor
+                Rodrigo) la barra de Productos sigue mostrando avance
+                real porque la carga inicial decrementa con cada
+                venta directa confirmada. */}
+            <ProgressCard
+              label="Paradas atendidas"
+              current={stats.atendidas}
+              total={stats.total}
+              color={COLORS.primary}
+              emptyCaption="Esta ruta no tiene paradas asignadas"
+            />
+            <ProgressCard
+              label="Pedidos entregados"
+              current={pedidosEntregados}
+              total={totalPedidosCargados}
+              color={COLORS.success}
+              emptyCaption="Esta ruta no tiene pedidos pre-asignados"
+            />
+            <ProgressCard
+              label="Productos (vendidos + entregados)"
+              current={cargaConsumidasUnidades}
+              total={cargaTotalUnidades}
+              color="#d97706"
+              emptyCaption="Esta ruta no tiene productos cargados"
+            />
           </Card>
         ) : (
           <Card className="mb-5">
@@ -450,17 +493,6 @@ const styles = StyleSheet.create({
   },
   routeInfo: { flex: 1 },
   routeName: { fontSize: 15, fontWeight: '600', color: COLORS.foreground },
-  progressSection: { marginTop: 14, gap: 6 },
-  progressTrack: {
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: COLORS.borderMedium,
-    overflow: 'hidden',
-  },
-  progressFill: { height: '100%', borderRadius: 4, backgroundColor: COLORS.primary },
-  progressRow: { flexDirection: 'row', justifyContent: 'space-between' },
-  progressText: { fontSize: 12, color: COLORS.textSecondary, fontWeight: '500' },
-  progressPercent: { fontSize: 12, color: COLORS.primary, fontWeight: '700' },
   emptyRoute: { alignItems: 'center', paddingVertical: 20, gap: 8 },
   emptyRouteText: { fontSize: 14, color: COLORS.textTertiary },
   quickActions: { flexDirection: 'row', gap: 10, marginBottom: 24 },

--- a/apps/mobile-app/src/components/shared/ProgressCard.tsx
+++ b/apps/mobile-app/src/components/shared/ProgressCard.tsx
@@ -1,0 +1,96 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { COLORS } from '@/theme/colors';
+
+/**
+ * Card de progreso para paradas/pedidos/productos. Si la categoría no
+ * tiene elementos (`total === 0`), renderiza una versión gris con
+ * caption explicativo en vez de "0/0 (NaN%)" — más informativo que
+ * ocultar y menos engañoso que mostrar 100%.
+ *
+ * Owner UX 2026-05-05. Usado por:
+ * - app/(tabs)/ruta/index.tsx (detalle de ruta)
+ * - components/dashboard/VendedorDashboard.tsx (home)
+ */
+export interface ProgressCardProps {
+  label: string;
+  current: number;
+  total: number;
+  color: string;
+  emptyCaption: string;
+}
+
+export default function ProgressCard({
+  label,
+  current,
+  total,
+  color,
+  emptyCaption,
+}: ProgressCardProps) {
+  const isEmpty = total === 0;
+  const pct = isEmpty ? 0 : Math.min(100, (current / total) * 100);
+  const fillColor = isEmpty ? '#cbd5e1' : color;
+  const labelColor = isEmpty ? COLORS.textSecondary : COLORS.foreground;
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <Text style={[styles.label, { color: labelColor }]} numberOfLines={1}>
+          {label}
+        </Text>
+        <Text style={[styles.count, { color: labelColor }]}>
+          {isEmpty ? '—' : `${current} / ${total}`}
+        </Text>
+      </View>
+      <View style={styles.track}>
+        <View
+          style={[
+            styles.fill,
+            { width: `${pct}%`, backgroundColor: fillColor },
+            isEmpty && styles.trackEmpty,
+          ]}
+        />
+      </View>
+      {isEmpty && <Text style={styles.emptyCaption}>{emptyCaption}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 8,
+  },
+  count: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  track: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#e5e7eb',
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 4,
+  },
+  trackEmpty: {
+    opacity: 0.6,
+  },
+  emptyCaption: {
+    fontSize: 11,
+    color: COLORS.textSecondary,
+    fontStyle: 'italic',
+    marginTop: 4,
+  },
+});


### PR DESCRIPTION
…didos/productos)

Reportado 2026-05-07 (vendedor Rodrigo, screenshot adjunto): home muestra solo "0/0 paradas" cuando la ruta del día se creó sin paradas planificadas. La ruta SÍ tiene productos asignados (carga inicial al camión) y el vendedor está vendiendo via venta directa — pero el home no comunica nada útil sobre eso.

Fix: portar el patrón de 3 ProgressCards (Paradas / Pedidos / Productos) que ya existía en /ruta (commit ab4a3068, 2026-05-05) al home dashboard. Coherencia visual con la pantalla detalle. Cuando una categoría tiene 0/0, el card muestra "—" gris con caption explicativo (no engañoso).

Cambios:

- Nuevo `apps/mobile-app/src/components/shared/ProgressCard.tsx`: componente extraído de /ruta inline a shared. Sin cambios de lógica.
- `apps/mobile-app/app/(tabs)/ruta/index.tsx`: elimina la definición inline + estilos `progressCardStyles`. Importa del shared.
- `apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx`:
  - Import `useOfflineRutaPedidos`, `useOfflineRutaCarga`, `ProgressCard`.
  - Computa `pedidosEntregados`, `totalPedidosCargados`, `cargaTotalUnidades`, `cargaConsumidasUnidades` con useMemo (idéntico al cómputo en /ruta).
  - Reemplaza la barra single de paradas por los 3 ProgressCards apilados en el card "Ruta del día".
  - Elimina estilos progressSection/Track/Fill/Row/Text/Percent ya no usados.

Cero backend, cero migrations. Datos ya vienen via sync (CantidadVendida y CantidadEntregada se incrementan en tiempo real al confirmar pedidos desde MobileVentaDirectaEndpoints + MobilePedidoEndpoints).

Verificación local:
- mobile tsc: clean
- mobile jest: 7/7 pass