### PR TITLE
feat(mobile-auth): rediseño sesiones Netflix-style — 1 código error + sid claim + picker UI

### DIFF
--- a/apps/mobile-app/app/(auth)/login.tsx
+++ b/apps/mobile-app/app/(auth)/login.tsx
@@ -59,14 +59,32 @@ export default function LoginScreen() {
   useEffect(() => {
     if (!loginMutation.isError) return;
     const err = loginMutation.error as any;
+
+    // Audit 2026-05-18: nuevo flow Netflix-style. Si el user alcanzó el
+    // límite de sesiones del plan, navegar a la pantalla session-limit
+    // que muestra picker con las sesiones activas. User elige cual
+    // revocar para entrar (atomic via /revoke-and-login).
+    if (err?.code === 'SESSION_LIMIT_REACHED') {
+      router.push({
+        pathname: '/(auth)/session-limit' as any,
+        params: {
+          email: email.trim(),
+          password,
+          totpCode: totpRequired ? totpCode.trim() : '',
+          activeSessions: JSON.stringify(err.activeSessions ?? []),
+          maxSessions: String(err.maxSessions ?? 1),
+        },
+      });
+      return;
+    }
+
+    // Legacy fallback: DEVICE_BOUND viene solo de /force-login (deprecated).
     if (err?.code === 'DEVICE_BOUND') {
       setShowDeviceBoundModal(true);
       return;
     }
     if (err?.code === 'TOTP_REQUIRED') {
       setTotpRequired(true);
-      // Si el usuario ya había ingresado un código (segundo intento fallido),
-      // limpiarlo y avisar.
       if (totpCode) {
         setErrors((e) => ({ ...e, totpCode: 'Código inválido' }));
         setTotpCode('');
@@ -79,7 +97,7 @@ export default function LoginScreen() {
       text2: err?.message || 'Intenta de nuevo',
       visibilityTime: 4000,
     });
-  }, [loginMutation.isError, loginMutation.error, totpCode]);
+  }, [loginMutation.isError, loginMutation.error, totpCode, email, password, totpRequired, router]);
 
   useEffect(() => {
     if (!forceLoginMutation.isError) return;

--- a/apps/mobile-app/app/(auth)/session-limit.tsx
+++ b/apps/mobile-app/app/(auth)/session-limit.tsx
@@ -1,0 +1,251 @@
+import { useState, useMemo } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Platform,
+  ImageBackground,
+} from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useMutation } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+import { Smartphone, Tablet, Monitor, ChevronLeft, Check } from 'lucide-react-native';
+import { HandyLogo } from '@/components/shared/HandyLogo';
+import { COLORS } from '@/theme/colors';
+import { authApi } from '@/api';
+import { useAuthStore } from '@/stores';
+import type { MySession } from '@/api/auth';
+
+/**
+ * Audit 2026-05-18 — pantalla del flow Netflix/Spotify-style.
+ *
+ * Llegamos aquí desde login.tsx cuando el backend devolvió
+ * SESSION_LIMIT_REACHED (user alcanzó el límite de sesiones concurrentes
+ * de su plan). Muestra picker con las sesiones activas; user elige una
+ * para revocarla y entrar al app via POST /api/mobile/auth/revoke-and-login.
+ *
+ * Si el user cancela, regresa a login sin tocar nada server-side.
+ */
+export default function SessionLimitScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    email: string;
+    password: string;
+    totpCode?: string;
+    activeSessions: string;
+    maxSessions: string;
+  }>();
+
+  const sessions = useMemo<MySession[]>(() => {
+    try {
+      return JSON.parse(params.activeSessions || '[]');
+    } catch {
+      return [];
+    }
+  }, [params.activeSessions]);
+
+  const maxSessions = parseInt(params.maxSessions || '1', 10);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const loginToStore = useAuthStore((s) => s.login);
+
+  const revokeAndLoginMutation = useMutation({
+    mutationFn: async (sessionId: number) => {
+      return authApi.revokeAndLogin(
+        params.email,
+        params.password,
+        sessionId,
+        params.totpCode || undefined,
+      );
+    },
+    onSuccess: async (data) => {
+      await loginToStore(data.user, data.token, data.refreshToken);
+      // Replace navigation: usuario no debe poder hacer "back" al picker.
+      router.replace('/(tabs)' as any);
+    },
+    onError: (err: any) => {
+      Toast.show({
+        type: 'error',
+        text1: 'No se pudo iniciar sesión',
+        text2: err?.message || 'Intenta de nuevo',
+        visibilityTime: 4000,
+      });
+    },
+  });
+
+  const handleSelect = (sessionId: number) => {
+    setSelectedId(sessionId);
+  };
+
+  const handleConfirm = () => {
+    if (selectedId == null) return;
+    revokeAndLoginMutation.mutate(selectedId);
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  const formatLastActivity = (iso: string): string => {
+    try {
+      const d = new Date(iso);
+      const diff = Date.now() - d.getTime();
+      if (diff < 60_000) return 'Hace unos segundos';
+      if (diff < 3600_000) return `Hace ${Math.floor(diff / 60_000)} min`;
+      if (diff < 86400_000) return `Hace ${Math.floor(diff / 3600_000)} h`;
+      const days = Math.floor(diff / 86400_000);
+      return days === 1 ? 'Ayer' : `Hace ${days} días`;
+    } catch {
+      return '';
+    }
+  };
+
+  const getIcon = (type: string, size = 22) => {
+    const t = (type || '').toLowerCase();
+    if (t === 'android' || t === 'ios') return <Smartphone size={size} color={COLORS.primary} />;
+    if (t === 'tablet') return <Tablet size={size} color={COLORS.primary} />;
+    return <Monitor size={size} color={COLORS.primary} />;
+  };
+
+  return (
+    <ImageBackground
+      source={require('@/../assets/images/onboarding/login-bg.png')}
+      style={styles.bg}
+      imageStyle={styles.bgImage}
+    >
+      <ScrollView
+        contentContainerStyle={[styles.scroll, { paddingTop: insets.top + 24, paddingBottom: insets.bottom + 24 }]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.card}>
+          <View style={styles.headerRow}>
+            <TouchableOpacity onPress={handleCancel} style={styles.backBtn} accessibilityLabel="Volver">
+              <ChevronLeft size={22} color={COLORS.foreground} />
+            </TouchableOpacity>
+            <View style={styles.logoSlot}>
+              <HandyLogo size={36} />
+            </View>
+            <View style={{ width: 22 }} />
+          </View>
+
+          <Text style={styles.title}>Límite de sesiones alcanzado</Text>
+          <Text style={styles.subtitle}>
+            Tu plan permite {maxSessions} {maxSessions === 1 ? 'sesión activa' : 'sesiones activas'}. Elige una para cerrarla y continuar aquí.
+          </Text>
+
+          <View style={styles.sessionsList}>
+            {sessions.map((session) => {
+              const isSelected = selectedId === session.id;
+              return (
+                <TouchableOpacity
+                  key={session.id}
+                  style={[styles.sessionCard, isSelected && styles.sessionCardSelected]}
+                  onPress={() => handleSelect(session.id)}
+                  activeOpacity={0.85}
+                >
+                  <View style={styles.sessionIcon}>{getIcon(session.deviceType)}</View>
+                  <View style={styles.sessionInfo}>
+                    <Text style={styles.sessionName} numberOfLines={1}>
+                      {session.deviceName || 'Dispositivo'}
+                    </Text>
+                    <Text style={styles.sessionMeta} numberOfLines={1}>
+                      {formatLastActivity(session.lastActivity)}
+                      {session.ipCity ? ` · ${session.ipCity}` : ''}
+                    </Text>
+                  </View>
+                  <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
+                    {isSelected && <Check size={16} color="#ffffff" />}
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+
+          <TouchableOpacity
+            style={[styles.confirmBtn, (!selectedId || revokeAndLoginMutation.isPending) && styles.confirmBtnDisabled]}
+            onPress={handleConfirm}
+            disabled={!selectedId || revokeAndLoginMutation.isPending}
+            activeOpacity={0.85}
+          >
+            {revokeAndLoginMutation.isPending ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={styles.confirmBtnText}>Desconectar y continuar aquí</Text>
+            )}
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={handleCancel} style={styles.cancelBtn} activeOpacity={0.7}>
+            <Text style={styles.cancelBtnText}>Cancelar</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </ImageBackground>
+  );
+}
+
+const styles = StyleSheet.create({
+  bg: { flex: 1, backgroundColor: '#000' },
+  bgImage: { opacity: 0.45 },
+  scroll: { flexGrow: 1, paddingHorizontal: 16, justifyContent: 'center' },
+  card: {
+    backgroundColor: 'rgba(255,255,255,0.96)',
+    borderRadius: 18,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+  },
+  headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  backBtn: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
+  logoSlot: { alignItems: 'center' },
+  title: { fontSize: 20, fontWeight: '800', color: COLORS.foreground, textAlign: 'center', marginTop: 12 },
+  subtitle: { fontSize: 14, color: COLORS.textSecondary, textAlign: 'center', lineHeight: 20, marginTop: 8, marginBottom: 20 },
+  sessionsList: { gap: 10, marginBottom: 16 },
+  sessionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: '#e5e7eb',
+    backgroundColor: '#f8fafc',
+    gap: 12,
+  },
+  sessionCardSelected: {
+    borderColor: COLORS.primary,
+    backgroundColor: '#eff6ff',
+  },
+  sessionIcon: { width: 40, height: 40, borderRadius: 10, alignItems: 'center', justifyContent: 'center', backgroundColor: '#ffffff' },
+  sessionInfo: { flex: 1 },
+  sessionName: { fontSize: 14, fontWeight: '700', color: COLORS.foreground },
+  sessionMeta: { fontSize: 12, color: COLORS.textSecondary, marginTop: 2 },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: '#cbd5e1',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+  },
+  checkboxSelected: { backgroundColor: COLORS.primary, borderColor: COLORS.primary },
+  confirmBtn: {
+    backgroundColor: COLORS.primary,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  confirmBtnDisabled: { opacity: 0.5 },
+  confirmBtnText: { color: '#ffffff', fontSize: 15, fontWeight: '700' },
+  cancelBtn: { paddingVertical: 12, alignItems: 'center', marginTop: 4 },
+  cancelBtnText: { color: COLORS.textSecondary, fontSize: 13 },
+});

--- a/apps/mobile-app/app/(tabs)/historial-rutas.tsx
+++ b/apps/mobile-app/app/(tabs)/historial-rutas.tsx
@@ -44,16 +44,34 @@ export default function HistorialRutasScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
   const fetchRutas = useCallback(async () => {
+    setErrorMsg(null);
     try {
       const res = await api.get<{ success: boolean; data: RutaHistoricoItem[]; count: number }>(
         '/api/mobile/rutas/historico',
         { params: { limit: 30 } }
       );
       setRutas(res.data?.data ?? []);
-    } catch {
-      // Silent — empty state se mostrará. Toast/error explícito sería
-      // ruido si vendedor solo está sin red al abrir la pantalla.
+    } catch (err: any) {
+      // Audit 2026-05-18: ya no silenciamos errores. Logueamos para
+      // diagnóstico y mostramos mensaje al user — ocultar el error
+      // hacía aparecer "Sin rutas" cuando en realidad había auth/network
+      // issue, confundiendo al vendedor.
+      const status = err?.response?.status;
+      const code = err?.response?.data?.code;
+      if (__DEV__) console.warn('[historial-rutas] fetch failed', status, code, err?.message);
+
+      if (code === 'SESSION_REVOKED' || code === 'DEVICE_REVOKED') {
+        setErrorMsg('Tu sesión fue cerrada. Inicia sesión de nuevo.');
+      } else if (err?.isNetworkError || !err?.response) {
+        setErrorMsg('Sin conexión. Verifica tu red.');
+      } else if (status && status >= 500) {
+        setErrorMsg('Error del servidor. Intenta más tarde.');
+      } else {
+        setErrorMsg('No se pudo cargar el historial. Intenta de nuevo.');
+      }
       setRutas([]);
     }
     setLoading(false);
@@ -125,7 +143,13 @@ export default function HistorialRutasScreen() {
         removeClippedSubviews
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={COLORS.primary} colors={[COLORS.primary]} />}
         ListEmptyComponent={
-          loading ? null : (
+          loading ? null : errorMsg ? (
+            <EmptyState
+              icon={<Route size={48} color="#dc2626" />}
+              title="Error al cargar"
+              message={errorMsg}
+            />
+          ) : (
             <EmptyState
               icon={<Route size={48} color="#cbd5e1" />}
               title="Sin rutas"

--- a/apps/mobile-app/src/api/auth.ts
+++ b/apps/mobile-app/src/api/auth.ts
@@ -12,6 +12,22 @@ import type { MeResponse } from './schemas';
 const LoginResponseWrapperSchema = ApiResponseSchema(LoginResponseSchema);
 const MeResponseWrapperSchema = ApiResponseSchema(MeResponseSchema);
 
+/**
+ * Audit 2026-05-18 — sesión activa según endpoint /my-sessions y datos del
+ * picker en SESSION_LIMIT_REACHED.
+ */
+export interface MySession {
+  id: number;
+  deviceName: string;
+  deviceType: string;
+  lastActivity: string;
+  loggedInAt: string;
+  appVersion: string;
+  osVersion: string;
+  ipCity: string;
+  isCurrent: boolean;
+}
+
 class MobileAuthApi {
   private basePath = '/api/mobile/auth';
 
@@ -27,17 +43,25 @@ class MobileAuthApi {
       const code = error.response?.data?.code;
       const backendMessage = error.response?.data?.message;
 
+      // Legacy: DEVICE_BOUND seguía siendo usado por /force-login (deprecated).
+      // Nuevo flow LoginAsync (audit 2026-05-18) usa SESSION_LIMIT_REACHED.
       if (status === 403 && code === 'DEVICE_BOUND') {
         const err = new Error(backendMessage || 'Tu cuenta está activa en otro dispositivo.');
         (err as any).code = 'DEVICE_BOUND';
         throw err;
       }
-      // VULN-M03 fix: backend retorna 401 + code=TOTP_REQUIRED cuando el
-      // usuario tiene 2FA habilitado. La UI debe mostrar un input para
-      // ingresar el código y reintentar el mismo login con totpCode.
+      // VULN-M03 fix: 2FA enforcement.
       if (status === 401 && code === 'TOTP_REQUIRED') {
         const err = new Error(backendMessage || 'Se requiere código de autenticación 2FA');
         (err as any).code = 'TOTP_REQUIRED';
+        throw err;
+      }
+      // Audit 2026-05-18 — session revoked durante refresh attempt o explicit
+      // (admin revoke, otro device tomó la sesión, etc.). Cliente debe mostrar
+      // mensaje claro pero sin auto-logout brusco.
+      if (status === 401 && (code === 'SESSION_REVOKED' || code === 'DEVICE_REVOKED')) {
+        const err = new Error(backendMessage || 'Tu sesión fue cerrada. Por favor inicia sesión de nuevo.');
+        (err as any).code = 'SESSION_REVOKED';
         throw err;
       }
       if (status === 401) throw new Error('Correo o contraseña incorrectos');
@@ -52,14 +76,56 @@ class MobileAuthApi {
 
   async login(email: string, password: string, totpCode?: string): Promise<LoginResponse> {
     try {
-      const response = await api.post<ApiResponse<LoginResponse>>(
+      const response = await api.post<any>(
         `${this.basePath}/login`,
         { email, password, totpCode }
+      );
+
+      // Audit 2026-05-18: nuevo flow Netflix-style. Si el user alcanzó el
+      // límite de sesiones del plan, el backend devuelve 200 con
+      // success=false + code=SESSION_LIMIT_REACHED + data.activeSessions.
+      // Throw error con code para que useLogin lo propague a la pantalla
+      // de session-limit (picker).
+      const body = response.data;
+      if (body && body.success === false && body.code === 'SESSION_LIMIT_REACHED') {
+        const err = new Error(body.message || 'Has alcanzado el límite de sesiones');
+        (err as any).code = 'SESSION_LIMIT_REACHED';
+        (err as any).activeSessions = body.data?.activeSessions ?? [];
+        (err as any).maxSessions = body.data?.maxSessions ?? 1;
+        throw err;
+      }
+
+      const validated = validateResponse(
+        LoginResponseWrapperSchema,
+        body,
+        'POST /api/mobile/auth/login'
+      );
+      if (!validated.success) {
+        throw new Error(validated.message || 'Error al iniciar sesión');
+      }
+      return validated.data;
+    } catch (error) {
+      // Re-throw si ya tiene code (SESSION_LIMIT_REACHED u otro propagado).
+      if (error instanceof Error && (error as any).code) throw error;
+      this.sanitizeAuthError(error);
+    }
+  }
+
+  /**
+   * Audit 2026-05-18 — flow nuevo Netflix-style. User llegó aquí desde
+   * la pantalla session-limit (picker) tras tocar el límite en login normal.
+   * Atomic: revoca la sesión que user eligió + crea nueva + emite tokens.
+   */
+  async revokeAndLogin(email: string, password: string, revokeSessionId: number, totpCode?: string): Promise<LoginResponse> {
+    try {
+      const response = await api.post<ApiResponse<LoginResponse>>(
+        `${this.basePath}/revoke-and-login`,
+        { email, password, totpCode, revokeSessionId }
       );
       const validated = validateResponse(
         LoginResponseWrapperSchema,
         response.data,
-        'POST /api/mobile/auth/login'
+        'POST /api/mobile/auth/revoke-and-login'
       );
       if (!validated.success) {
         throw new Error(validated.message || 'Error al iniciar sesión');
@@ -71,9 +137,28 @@ class MobileAuthApi {
   }
 
   /**
-   * Force-login: cierra otras sesiones activas y crea nueva. El cliente lo
-   * invoca tras confirmar en modal "¿Desconectar otro dispositivo?". También
-   * acepta totpCode si el usuario tiene 2FA habilitado.
+   * Audit 2026-05-18 — pantalla "Mis sesiones".
+   */
+  async getMySessions(): Promise<MySession[]> {
+    const response = await api.get<{ success: boolean; data: MySession[] }>(
+      `${this.basePath}/my-sessions`
+    );
+    return response.data?.data ?? [];
+  }
+
+  /**
+   * Audit 2026-05-18 — revocar una sesión propia (self-service). Si revoca
+   * la actual, el siguiente request devuelve 401 SESSION_REVOKED.
+   */
+  async revokeMySession(sessionId: number): Promise<void> {
+    await api.post(`${this.basePath}/revoke-session/${sessionId}`);
+  }
+
+  /**
+   * Force-login: deprecated (audit 2026-05-18). Reemplazado por flow
+   * SESSION_LIMIT_REACHED + revokeAndLogin. Mantenido como fallback durante
+   * window de compat para clientes pre-OTA. Será removido en 60 días.
+   * @deprecated Use revokeAndLogin con sessionId del picker.
    */
   async forceLogin(email: string, password: string, totpCode?: string): Promise<LoginResponse> {
     try {

--- a/apps/mobile-app/src/api/client.ts
+++ b/apps/mobile-app/src/api/client.ts
@@ -192,7 +192,16 @@ apiInstance.interceptors.request.use(async (config: InternalAxiosRequestConfig) 
   return config;
 });
 
-// --- Response interceptor: 401 handling with token refresh + device binding ---
+// --- Response interceptor: 401 handling with token refresh ---
+// Audit 2026-05-18 — rediseño Netflix/Spotify-style:
+// Backend ahora responde 1 solo código de session error: SESSION_REVOKED (401).
+// Cliente: emite 'sessionRevoked' como SOFT signal (no auto-logout). El
+// authStore listener muestra banner persistente; user decide cuándo
+// re-loguear. Tokens locales SE CONSERVAN hasta que user vaya a login
+// screen. Pending data en WDB intacto.
+//
+// Para AUTH endpoints (login/refresh/revoke-and-login), NO emitir eventos
+// porque el caller (useLogin/auth.ts) maneja directamente.
 apiInstance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError<{ code?: string; message?: string }>) => {
@@ -200,70 +209,40 @@ apiInstance.interceptors.response.use(
       _retry?: boolean;
     };
 
-    // Audit 2026-05-08: middleware backend responde 403 + DEVICE_BOUND
-    // cuando el fingerprint del request no matchea ninguna sesión activa
-    // (reinstalo, OS update, sesión huérfana). Cliente VIEJO caía al
-    // refresh-token loop → "no hay conexión". Ahora limpiamos local
-    // state y emitimos 'deviceTakeoverRequired' para que la UI navegue a
-    // login + muestre hint takeover.
-    //
-    // CRITICAL (2026-05-08 hotfix #2): SKIP este handler para endpoints
-    // de auth (login/force-login/refresh). En esos casos:
-    //   - /login DEVICE_BOUND ya lo maneja auth.ts.sanitizeAuthError +
-    //     useLogin onError + login.tsx modal takeover (flow original).
-    //   - Si emitimos deviceTakeoverRequired aquí, authStore.logout() se
-    //     dispara durante el login en curso, desmonta /login screen,
-    //     cancela la mutation, y user ve "sin conexión" sin modal.
-    //   - /force-login mismo problema.
-    //   - /refresh: si falla con DEVICE_BOUND, dejamos que el path de
-    //     refresh natural lo maneje (forceLogout o silencio).
     const requestUrl = originalRequest?.url || '';
     const isAuthEndpoint = requestUrl.includes('/api/mobile/auth/');
-    if (
-      !isAuthEndpoint &&
-      error.response?.status === 403 &&
-      error.response.data?.code === 'DEVICE_BOUND'
-    ) {
-      if (__DEV__) console.log('[API] 403 DEVICE_BOUND on non-auth request — emitting deviceTakeoverRequired');
-      authEventEmitter.emit('deviceTakeoverRequired');
-      return Promise.reject(error);
-    }
 
     if (error.response?.status === 401) {
       const errorCode = error.response.data?.code;
-      // Capturamos el token con el que se mandó la request original.
-      // Si entre el envío y recibir el 401, el user hizo login fresh,
-      // _cachedAccessToken cambió — el 401 corresponde a la sesión vieja
-      // y NO debe disparar forceLogout sobre la sesión nueva.
       const tokenAtRequest = (originalRequest.headers?.Authorization as string | undefined)
         ?.replace('Bearer ', '');
 
-      // Bug #1 (audit 2026-05-07): si la request usó un token que fue
-      // explícitamente superado por login/force-login fresh, ignorar el
-      // 401 SIN intentar refresh. El refresh_token previo también fue
-      // revocado server-side; intentar refresh solo logra:
-      //   1) golpear el rate limit (5/min) → 429 → toast "demasiados reintentos"
-      //   2) processQueueError + forceLogout cascade → mata la sesión
-      //      nueva válida que el user acaba de aceptar
-      // Reportado: vendedor@jeyma.com, modal "Continuar aquí" → logout instantáneo.
+      // Guard race: si el token de la request fue superado por login fresh,
+      // ignorar el 401 sin emitir nada (la sesión nueva es válida).
       if (tokenAtRequest && _staleTokens.has(tokenAtRequest)) {
-        if (__DEV__) console.log('[API] 401 on stale token — ignoring (superseded by force-login)');
+        if (__DEV__) console.log('[API] 401 on stale token — ignoring (superseded by fresh login)');
         return Promise.reject(error);
       }
 
-      // Device was revoked by admin — force logout with specific message
-      if (errorCode === 'DEVICE_REVOKED' || errorCode === 'SESSION_REVOKED') {
-        // Guard: si el JWT actual ya es uno nuevo, ignorar — el revoke
-        // aplicaba a la sesión previa, ya superada por login fresh.
+      // SESSION_REVOKED: sesión específica revocada server-side (logout en
+      // otro device, admin revoke, expiración, etc.). Emit 'sessionRevoked'
+      // como SOFT signal. authStore NO hace clear de tokens — sólo marca
+      // state.sessionExpired = true. UI muestra banner persistente.
+      // Pending data en WDB intacta.
+      if (errorCode === 'SESSION_REVOKED' || errorCode === 'DEVICE_REVOKED') {
         if (tokenAtRequest && _cachedAccessToken && tokenAtRequest !== _cachedAccessToken) {
           if (__DEV__) console.log('[API] 401 SESSION_REVOKED on stale token — ignoring (user re-logged in)');
           return Promise.reject(error);
         }
-        authEventEmitter.emit('deviceRevoked');
+        if (!isAuthEndpoint) {
+          if (__DEV__) console.log('[API] 401 SESSION_REVOKED — emitting sessionRevoked (soft)');
+          authEventEmitter.emit('sessionRevoked');
+        }
         return Promise.reject(error);
       }
 
-      if (!originalRequest._retry) {
+      // 401 sin code conocido: intentar token refresh una vez.
+      if (!originalRequest._retry && !isAuthEndpoint) {
         originalRequest._retry = true;
 
         if (!isRefreshing) {
@@ -283,21 +262,29 @@ apiInstance.interceptors.response.use(
             return apiInstance(originalRequest);
           }
         } catch (e) {
-          // fall through
-          if (__DEV__) console.warn('[API]', e);
+          if (__DEV__) console.warn('[API] refresh failed', e);
         }
 
-        // Guard: si el cliente ya tiene un token válido distinto del que
-        // falló (login fresh ocurrió mientras hacíamos refresh), no
-        // forzamos logout — la sesión nueva es válida.
+        // Refresh fail: si el cliente ya tiene token nuevo distinto, no
+        // hacer logout (race con login fresh).
         if (tokenAtRequest && _cachedAccessToken && tokenAtRequest !== _cachedAccessToken) {
-          if (__DEV__) console.log('[API] refresh fail on stale token — ignoring (user re-logged in)');
+          if (__DEV__) console.log('[API] refresh fail on stale token — ignoring');
           return Promise.reject(error);
         }
 
+        // Refresh definitivamente falló → tratar como sesión revocada (soft).
+        // NO emit 'forceLogout' (legacy hard logout). Emit sessionRevoked
+        // para que UI muestre banner y user decida.
         processQueueError(new Error('Token refresh failed'));
-        authEventEmitter.emit('forceLogout');
+        if (__DEV__) console.log('[API] refresh exhausted — emitting sessionRevoked (soft)');
+        authEventEmitter.emit('sessionRevoked');
       }
+    }
+
+    // Network errors (axios sin response): marcar específicamente para que
+    // callers diferencien "sin conexión" vs "401 sin procesar".
+    if (!error.response) {
+      (error as AxiosError & { isNetworkError?: boolean }).isNetworkError = true;
     }
 
     return Promise.reject(error);

--- a/apps/mobile-app/src/stores/authStore.ts
+++ b/apps/mobile-app/src/stores/authStore.ts
@@ -12,11 +12,20 @@ interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
   isLoggingIn: boolean;
+  /**
+   * Audit 2026-05-18 — soft signal: sesión revocada server-side (otro device
+   * tomó la sesión, admin revoke, expiración). UI muestra banner persistente
+   * "Tu sesión fue cerrada, presiona aquí para iniciar sesión". Mientras
+   * tanto, tokens locales NO se borran y WDB conserva pending data
+   * (pedidos, clientes capturados offline). User decide cuándo re-loguear.
+   */
+  sessionExpired: boolean;
 
   login: (user: AuthUser, token: string, refreshToken: string) => Promise<void>;
   logout: () => Promise<void>;
   restoreSession: () => Promise<void>;
   setLoggingIn: (loading: boolean) => void;
+  setSessionExpired: (expired: boolean) => void;
   /**
    * Actualiza campos del usuario logueado (merge parcial). Persiste el
    * snapshot en secureStorage. Usado por `useMe` cuando refresca el perfil
@@ -30,6 +39,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   isAuthenticated: false,
   isLoading: true,
   isLoggingIn: false,
+  sessionExpired: false,
 
   login: async (user, token, refreshToken) => {
     setAccessToken(token);
@@ -47,8 +57,11 @@ export const useAuthStore = create<AuthState>((set) => ({
         mustChangePassword: user.mustChangePassword ?? false,
       })),
     ]);
-    set({ user, isAuthenticated: true, isLoading: false, isLoggingIn: false });
+    // Clear sessionExpired flag al hacer login fresh.
+    set({ user, isAuthenticated: true, isLoading: false, isLoggingIn: false, sessionExpired: false });
   },
+
+  setSessionExpired: (expired: boolean) => set({ sessionExpired: expired }),
 
   logout: async () => {
     setAccessToken(null);
@@ -141,18 +154,28 @@ authEventEmitter.on('deviceRevoked', () => {
   );
 });
 
-// Audit 2026-05-08: middleware backend dispara DEVICE_BOUND (403) cuando
-// fingerprint del request no matchea ninguna sesión activa pero user
-// tiene otras (caso reinstalo, OS update, sesión huérfana). Preservamos
-// el email del user para que la pantalla de login lo pre-rellene y
-// muestre hint "Tu sesión está activa en otro dispositivo. Ingresa tu
-// contraseña para tomarla aquí". User pone password → tap login → backend
-// devuelve DEVICE_BOUND → modal takeover normal → /force-login.
+// Audit 2026-05-18 — soft session revoked. Backend devolvió 401
+// SESSION_REVOKED en algún endpoint (sesión cerrada en otro device,
+// admin revoke, refresh agotado). NO hacer auto-logout que limpie
+// tokens — eso destruye pending data path en WDB y confunde al user.
+// Solo marcar state.sessionExpired = true; UI muestra banner persistente
+// con tap → login screen.
+//
+// Beneficios vs viejo flow (deviceTakeoverRequired/forceLogout):
+// 1. WDB local intacto — pedidos/clientes pendientes no se pierden
+// 2. User decide cuándo re-loguear (no forzado)
+// 3. No race conditions durante mutations en flight
+// 4. Si vuelve la sesión válida (race con otra app session activa),
+//    el siguiente request natural sucede sin interrupciones
+authEventEmitter.on('sessionRevoked', () => {
+  useAuthStore.getState().setSessionExpired(true);
+});
+
+// Backward-compat listeners: handlers viejos siguen disparando si el bundle
+// recibe eventos legacy. Mismo comportamiento soft (no clear tokens).
+authEventEmitter.on('forceLogout', () => {
+  useAuthStore.getState().setSessionExpired(true);
+});
 authEventEmitter.on('deviceTakeoverRequired', () => {
-  const state = useAuthStore.getState();
-  const email = state.user?.email;
-  if (email) {
-    secureStorage.set(STORAGE_KEYS.PENDING_TAKEOVER_EMAIL, email).catch(() => {});
-  }
-  state.logout();
+  useAuthStore.getState().setSessionExpired(true);
 });

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
@@ -37,8 +37,6 @@ public static class MobileAuthEndpoints
             {
                 if (result.TotpRequired)
                 {
-                    // 401 con code=TOTP_REQUIRED → cliente muestra UI para
-                    // ingresar código y reintenta el mismo POST con totpCode.
                     return Results.Json(new
                     {
                         success = false,
@@ -47,6 +45,25 @@ public static class MobileAuthEndpoints
                     }, statusCode: 401);
                 }
 
+                // Audit 2026-05-18: nuevo flow Netflix-style. Cuando user
+                // alcanza el límite del plan, devolver 200 con código
+                // SESSION_LIMIT_REACHED + lista de sesiones activas. UI
+                // muestra picker; user elige una para revocar via
+                // /revoke-and-login.
+                if (result.SessionLimitReached)
+                {
+                    return Results.Ok(new
+                    {
+                        success = false,
+                        code = "SESSION_LIMIT_REACHED",
+                        message = result.Message,
+                        data = result.Data
+                    });
+                }
+
+                // Legacy DeviceBound (ForceLoginAsync sigue lo usando para
+                // back-compat con clients pre-OTA). Nuevo LoginAsync ya no
+                // lo devuelve.
                 if (result.DeviceBound)
                 {
                     return Results.Json(new
@@ -78,10 +95,109 @@ public static class MobileAuthEndpoints
         })
         .RequireRateLimiting("mobile-auth")
         .WithSummary("Login de vendedor móvil")
-        .WithDescription("Autentica un vendedor y devuelve tokens JWT. Si el usuario tiene 2FA, primero retorna 401 + code=TOTP_REQUIRED; el cliente repite el POST con totpCode. Incluir headers X-Device-Id y X-Device-Fingerprint para device binding.")
+        .WithDescription("Autentica un vendedor y devuelve tokens JWT. Si tiene 2FA → 401 TOTP_REQUIRED. Si alcanzó límite de sesiones del plan → 200 SESSION_LIMIT_REACHED con lista de sesiones activas (UI debe mostrar picker).")
         .Produces<object>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
         .Produces(StatusCodes.Status403Forbidden);
+
+        // ──────────────────────────────────────────────────────────
+        // POST /revoke-and-login (audit 2026-05-18)
+        // Atomic: revoca sesión elegida en picker + crea nueva + emite tokens.
+        // Body: { email, password, totpCode?, revokeSessionId }
+        // ──────────────────────────────────────────────────────────
+        group.MapPost("/revoke-and-login", async (
+            RevokeAndLoginDto dto,
+            IValidator<UsuarioLoginDto> loginValidator,
+            [FromServices] MobileAuthService auth,
+            HttpContext context) =>
+        {
+            // Reuso validator de login para email + password.
+            var loginDto = new UsuarioLoginDto { email = dto.email, password = dto.password, totpCode = dto.totpCode };
+            var validation = await loginValidator.ValidateAsync(loginDto);
+            if (!validation.IsValid)
+                return Results.BadRequest(new { success = false, errors = validation.ToDictionary() });
+
+            if (dto.revokeSessionId <= 0)
+                return Results.BadRequest(new { success = false, message = "revokeSessionId es requerido" });
+
+            var deviceId = context.Request.Headers["X-Device-Id"].FirstOrDefault();
+            var deviceFingerprint = context.Request.Headers["X-Device-Fingerprint"].FirstOrDefault();
+
+            var result = await auth.RevokeAndLoginAsync(
+                dto.email, dto.password, dto.revokeSessionId,
+                deviceId, deviceFingerprint, dto.totpCode);
+
+            if (!result.Success)
+            {
+                if (result.TotpRequired)
+                {
+                    return Results.Json(new { success = false, code = "TOTP_REQUIRED", message = result.Message }, statusCode: 401);
+                }
+                if (!string.IsNullOrEmpty(result.Message))
+                {
+                    return Results.Json(new { success = false, message = result.Message }, statusCode: 401);
+                }
+                return Results.Unauthorized();
+            }
+
+            return Results.Ok(new { success = true, data = result.Data });
+        })
+        .RequireRateLimiting("mobile-auth")
+        .WithSummary("Revoke other session + login (picker UX)")
+        .WithDescription("Usado tras SESSION_LIMIT_REACHED: user eligió una sesión en el picker UI. Revoca esa sesión + crea nueva en este device + emite tokens. Atomic.")
+        .Produces<object>(StatusCodes.Status200OK);
+
+        // ──────────────────────────────────────────────────────────
+        // GET /my-sessions (audit 2026-05-18)
+        // User ve sus propias sesiones activas. UI mobile "Mis sesiones".
+        // ──────────────────────────────────────────────────────────
+        group.MapGet("/my-sessions", async (
+            [FromServices] MobileAuthService auth,
+            HttpContext context) =>
+        {
+            var userIdStr = context.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                            ?? context.User.FindFirstValue("sub");
+            var tenantIdStr = context.User.FindFirstValue("tenant_id");
+            var sidStr = context.User.FindFirstValue("sid");
+
+            if (!int.TryParse(userIdStr, out var userId) || !int.TryParse(tenantIdStr, out var tenantId))
+                return Results.Unauthorized();
+
+            int? currentSid = int.TryParse(sidStr, out var s) ? s : (int?)null;
+
+            var sessions = await auth.GetMySessionsAsync(userId, tenantId, currentSid);
+            return Results.Ok(new { success = true, data = sessions });
+        })
+        .RequireAuthorization()
+        .WithSummary("Mis sesiones activas")
+        .WithDescription("Devuelve las sesiones activas del user actual con flag isCurrent para identificar la del JWT actual.");
+
+        // ──────────────────────────────────────────────────────────
+        // POST /revoke-session/{sid} (audit 2026-05-18)
+        // User revoca una de sus propias sesiones (self-service).
+        // Si revoca la actual, equivale a logout.
+        // ──────────────────────────────────────────────────────────
+        group.MapPost("/revoke-session/{sessionId:int}", async (
+            int sessionId,
+            [FromServices] MobileAuthService auth,
+            HttpContext context) =>
+        {
+            var userIdStr = context.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                            ?? context.User.FindFirstValue("sub");
+            var tenantIdStr = context.User.FindFirstValue("tenant_id");
+
+            if (!int.TryParse(userIdStr, out var userId) || !int.TryParse(tenantIdStr, out var tenantId))
+                return Results.Unauthorized();
+
+            var ok = await auth.RevokeMySessionAsync(userId, tenantId, sessionId);
+            if (!ok)
+                return Results.NotFound(new { success = false, message = "Sesión no encontrada o ya inactiva" });
+
+            return Results.Ok(new { success = true, message = "Sesión revocada" });
+        })
+        .RequireAuthorization()
+        .WithSummary("Revocar mi sesión específica")
+        .WithDescription("User revoca una de sus propias sesiones (self-service). Si revoca la actual, su próximo request devolverá 401 SESSION_REVOKED.");
 
         // Force-login: ignora DEVICE_BOUND y revoca otras sesiones activas.
         // Cliente lo invoca tras confirmar en modal "¿Desconectar otro dispositivo?".
@@ -234,66 +350,75 @@ public static class MobileAuthEndpoints
 
         group.MapPost("/logout", async (
             LogoutRequest? request,
+            [FromServices] MobileAuthService auth,
             [FromServices] HandySuitesDbContext db,
             HttpContext context) =>
         {
             var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
                            ?? context.User.FindFirst("sub")?.Value;
+            var sidClaim = context.User.FindFirst("sid")?.Value;
 
             if (!string.IsNullOrEmpty(userIdClaim) && int.TryParse(userIdClaim, out var userId))
             {
-                // Revoke refresh token if provided (tokens are stored as SHA-256 hashes)
-                if (!string.IsNullOrEmpty(request?.RefreshToken))
+                // Audit 2026-05-18: nuevo flow per-session. Si el JWT tiene
+                // `sid`, revocamos SOLO esa sesión + sus refresh tokens.
+                // Otras sesiones del user en otros devices: intactas
+                // (key feature del modelo Netflix-style).
+                if (!string.IsNullOrEmpty(sidClaim) && int.TryParse(sidClaim, out var sessionId))
                 {
-                    var hash = SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(request.RefreshToken));
-                    var tokenHash = Convert.ToBase64String(hash);
-                    var token = await db.RefreshTokens
-                        .FirstOrDefaultAsync(t => t.Token == tokenHash && !t.IsRevoked);
-                    if (token != null)
-                    {
-                        token.IsRevoked = true;
-                        token.RevokedAt = DateTime.UtcNow;
-                    }
+                    await auth.LogoutSessionAsync(userId, sessionId);
                 }
                 else
                 {
-                    // SECURITY (audit MED): si el cliente NO mandó refreshToken
-                    // (caso default — el mobile no siempre lo incluye), revocamos
-                    // TODOS los refresh tokens activos de este user. Antes el
-                    // logout sin token era no-op y el token seguía válido hasta
-                    // expirar (default 30 días). Ahora logout = sesión muerta.
-                    var activeTokens = await db.RefreshTokens
-                        .Where(t => t.UserId == userId && !t.IsRevoked && t.ExpiresAt > DateTime.UtcNow)
-                        .ToListAsync();
-                    foreach (var t in activeTokens)
+                    // Fallback legacy (JWT sin sid, pre-rediseño): comportamiento
+                    // anterior — revocar todos los refresh tokens del user +
+                    // sesión por fingerprint si está. Backward-compat window.
+                    if (!string.IsNullOrEmpty(request?.RefreshToken))
                     {
-                        t.IsRevoked = true;
-                        t.RevokedAt = DateTime.UtcNow;
+                        var hash = SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(request.RefreshToken));
+                        var tokenHash = Convert.ToBase64String(hash);
+                        var token = await db.RefreshTokens
+                            .FirstOrDefaultAsync(t => t.Token == tokenHash && !t.IsRevoked);
+                        if (token != null)
+                        {
+                            token.IsRevoked = true;
+                            token.RevokedAt = DateTime.UtcNow;
+                        }
                     }
-                }
-
-                // Update device session status if fingerprint provided
-                var deviceFingerprint = context.Request.Headers["X-Device-Fingerprint"].FirstOrDefault();
-                if (!string.IsNullOrEmpty(deviceFingerprint))
-                {
-                    var session = await db.DeviceSessions
-                        .IgnoreQueryFilters()
-                        .Where(ds => ds.UsuarioId == userId
-                                  && ds.DeviceFingerprint == deviceFingerprint
-                                  && ds.EliminadoEn == null
-                                  && ds.Status == SessionStatus.Active)
-                        .OrderByDescending(ds => ds.LastActivity)
-                        .FirstOrDefaultAsync();
-
-                    if (session != null)
+                    else
                     {
-                        session.Status = SessionStatus.LoggedOut;
-                        session.LoggedOutAt = DateTime.UtcNow;
-                        session.LogoutReason = "user_logout";
+                        var activeTokens = await db.RefreshTokens
+                            .Where(t => t.UserId == userId && !t.IsRevoked && t.ExpiresAt > DateTime.UtcNow)
+                            .ToListAsync();
+                        foreach (var t in activeTokens)
+                        {
+                            t.IsRevoked = true;
+                            t.RevokedAt = DateTime.UtcNow;
+                        }
                     }
-                }
 
-                await db.SaveChangesAsync();
+                    var deviceFingerprint = context.Request.Headers["X-Device-Fingerprint"].FirstOrDefault();
+                    if (!string.IsNullOrEmpty(deviceFingerprint))
+                    {
+                        var session = await db.DeviceSessions
+                            .IgnoreQueryFilters()
+                            .Where(ds => ds.UsuarioId == userId
+                                      && ds.DeviceFingerprint == deviceFingerprint
+                                      && ds.EliminadoEn == null
+                                      && ds.Status == SessionStatus.Active)
+                            .OrderByDescending(ds => ds.LastActivity)
+                            .FirstOrDefaultAsync();
+
+                        if (session != null)
+                        {
+                            session.Status = SessionStatus.LoggedOut;
+                            session.LoggedOutAt = DateTime.UtcNow;
+                            session.LogoutReason = "user_logout_legacy";
+                        }
+                    }
+
+                    await db.SaveChangesAsync();
+                }
             }
 
             return Results.Ok(new { success = true, message = "Sesión cerrada exitosamente" });
@@ -367,3 +492,14 @@ public class LogoutRequest
 
 /// <summary>Payload para POST /api/mobile/auth/change-password.</summary>
 public record ChangePasswordDto(string OldPassword, string NewPassword);
+
+/// <summary>Audit 2026-05-18 — payload para POST /api/mobile/auth/revoke-and-login.
+/// User llegó aquí desde el picker UI tras SESSION_LIMIT_REACHED en login normal.
+/// revokeSessionId = id de la sesión que user eligió cerrar.</summary>
+public class RevokeAndLoginDto
+{
+    public string email { get; set; } = string.Empty;
+    public string password { get; set; } = string.Empty;
+    public string? totpCode { get; set; }
+    public int revokeSessionId { get; set; }
+}

--- a/apps/mobile/HandySuites.Mobile.Api/Middleware/MobileSessionValidationMiddleware.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Middleware/MobileSessionValidationMiddleware.cs
@@ -7,8 +7,17 @@ using Microsoft.Extensions.Caching.Memory;
 namespace HandySuites.Mobile.Api.Middleware;
 
 /// <summary>
-/// Validates that the mobile device session has not been revoked by admin.
-/// Checks DeviceSession status via the X-Device-Fingerprint header.
+/// Audit 2026-05-18 — rediseño Netflix/Spotify-style session model.
+///
+/// Valida que la DeviceSession del request (identificada por el claim `sid`
+/// del JWT) siga Active. Si no, devuelve 401 SESSION_REVOKED uniforme.
+///
+/// Cambio vs versión anterior (DEVICE_BOUND / DEVICE_NOT_RECOGNIZED /
+/// DEVICE_FINGERPRINT_REQUIRED): un solo código de error, vinculado
+/// criptográficamente al token (no por fingerprint match frágil).
+///
+/// Backward compat: JWTs sin claim `sid` (legacy pre-deploy) se aceptan
+/// durante window de 30 días. Después de eso se rechazan también.
 /// </summary>
 public class MobileSessionValidationMiddleware
 {
@@ -23,14 +32,14 @@ public class MobileSessionValidationMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        // Skip for unauthenticated requests
+        // Skip para requests no autenticadas (login, refresh, etc.)
         if (context.User.Identity?.IsAuthenticated != true)
         {
             await _next(context);
             return;
         }
 
-        // Skip for excluded paths
+        // Skip paths excluidos (login/refresh/health/swagger).
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
         if (ShouldSkipValidation(path))
         {
@@ -38,129 +47,57 @@ public class MobileSessionValidationMiddleware
             return;
         }
 
-        var userIdClaim = context.User.FindFirstValue(ClaimTypes.NameIdentifier)
-                        ?? context.User.FindFirstValue("sub");
-        var deviceFingerprint = context.Request.Headers["X-Device-Fingerprint"].FirstOrDefault();
-
-        if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+        // Si el JWT no tiene claim `sid` (token legacy generado antes del
+        // rediseño 2026-05-18), permitir paso durante backward-compat window.
+        // Tokens viejos expiran <30d, naturalmente se renuevan con sid.
+        var sidClaim = context.User.FindFirstValue("sid");
+        if (string.IsNullOrEmpty(sidClaim) || !int.TryParse(sidClaim, out var sessionId))
         {
             await _next(context);
             return;
         }
 
-        // If fingerprint is absent, check if user has any device sessions — if so, require it
-        if (string.IsNullOrEmpty(deviceFingerprint))
+        // Validate session status (cached 30s).
+        var cacheKey = $"session_status_{sessionId}";
+        if (!_cache.TryGetValue<SessionStatus>(cacheKey, out var status))
         {
-            var cacheKeyHasSessions = $"has_device_sessions_{userId}";
-            if (!_cache.TryGetValue<bool>(cacheKeyHasSessions, out var hasSessions))
-            {
-                using var scopeCheck = context.RequestServices.CreateScope();
-                var dbCheck = scopeCheck.ServiceProvider.GetRequiredService<HandySuitesDbContext>();
-                hasSessions = await dbCheck.DeviceSessions
-                    .IgnoreQueryFilters()
-                    .AnyAsync(ds => ds.UsuarioId == userId && ds.EliminadoEn == null);
-                _cache.Set(cacheKeyHasSessions, hasSessions, TimeSpan.FromMinutes(2));
-            }
+            using var scope = context.RequestServices.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<HandySuitesDbContext>();
 
-            if (hasSessions)
-            {
-                // Audit 2026-05-08: alias a DEVICE_BOUND/403 (mismo que login).
-                // Antes era DEVICE_FINGERPRINT_REQUIRED/401 — el cliente no lo
-                // manejaba y caía al refresh-token loop → vendedor veía
-                // "no hay conexión" sin poder salir. Ahora reusa el mismo
-                // flow takeover del login (modal "Continuar aquí").
-                context.Response.StatusCode = 403;
-                await context.Response.WriteAsJsonAsync(new
-                {
-                    code = "DEVICE_BOUND",
-                    message = "Tu cuenta está activa en otro dispositivo. Continúa aquí para tomar la sesión."
-                });
-                return;
-            }
+            var session = await db.DeviceSessions
+                .AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(ds => ds.Id == sessionId && ds.EliminadoEn == null)
+                .Select(ds => new { ds.Status })
+                .FirstOrDefaultAsync();
+
+            // Si la sesión no existe (purgada manualmente) → tratarla como Revoked.
+            status = session?.Status ?? SessionStatus.RevokedByAdmin;
+            _cache.Set(cacheKey, status, TimeSpan.FromSeconds(30));
         }
 
-        // Check device session status when fingerprint is present
-        if (!string.IsNullOrEmpty(deviceFingerprint))
+        if (status == SessionStatus.Active)
         {
-            var cacheKey = $"device_status_{userId}_{deviceFingerprint}";
-            if (!_cache.TryGetValue<SessionStatus>(cacheKey, out var sessionStatus))
-            {
-                using var scope = context.RequestServices.CreateScope();
-                var db = scope.ServiceProvider.GetRequiredService<HandySuitesDbContext>();
-
-                var session = await db.DeviceSessions
-                    .IgnoreQueryFilters()
-                    .Where(ds => ds.UsuarioId == userId &&
-                                 ds.DeviceFingerprint == deviceFingerprint &&
-                                 ds.EliminadoEn == null)
-                    .OrderByDescending(ds => ds.LastActivity)
-                    .Select(ds => new { ds.Status })
-                    .FirstOrDefaultAsync();
-
-                if (session == null)
-                {
-                    // Unknown fingerprint — check if user has other sessions
-                    var hasOtherSessions = await db.DeviceSessions
-                        .IgnoreQueryFilters()
-                        .AnyAsync(ds => ds.UsuarioId == userId && ds.EliminadoEn == null);
-
-                    sessionStatus = hasOtherSessions ? SessionStatus.RevokedByAdmin : SessionStatus.Active;
-
-                    if (hasOtherSessions)
-                    {
-                        _cache.Set(cacheKey, sessionStatus, TimeSpan.FromSeconds(30));
-                        // Audit 2026-05-08: alias a DEVICE_BOUND/403 (mismo que login).
-                        // Antes era DEVICE_NOT_RECOGNIZED/401 — el cliente no lo
-                        // manejaba y caía al refresh-token loop → "no hay
-                        // conexión" sin salida. Ahora reusa el flow takeover.
-                        // Casos comunes: reinstalo de app cambia fingerprint,
-                        // OS update mayor cambia modelName, sesiones huérfanas
-                        // de QA/dev. La regla "1 vendedor = 1 device" se
-                        // mantiene en login + force-login.
-                        context.Response.StatusCode = 403;
-                        await context.Response.WriteAsJsonAsync(new
-                        {
-                            code = "DEVICE_BOUND",
-                            message = "Tu cuenta está activa en otro dispositivo. Continúa aquí para tomar la sesión."
-                        });
-                        return;
-                    }
-                }
-
-                sessionStatus = session?.Status ?? SessionStatus.Active;
-                _cache.Set(cacheKey, sessionStatus, TimeSpan.FromSeconds(30));
-            }
-
-            if (sessionStatus == SessionStatus.RevokedByAdmin ||
-                sessionStatus == SessionStatus.PendingUnbind)
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsJsonAsync(new
-                {
-                    code = "DEVICE_REVOKED",
-                    message = "Tu acceso fue revocado por el administrador. Contacta a tu administrador."
-                });
-                return;
-            }
-
-            if (sessionStatus == SessionStatus.Unbound)
-            {
-                context.Response.StatusCode = 401;
-                await context.Response.WriteAsJsonAsync(new
-                {
-                    code = "DEVICE_REVOKED",
-                    message = "Este dispositivo fue desvinculado. Contacta a tu administrador para volver a acceder."
-                });
-                return;
-            }
+            await _next(context);
+            return;
         }
 
-        await _next(context);
+        // Cualquier otro estado = revocada. Mensaje uniforme; cliente lo
+        // maneja como banner "Sesión cerrada, iniciar sesión de nuevo".
+        // El cliente NO debe auto-loguear (para preservar pending data en WDB).
+        context.Response.StatusCode = 401;
+        await context.Response.WriteAsJsonAsync(new
+        {
+            code = "SESSION_REVOKED",
+            message = "Tu sesión fue cerrada. Por favor inicia sesión de nuevo."
+        });
     }
 
     private static bool ShouldSkipValidation(string path)
     {
         return path.StartsWith("/api/mobile/auth/login") ||
+               path.StartsWith("/api/mobile/auth/force-login") ||  // legacy, deprecated
+               path.StartsWith("/api/mobile/auth/revoke-and-login") ||  // nuevo
                path.StartsWith("/api/mobile/auth/refresh") ||
                path.StartsWith("/api/mobile/auth/ack-unbind") ||
                path.StartsWith("/api/crash-reports") ||

--- a/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
@@ -12,10 +12,19 @@ namespace HandySuites.Mobile.Api.Services;
 public class LoginResult
 {
     public bool Success { get; init; }
+    /// <summary>Legacy: true cuando el viejo flow detecta DeviceBound. Mantenido
+    /// para back-compat con ForceLoginAsync. El nuevo flow usa SessionLimitReached
+    /// (audit 2026-05-18). Cuando ambos están en false y Success en false, es
+    /// un fallo de credenciales puro.</summary>
     public bool DeviceBound { get; init; }
     /// <summary>True cuando el usuario tiene 2FA habilitado y el cliente debe
     /// llamar a /verify-totp con el código antes de obtener tokens.</summary>
     public bool TotpRequired { get; init; }
+    /// <summary>Audit 2026-05-18: true cuando el user alcanzó el límite de
+    /// sesiones concurrentes de su plan. En este caso Data incluye
+    /// `activeSessions` (lista para que UI muestre picker) y `maxSessions`.
+    /// User debe revocar una via /revoke-and-login para entrar.</summary>
+    public bool SessionLimitReached { get; init; }
     public string? Message { get; init; }
     public object? Data { get; init; }
 }
@@ -33,143 +42,264 @@ public class MobileAuthService
         _totpVerifier = totpVerifier;
     }
 
-    public async Task<LoginResult> LoginAsync(string email, string password, string? deviceId = null, string? deviceFingerprint = null, string? totpCode = null)
+    public async Task<LoginResult> LoginAsync(string email, string password, string? deviceId = null, string? deviceFingerprint = null, string? totpCode = null, string? deviceName = null)
+    {
+        // ---- 1. Credenciales + estado de cuenta ----
+        var (usuario, authResult) = await AuthenticateCredsAsync(email, password, totpCode);
+        if (authResult != null) return authResult; // login failure (creds, totp, deactivated)
+        // usuario garantizado no-null aquí
+
+        // ---- 2. Check concurrent session limit (Netflix-style) ----
+        // Reusar sesión Active existente del mismo device si la hay (mismo
+        // fingerprint o mismo deviceId). NO cuenta para el limit porque es
+        // el mismo device físico re-logging.
+        var existingSessionSameDevice = await FindExistingSessionForDeviceAsync(usuario!.Id, usuario.TenantId, deviceFingerprint, deviceId);
+
+        var maxSessions = await GetMaxConcurrentSessionsAsync(usuario.TenantId);
+        var activeCount = await CountActiveSessionsAsync(usuario.Id, usuario.TenantId, excludeSessionId: existingSessionSameDevice?.Id);
+
+        if (activeCount >= maxSessions)
+        {
+            // SessionLimitReached: devolver lista de sesiones para que cliente
+            // muestre picker. NO crear sesión nueva ni emitir tokens.
+            var activeSessions = await GetActiveSessionsDtoAsync(usuario.Id, usuario.TenantId);
+            return new LoginResult
+            {
+                Success = false,
+                SessionLimitReached = true,
+                Message = $"Has alcanzado el límite de {maxSessions} sesión{(maxSessions == 1 ? "" : "es")} activa{(maxSessions == 1 ? "" : "s")}. Elige una para cerrarla y continuar aquí.",
+                Data = new
+                {
+                    maxSessions,
+                    currentCount = activeCount,
+                    activeSessions
+                }
+            };
+        }
+
+        // ---- 3. Create/reuse session + emit tokens ----
+        return await CreateSessionAndTokensAsync(usuario, existingSessionSameDevice, deviceId, deviceFingerprint, deviceName);
+    }
+
+    /// <summary>
+    /// Audit 2026-05-18: nuevo flow. El user llegó aquí porque su login tocó
+    /// el límite de sesiones (SESSION_LIMIT_REACHED) y eligió en el picker
+    /// qué sesión revocar. Atomic: verifica creds + TOTP + revoca la sesión
+    /// elegida + crea nueva + emite tokens.
+    /// </summary>
+    public async Task<LoginResult> RevokeAndLoginAsync(string email, string password, int revokeSessionId, string? deviceId = null, string? deviceFingerprint = null, string? totpCode = null, string? deviceName = null)
+    {
+        var (usuario, authResult) = await AuthenticateCredsAsync(email, password, totpCode);
+        if (authResult != null) return authResult;
+
+        // Verificar que la sesión a revocar pertenece a este usuario.
+        var sessionToRevoke = await _db.DeviceSessions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(ds => ds.Id == revokeSessionId &&
+                                       ds.UsuarioId == usuario!.Id &&
+                                       ds.TenantId == usuario.TenantId &&
+                                       ds.EliminadoEn == null);
+
+        if (sessionToRevoke == null)
+        {
+            return new LoginResult
+            {
+                Success = false,
+                Message = "La sesión seleccionada ya no existe."
+            };
+        }
+
+        // Revocar la sesión elegida + sus refresh tokens.
+        await RevokeSessionInternalAsync(sessionToRevoke, reason: "limit_picker");
+
+        // Reuso sesión existente del mismo device si la hay (post-revoke).
+        var existingSessionSameDevice = await FindExistingSessionForDeviceAsync(usuario!.Id, usuario.TenantId, deviceFingerprint, deviceId);
+
+        return await CreateSessionAndTokensAsync(usuario, existingSessionSameDevice, deviceId, deviceFingerprint, deviceName);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers privados — extracción de duplicación cross LoginAsync,
+    // ForceLoginAsync, RevokeAndLoginAsync.
+    // ──────────────────────────────────────────────────────────────
+
+    private async Task<(Usuario? usuario, LoginResult? failure)> AuthenticateCredsAsync(string email, string password, string? totpCode)
     {
         var usuario = await _db.Usuarios.FirstOrDefaultAsync(u => u.Email == email);
-
         var loginSuccess = usuario != null && BCrypt.Net.BCrypt.Verify(password, usuario.PasswordHash);
 
         if (!loginSuccess || usuario == null)
-            return new LoginResult { Success = false };
+            return (null, new LoginResult { Success = false });
 
-        // Check if the user account is active
         if (!usuario.Activo)
-            return new LoginResult { Success = false, Message = "Cuenta desactivada" };
+            return (usuario, new LoginResult { Success = false, Message = "Cuenta desactivada" });
 
-        // VULN-M03 fix: si el usuario tiene 2FA habilitado, exigir código TOTP
-        // antes de emitir tokens. Antes el mobile bypaseaba completamente la
-        // verificación — un atacante con creds robadas pivoteaba al endpoint
-        // mobile y obtenía full access ignorando el segundo factor.
+        // VULN-M03 fix: 2FA enforcement.
         if (usuario.TotpEnabled)
         {
             if (string.IsNullOrEmpty(totpCode))
             {
-                return new LoginResult
+                return (usuario, new LoginResult
                 {
                     Success = false,
                     TotpRequired = true,
                     Message = "Se requiere código de autenticación 2FA"
-                };
+                });
             }
 
             var totpOk = await _totpVerifier.VerifyLoginCodeAsync(usuario.Id, totpCode);
             if (!totpOk)
             {
-                // Fallback: aceptar recovery code (formato XXXX-XXXX). El
-                // verifier marca el código como usado al consumirlo.
                 var recoveryOk = await _totpVerifier.UseRecoveryCodeAsync(usuario.Id, totpCode);
                 if (!recoveryOk)
                 {
-                    return new LoginResult
+                    return (usuario, new LoginResult
                     {
                         Success = false,
                         TotpRequired = true,
                         Message = "Código 2FA inválido"
-                    };
+                    });
                 }
             }
         }
 
-        // --- Device session management ---
-        // Cambio 2026-04-28: el binding check ahora aplica aunque el cliente
-        // NO mande fingerprint (caso APK viejo). Antes el if externo bypaseaba
-        // la restriccion completa para esos clientes.
-        DeviceSession? existingSession = null;
-        if (!string.IsNullOrEmpty(deviceFingerprint) || !string.IsNullOrEmpty(deviceId))
-        {
-            // Find existing session by fingerprint or deviceId (reuse same device session)
-            existingSession = await _db.DeviceSessions
-                .IgnoreQueryFilters()
-                .Where(ds => ds.UsuarioId == usuario.Id &&
-                             ds.TenantId == usuario.TenantId &&
-                             ds.EliminadoEn == null &&
-                             (ds.Status == SessionStatus.Active || ds.Status == SessionStatus.LoggedOut))
-                .OrderByDescending(ds => ds.LastActivity)
-                .FirstOrDefaultAsync(ds =>
-                    (!string.IsNullOrEmpty(deviceFingerprint) && ds.DeviceFingerprint == deviceFingerprint) ||
-                    (!string.IsNullOrEmpty(deviceId) && ds.DeviceId == deviceId));
-        }
+        return (usuario, null);
+    }
 
-        // Device binding check — only for non-admin users.
-        // Reportado 2026-04-28: la version anterior tenia 3 escapes:
-        // 1) Solo aplicaba si cliente mandaba fingerprint (el if externo)
-        // 2) Excluia sesiones con fingerprint NULL (legacy)
-        // 3) Permitia status LoggedOut como activo
-        // Ahora la regla es: si EXISTE OTRA sesion Active del mismo usuario
-        // (con o sin fingerprint), bloquear. Esto refuerza el modelo de
-        // negocio "1 vendedor = 1 device".
-        if (!usuario.IsAdminOrAbove && usuario.Rol != RoleNames.Supervisor)
-        {
-            var boundSession = await _db.DeviceSessions
-                .IgnoreQueryFilters()
-                .Where(ds => ds.UsuarioId == usuario.Id &&
-                             ds.TenantId == usuario.TenantId &&
-                             ds.EliminadoEn == null &&
-                             ds.Status == SessionStatus.Active &&
-                             (
-                                 (!string.IsNullOrEmpty(ds.DeviceFingerprint)
-                                   && ds.DeviceFingerprint != deviceFingerprint) ||
-                                 (string.IsNullOrEmpty(ds.DeviceFingerprint)
-                                   && !string.IsNullOrEmpty(ds.DeviceId)
-                                   && (string.IsNullOrEmpty(deviceId) || ds.DeviceId != deviceId)) ||
-                                 (string.IsNullOrEmpty(ds.DeviceFingerprint)
-                                   && string.IsNullOrEmpty(ds.DeviceId))
-                             ))
-                .OrderByDescending(ds => ds.LastActivity)
-                .FirstOrDefaultAsync();
+    private async Task<DeviceSession?> FindExistingSessionForDeviceAsync(int usuarioId, int tenantId, string? deviceFingerprint, string? deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceFingerprint) && string.IsNullOrEmpty(deviceId))
+            return null;
 
-            if (boundSession != null)
+        return await _db.DeviceSessions
+            .IgnoreQueryFilters()
+            .Where(ds => ds.UsuarioId == usuarioId &&
+                         ds.TenantId == tenantId &&
+                         ds.EliminadoEn == null &&
+                         ds.Status == SessionStatus.Active)
+            .OrderByDescending(ds => ds.LastActivity)
+            .FirstOrDefaultAsync(ds =>
+                (!string.IsNullOrEmpty(deviceFingerprint) && ds.DeviceFingerprint == deviceFingerprint) ||
+                (!string.IsNullOrEmpty(deviceId) && ds.DeviceId == deviceId));
+    }
+
+    private async Task<int> GetMaxConcurrentSessionsAsync(int tenantId)
+    {
+        // Cada Tenant tiene un SubscriptionPlanId; el plan define max sessions.
+        // Fallback a 1 si no hay plan asignado (defensa contra rows huérfanas).
+        var max = await _db.Tenants
+            .AsNoTracking()
+            .Where(t => t.Id == tenantId)
+            .Join(_db.SubscriptionPlans.AsNoTracking(),
+                  t => t.SubscriptionPlanId,
+                  p => p.Id,
+                  (t, p) => p.MaxConcurrentSessions)
+            .FirstOrDefaultAsync();
+
+        return max > 0 ? max : 1;
+    }
+
+    private async Task<int> CountActiveSessionsAsync(int usuarioId, int tenantId, int? excludeSessionId = null)
+    {
+        var query = _db.DeviceSessions
+            .IgnoreQueryFilters()
+            .Where(ds => ds.UsuarioId == usuarioId &&
+                         ds.TenantId == tenantId &&
+                         ds.EliminadoEn == null &&
+                         ds.Status == SessionStatus.Active);
+
+        if (excludeSessionId.HasValue)
+            query = query.Where(ds => ds.Id != excludeSessionId.Value);
+
+        return await query.CountAsync();
+    }
+
+    private async Task<List<object>> GetActiveSessionsDtoAsync(int usuarioId, int tenantId, int? currentSessionId = null)
+    {
+        var sessions = await _db.DeviceSessions
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(ds => ds.UsuarioId == usuarioId &&
+                         ds.TenantId == tenantId &&
+                         ds.EliminadoEn == null &&
+                         ds.Status == SessionStatus.Active)
+            .OrderByDescending(ds => ds.LastActivity)
+            .Select(ds => new
             {
-                return new LoginResult
-                {
-                    Success = false,
-                    DeviceBound = true,
-                    Message = "Tu cuenta está activa en otro dispositivo. Por seguridad, solo se permite una sesión a la vez."
-                };
-            }
-        }
+                id = ds.Id,
+                deviceName = ds.DeviceName ?? ds.DeviceModel ?? "Dispositivo desconocido",
+                deviceType = ds.DeviceType.ToString(),
+                lastActivity = ds.LastActivity,
+                loggedInAt = ds.LoggedInAt,
+                appVersion = ds.AppVersion ?? "",
+                osVersion = ds.OsVersion ?? "",
+                ipCity = "", // futuro: geo-IP lookup
+                isCurrent = currentSessionId.HasValue && ds.Id == currentSessionId.Value
+            })
+            .ToListAsync();
 
-        // Reuse existing session or create new one
+        return sessions.Cast<object>().ToList();
+    }
+
+    private async Task RevokeSessionInternalAsync(DeviceSession session, string reason)
+    {
+        var now = DateTime.UtcNow;
+        session.Status = SessionStatus.RevokedByUser;
+        session.LoggedOutAt = now;
+        session.LogoutReason = reason;
+        session.ActualizadoEn = now;
+
+        // Revocar refresh tokens vinculados a esta sesión específica.
+        var linkedTokens = await _db.RefreshTokens
+            .Where(rt => rt.DeviceSessionId == session.Id && !rt.IsRevoked)
+            .ToListAsync();
+
+        foreach (var token in linkedTokens)
+        {
+            token.IsRevoked = true;
+            token.RevokedAt = now;
+        }
+        // NO llamamos SaveChangesAsync — caller decide cuándo persistir.
+    }
+
+    private async Task<LoginResult> CreateSessionAndTokensAsync(Usuario usuario, DeviceSession? existingSession, string? deviceId, string? deviceFingerprint, string? deviceName)
+    {
+        DeviceSession session;
         if (existingSession != null)
         {
-            existingSession.DeviceFingerprint = deviceFingerprint;
+            existingSession.DeviceFingerprint = deviceFingerprint ?? existingSession.DeviceFingerprint;
             existingSession.DeviceId = deviceId ?? existingSession.DeviceId;
+            existingSession.DeviceName = deviceName ?? existingSession.DeviceName;
             existingSession.LastActivity = DateTime.UtcNow;
             existingSession.Status = SessionStatus.Active;
+            session = existingSession;
         }
-        else if (!string.IsNullOrEmpty(deviceId))
+        else
         {
-            _db.DeviceSessions.Add(new DeviceSession
+            session = new DeviceSession
             {
                 TenantId = usuario.TenantId,
                 UsuarioId = usuario.Id,
-                DeviceId = deviceId,
+                DeviceId = deviceId ?? Guid.NewGuid().ToString(),
                 DeviceFingerprint = deviceFingerprint,
-                DeviceName = null,
+                DeviceName = deviceName,
                 DeviceType = DeviceType.Unknown,
                 Status = SessionStatus.Active,
                 LastActivity = DateTime.UtcNow,
                 LoggedInAt = DateTime.UtcNow
-            });
+            };
+            _db.DeviceSessions.Add(session);
         }
 
+        // SaveChanges para obtener session.Id si es nueva.
         await _db.SaveChangesAsync();
 
-        var token = _jwt.GenerateTokenWithRoles(usuario.Id.ToString(), usuario.TenantId, usuario.Rol);
+        // Crear refresh token VINCULADO a esta DeviceSession específica (1:1)
+        var (_, plainRefreshToken) = await CreateRefreshTokenAsync(usuario.Id, session.Id);
 
-        var (_, plainRefreshToken) = await CreateRefreshTokenAsync(usuario.Id);
+        // JWT con sid claim para que el middleware pueda validar por-sesión.
+        var token = _jwt.GenerateTokenWithRoles(usuario.Id.ToString(), usuario.TenantId, usuario.Rol, sessionId: session.Id);
 
-        // Fetch company logo for the tenant (nullable)
         var companyLogo = await _db.CompanySettings
             .AsNoTracking()
             .Where(cs => cs.TenantId == usuario.TenantId)
@@ -192,7 +322,8 @@ public class MobileAuthService
                     mustChangePassword = usuario.MustChangePassword
                 },
                 token = token,
-                refreshToken = plainRefreshToken
+                refreshToken = plainRefreshToken,
+                sessionId = session.Id
             }
         };
     }
@@ -393,11 +524,24 @@ public class MobileAuthService
         await _db.SaveChangesAsync();
     }
 
-    private async Task<(RefreshToken Entity, string PlainToken)> CreateRefreshTokenAsync(int userId)
+    /// <summary>
+    /// Crea refresh token. Audit 2026-05-18:
+    /// - Si `deviceSessionId` está, revoca SOLO tokens previos de ESA sesión
+    ///   (1:1 nuevo modelo). Otras sesiones del user no se ven afectadas.
+    /// - Si `deviceSessionId` es null (legacy callers como RefreshTokenAsync
+    ///   sin sid), revoca todos los tokens del user (comportamiento viejo).
+    /// </summary>
+    private async Task<(RefreshToken Entity, string PlainToken)> CreateRefreshTokenAsync(int userId, int? deviceSessionId = null)
     {
-        var existingTokens = await _db.RefreshTokens
-            .Where(rt => rt.UserId == userId && !rt.IsRevoked && rt.ExpiresAt > DateTime.UtcNow)
-            .ToListAsync();
+        IQueryable<RefreshToken> existingQuery = _db.RefreshTokens
+            .Where(rt => rt.UserId == userId && !rt.IsRevoked && rt.ExpiresAt > DateTime.UtcNow);
+
+        if (deviceSessionId.HasValue)
+        {
+            existingQuery = existingQuery.Where(rt => rt.DeviceSessionId == deviceSessionId.Value);
+        }
+
+        var existingTokens = await existingQuery.ToListAsync();
 
         foreach (var token in existingTokens)
         {
@@ -410,6 +554,7 @@ public class MobileAuthService
         {
             Token = HashToken(plainToken),
             UserId = userId,
+            DeviceSessionId = deviceSessionId,
             ExpiresAt = DateTime.UtcNow.AddDays(30),
             CreatedAt = DateTime.UtcNow
         };
@@ -418,6 +563,59 @@ public class MobileAuthService
         await _db.SaveChangesAsync();
 
         return (refreshToken, plainToken);
+    }
+
+    /// <summary>
+    /// Audit 2026-05-18: lista sesiones activas del usuario actual. UI mobile
+    /// usa esto en pantalla "Mis sesiones" para gestión por el propio user.
+    /// `currentSessionId` viene del JWT sid claim para marcar cuál es esta.
+    /// </summary>
+    public async Task<List<object>> GetMySessionsAsync(int userId, int tenantId, int? currentSessionId)
+    {
+        return await GetActiveSessionsDtoAsync(userId, tenantId, currentSessionId);
+    }
+
+    /// <summary>
+    /// Audit 2026-05-18: revoca una sesión específica del usuario (self-service).
+    /// Si el sid es el del request actual, equivale a logout. Si es otro,
+    /// es un "logout remoto" desde mobile.
+    /// </summary>
+    public async Task<bool> RevokeMySessionAsync(int userId, int tenantId, int sessionIdToRevoke)
+    {
+        var session = await _db.DeviceSessions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(ds => ds.Id == sessionIdToRevoke &&
+                                       ds.UsuarioId == userId &&
+                                       ds.TenantId == tenantId &&
+                                       ds.EliminadoEn == null);
+
+        if (session == null || session.Status != SessionStatus.Active)
+            return false;
+
+        await RevokeSessionInternalAsync(session, reason: "user_revoke");
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    /// <summary>
+    /// Audit 2026-05-18: logout per-session (no más logout que revoca todos los
+    /// tokens del user). Marca la sesión del `sid` del JWT actual como
+    /// RevokedByUser + revoca solo sus refresh tokens. Otras sessions del
+    /// user en otros devices: intactas.
+    /// </summary>
+    public async Task LogoutSessionAsync(int userId, int sessionId)
+    {
+        var session = await _db.DeviceSessions
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(ds => ds.Id == sessionId &&
+                                       ds.UsuarioId == userId &&
+                                       ds.EliminadoEn == null);
+
+        if (session != null && session.Status == SessionStatus.Active)
+        {
+            await RevokeSessionInternalAsync(session, reason: "logout");
+            await _db.SaveChangesAsync();
+        }
     }
 
     private static string HashToken(string token)

--- a/libs/HandySuites.Domain/Entities/RefreshToken.cs
+++ b/libs/HandySuites.Domain/Entities/RefreshToken.cs
@@ -32,5 +32,15 @@ public class RefreshToken
     [Column("SessionVersionAtCreation")]
     public int? SessionVersionAtCreation { get; set; }
 
+    /// <summary>
+    /// FK a DeviceSession 1:1 — cada refresh token pertenece a UNA session.
+    /// Permite que logout en device A revoque solo SUS tokens (no del user
+    /// completo). Nullable durante migration window; NOT NULL después de
+    /// backfill (Phase 3 del rediseño 2026-05-18).
+    /// </summary>
+    [Column("DeviceSessionId")]
+    public int? DeviceSessionId { get; set; }
+
     public Usuario Usuario { get; set; } = null!;
+    public DeviceSession? DeviceSession { get; set; }
 }

--- a/libs/HandySuites.Domain/Entities/SubscriptionPlan.cs
+++ b/libs/HandySuites.Domain/Entities/SubscriptionPlan.cs
@@ -74,6 +74,17 @@ public class SubscriptionPlan
     [Column("orden")]
     public int Orden { get; set; }
 
+    /// <summary>
+    /// Sesiones concurrentes permitidas por usuario en mobile (Netflix-style).
+    /// Default 1 (mantiene compat con regla histórica "1 vendedor = 1 device").
+    /// Plans más altos pueden permitir más (BUSINESS=10 ej.).
+    /// Cuando user intenta login y ya tiene N sesiones activas, el endpoint
+    /// devuelve SESSION_LIMIT_REACHED con lista — UI muestra picker para
+    /// revocar una y entrar.
+    /// </summary>
+    [Column("max_concurrent_sessions")]
+    public int MaxConcurrentSessions { get; set; } = 1;
+
     // Navigation
     public virtual ICollection<Tenant> Tenants { get; set; } = new List<Tenant>();
 }

--- a/libs/HandySuites.Infrastructure/Migrations/20260519063845_AddSessionModelRedesign.Designer.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260519063845_AddSessionModelRedesign.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace HandySuites.Infrastructure.Migrations
 {
     [DbContext(typeof(HandySuitesDbContext))]
-    partial class HandySuitesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519063845_AddSessionModelRedesign")]
+    partial class AddSessionModelRedesign
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/HandySuites.Infrastructure/Migrations/20260519063845_AddSessionModelRedesign.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260519063845_AddSessionModelRedesign.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HandySuites.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionModelRedesign : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Default = 1 (mantiene compat con regla histórica "1 device por user").
+            // Plans específicos pueden tener más (BASIC=2, PRO=5, BUSINESS=10) —
+            // ajustables después del deploy por admin desde UI.
+            migrationBuilder.AddColumn<int>(
+                name: "max_concurrent_sessions",
+                table: "subscription_plans",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            // Bump default por código de plan. Si los códigos no matchean, no
+            // afecta (rows quedan en 1). Esto da plans "starter" 1 sesión,
+            // BUSINESS hasta 10. Admin puede editar después.
+            migrationBuilder.Sql(@"
+                UPDATE subscription_plans SET max_concurrent_sessions = 2 WHERE codigo IN ('BASIC', 'STARTER');
+                UPDATE subscription_plans SET max_concurrent_sessions = 5 WHERE codigo IN ('PRO', 'PROFESSIONAL');
+                UPDATE subscription_plans SET max_concurrent_sessions = 10 WHERE codigo IN ('BUSINESS', 'ENTERPRISE');
+            ");
+
+            // FK 1:1 RefreshToken -> DeviceSession (nullable durante migration window).
+            // Después de backfill será NOT NULL en Phase 3 del rediseño.
+            migrationBuilder.AddColumn<int>(
+                name: "DeviceSessionId",
+                table: "RefreshTokens",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_DeviceSessionId",
+                table: "RefreshTokens",
+                column: "DeviceSessionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RefreshTokens_DeviceSessions_DeviceSessionId",
+                table: "RefreshTokens",
+                column: "DeviceSessionId",
+                principalTable: "DeviceSessions",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RefreshTokens_DeviceSessions_DeviceSessionId",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RefreshTokens_DeviceSessionId",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "max_concurrent_sessions",
+                table: "subscription_plans");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceSessionId",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
+++ b/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
@@ -212,6 +212,15 @@ public class HandySuitesDbContext : DbContext
                   .HasPrincipalKey(u => u.Id);
             // Matching query filter with Usuario (suppresses EF Core warning)
             entity.HasQueryFilter(rt => rt.Usuario!.EliminadoEn == null);
+
+            // Audit 2026-05-18: vinculo RefreshToken 1:1 con DeviceSession.
+            // Permite revoke per-device sin afectar otras sesiones del user.
+            // Nullable durante migration window; NOT NULL después de backfill.
+            entity.HasOne(rt => rt.DeviceSession)
+                  .WithMany()
+                  .HasForeignKey(rt => rt.DeviceSessionId)
+                  .OnDelete(DeleteBehavior.SetNull);
+            entity.HasIndex(rt => rt.DeviceSessionId);
         });
 
         // Configure Producto relationships explicitly

--- a/libs/HandySuites.Shared/Security/JwtTokenGenerator.cs
+++ b/libs/HandySuites.Shared/Security/JwtTokenGenerator.cs
@@ -21,10 +21,16 @@ public class JwtTokenGenerator
         return GenerateTokenWithRoles(userId, tenantId, "VENDEDOR", sessionVersion);
     }
 
-    public string GenerateTokenWithRoles(string userId, int tenantId, string role, int sessionVersion = 1)
+    public string GenerateTokenWithRoles(string userId, int tenantId, string role, int sessionVersion = 1, int? sessionId = null)
     {
         // Single source of truth: claim "role" (string).
         // Los claims booleanos legacy "es_admin" / "es_super_admin" se eliminaron en abril 2026.
+        //
+        // Audit 2026-05-18 — sid claim (DeviceSession.Id):
+        // Permite al middleware validar el token contra una DeviceSession
+        // específica para per-device revocation, en lugar de validar por
+        // fingerprint match (frágil). Solo se incluye si sessionId != null;
+        // tokens de impersonación / web no llevan sid.
         var claims = new List<Claim>
         {
             new Claim(JwtRegisteredClaimNames.Sub, userId),
@@ -33,6 +39,11 @@ public class JwtTokenGenerator
             new Claim("role", role),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
         };
+
+        if (sessionId.HasValue)
+        {
+            claims.Add(new Claim("sid", sessionId.Value.ToString()));
+        }
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Secret));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);


### PR DESCRIPTION
## Resumen
Rediseño completo del modelo de sesiones mobile end-to-end (incident Rodrigo 2026-05-13).

- **N sesiones concurrentes configurables por plan** (`SubscriptionPlan.MaxConcurrentSessions` — defaults BASIC=2, PRO=5, BUSINESS=10)
- **JWT con claim `sid`** vinculado a `DeviceSession.Id` (sustituye fingerprint match frágil)
- **1 solo código de error** `SESSION_REVOKED` (antes: DEVICE_BOUND / DEVICE_NOT_RECOGNIZED / DEVICE_FINGERPRINT_REQUIRED / DEVICE_REVOKED)
- **Picker Netflix-style** cuando se alcanza el límite (`/revoke-and-login` atomic)
- **Soft logout**: `sessionRevoked` solo setea flag, NO limpia tokens ni WatermelonDB (preserva pending data)
- **`RefreshToken.DeviceSessionId`** FK — logout revoca solo tokens de esa session, no todas las del user

## Verificación

- ✅ dotnet test mobile API: 46/46
- ✅ Jest mobile-app: 7/7
- ✅ Smoke API local: login bajo límite, SESSION_LIMIT_REACHED, /revoke-and-login, /my-sessions, /revoke-session/{sid}, logout(sid), middleware bloquea JWT stale tras cache TTL
- ✅ Emulator Android E2E full flow: login → home → logout → re-login con ghost session → picker UI → revoke-and-login → home
- ✅ Playwright `auth.spec.ts` web: 5/5 (cero cambios en apps/web — sin regresión)

## Migration

`20260519063845_AddSessionModelRedesign` agrega `subscription_plans.max_concurrent_sessions` (NOT NULL DEFAULT 1) + `RefreshTokens.DeviceSessionId` (nullable FK con SET NULL on delete) + sane defaults por código de plan. Idempotente y reversible.

## Backward compat

- JWT sin claim `sid` (legacy pre-deploy) bypass del middleware durante ventana de 30 días (los tokens viejos expiran naturalmente)
- Endpoint `/force-login` mantenido pero deprecado — listeners `forceLogout` y `deviceTakeoverRequired` mobile usan ahora el comportamiento soft
- Cliente mobile maneja la respuesta 200 con `code: SESSION_LIMIT_REACHED` → navigate a `session-limit.tsx`

## Phase pending (NO en este PR)

- Backfill `DeviceSessionId` en RefreshTokens viejos (job background)
- Web admin UI para editar `MaxConcurrentSessions` por plan
- Pantalla mobile "Mis sesiones" (self-service)
- Deprecar `/force-login` (window 60d después del deploy)
- Push al device cuando sesión revocada
