### PR TITLE
﻿hotfix(mobile/auth): skip deviceTakeoverRequired handler en endpoint…

### DIFF
--- a/apps/mobile-app/src/api/client.ts
+++ b/apps/mobile-app/src/api/client.ts
@@ -200,17 +200,31 @@ apiInstance.interceptors.response.use(
       _retry?: boolean;
     };
 
-    // Audit 2026-05-08: middleware backend ahora responde 403 + DEVICE_BOUND
+    // Audit 2026-05-08: middleware backend responde 403 + DEVICE_BOUND
     // cuando el fingerprint del request no matchea ninguna sesión activa
-    // (caso reinstalo, OS update, sesión huérfana, cuenta compartida).
-    // Antes era 401 + DEVICE_NOT_RECOGNIZED → cliente caía al refresh-token
-    // loop → "no hay conexión". Ahora limpiamos local state y emitimos
-    // 'deviceTakeoverRequired' para que la UI navegue a login + auto-abra
-    // modal "Continuar aquí" (mismo flow que cuando login devuelve
-    // DEVICE_BOUND directamente). El user ya tiene UI lista en
-    // app/(auth)/login.tsx para esto — solo cambiamos el trigger.
-    if (error.response?.status === 403 && error.response.data?.code === 'DEVICE_BOUND') {
-      if (__DEV__) console.log('[API] 403 DEVICE_BOUND on request — emitting deviceTakeoverRequired');
+    // (reinstalo, OS update, sesión huérfana). Cliente VIEJO caía al
+    // refresh-token loop → "no hay conexión". Ahora limpiamos local
+    // state y emitimos 'deviceTakeoverRequired' para que la UI navegue a
+    // login + muestre hint takeover.
+    //
+    // CRITICAL (2026-05-08 hotfix #2): SKIP este handler para endpoints
+    // de auth (login/force-login/refresh). En esos casos:
+    //   - /login DEVICE_BOUND ya lo maneja auth.ts.sanitizeAuthError +
+    //     useLogin onError + login.tsx modal takeover (flow original).
+    //   - Si emitimos deviceTakeoverRequired aquí, authStore.logout() se
+    //     dispara durante el login en curso, desmonta /login screen,
+    //     cancela la mutation, y user ve "sin conexión" sin modal.
+    //   - /force-login mismo problema.
+    //   - /refresh: si falla con DEVICE_BOUND, dejamos que el path de
+    //     refresh natural lo maneje (forceLogout o silencio).
+    const requestUrl = originalRequest?.url || '';
+    const isAuthEndpoint = requestUrl.includes('/api/mobile/auth/');
+    if (
+      !isAuthEndpoint &&
+      error.response?.status === 403 &&
+      error.response.data?.code === 'DEVICE_BOUND'
+    ) {
+      if (__DEV__) console.log('[API] 403 DEVICE_BOUND on non-auth request — emitting deviceTakeoverRequired');
       authEventEmitter.emit('deviceTakeoverRequired');
       return Promise.reject(error);
     }


### PR DESCRIPTION
…s /api/mobile/auth/* (incident 2026-05-08)

Mi PR #70 introdujo un handler en el response interceptor que emite 'deviceTakeoverRequired' cuando llega 403 + DEVICE_BOUND en CUALQUIER request. El bug: ese handler se disparaba TAMBIEN para POST /login y /force-login del mismo flow.

Cuando user tap login y backend responde 403 DEVICE_BOUND (porque tiene otra sesion activa), el flow esperado es:
  1. auth.ts.sanitizeAuthError detecta 403+DEVICE_BOUND
  2. throw Error con code=DEVICE_BOUND
  3. useLogin().onError fires
  4. login.tsx useEffect detecta err.code y abre modal takeover
  5. user confirma -> useForceLogin -> /force-login

Pero mi nuevo handler interceptaba ANTES:
  1. emit 'deviceTakeoverRequired'
  2. authStore listener -> state.logout() (limpia tokens, set isAuthenticated=false)
  3. login screen unmount/remount por cambio de auth state
  4. useMutation cancelada -> onError nunca dispara
  5. modal nunca se muestra
  6. user ve la app "como si no pasara nada" o toast generico

Reportado: 2026-05-08 incident produccion despues de PR #70 + EAS update prod. Vendedor@jeyma.com (id=3) y otros con el mismo problema.

Fix: skipear el handler cuando la URL del request contenga '/api/mobile/auth/'. Esos endpoints (login, force-login, refresh) ya tienen su propio manejo en auth.ts. Solo aplicar el handler a requests post-login (sync, me, clientes, pedidos, etc.) — su uso original.

Verificacion local:
- mobile tsc clean
- mobile jest 7/7 pass