### PR TITLE
fix(mobile-auth): refresh token race + sessionExpired UI (incident vendedor@jeyma)

### DIFF
--- a/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
+++ b/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
@@ -228,11 +228,18 @@ public class HandySuitesDbContext : DbContext
             // DbUpdateConcurrencyException (capturada en RefreshTokenAsync → null).
             // Sin esto: ambas creaban tokens nuevos, uno quedaba huérfano y el
             // device terminaba con un token revocado (incident vendedor@jeyma 2026-05-19).
-            // Patrón moderno (UseXminAsConcurrencyToken obsoleto): shadow property.
-            entity.Property<uint>("xmin")
-                  .HasColumnType("xid")
-                  .ValueGeneratedOnAddOrUpdate()
-                  .IsConcurrencyToken();
+            //
+            // Solo se aplica cuando el provider es Npgsql (PostgreSQL). En tests
+            // que corren contra SQLite el xmin no existe como columna sistema y
+            // EF intentaría crearlo como NOT NULL plain → INSERT fails con
+            // "NOT NULL constraint failed: RefreshTokens.xmin". Skip en non-PG.
+            if (Database.IsNpgsql())
+            {
+                entity.Property<uint>("xmin")
+                      .HasColumnType("xid")
+                      .ValueGeneratedOnAddOrUpdate()
+                      .IsConcurrencyToken();
+            }
         });
 
         // Configure Producto relationships explicitly


### PR DESCRIPTION
## Contexto

Vendedor@jeyma reporto 'Network Error' en sync con 12 pedidos pendientes mientras la sesion seguia Active en backend. Causa raiz: race condition en /refresh server-side + bandera sessionExpired sin UI que la consumiera. Datos en prod confirmaron el race: tokens 1026 y 1027 creados con 140us de diferencia para mismo source token -> uno huerfano.

## Server-side (root cause)

1. xmin concurrency token en RefreshToken via shadow property PG nativa (guard if Database.IsNpgsql para SQLite tests)
2. Catch DbUpdateConcurrencyException en RefreshTokenAsync (loser devuelve null limpio)
3. Pasa tokenEntity.DeviceSessionId en rotation (preserva linkage 1:1, sin sid=NULL)
4. Quita rate limit mobile-auth de /refresh (5/min/IP causaba 429 en oficinas con NAT)

## Cliente (UX + coalescing)

5. coalesceRefresh() exportado desde client.ts (interceptor 401 + useSessionRefresh hook usan mismo promise)
6. SessionExpiredBanner mounted en (tabs)/_layout.tsx (consume bandera, CTA navega a login preservando WDB)
7. translateSyncError en sync.tsx (traduce 'Network Error' / 401 / 5xx a mensajes accionables)

## Metro dev fix

8. Stub css-tree/mdn-data en metro.config.js (bug pre-existente Hermes dev mode con react-native-svg, no afecta produccion EAS Build)

## Migration

20260520031401_AddRefreshTokenConcurrencyXmin - marker no-op (xmin es columna sistema PG, no schema changes).

## Verificacion

- dotnet test main API 500/501 pass (1 skip pre-existente)
- dotnet test mobile API 46/46 pass
- Playwright web auth 5/5 pass (no regresion)
- Smoke race local: 5 POST /refresh paralelas -> 1 winner / 4 losers 401 / 0 orphans / sid=808 preservado
- Emulator dev validation BLOQUEADA por 2 bugs ambientales (no del codigo): Hermes parser con mdn-data + Windows MAX_PATH en native build. Plan: validar visual via EAS update staging post-merge.

## Post-merge

1. Railway staging redeploya backend automaticamente
2. Smoke contra mobile-api-staging.up.railway.app
3. npx eas update --branch staging (cuando autorices)
4. Validar flow real en device fisico
5. PR staging -> main + EAS production cuando OK