### PR TITLE
release: promote staging -> main (refresh token race fix + sessionExpired UI)

### DIFF
--- a/apps/mobile-app/app/(tabs)/_layout.tsx
+++ b/apps/mobile-app/app/(tabs)/_layout.tsx
@@ -9,6 +9,7 @@ import { usePendingCount } from '@/hooks';
 import { useAuthStore } from '@/stores';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { OfflineBanner } from '@/components/ui/OfflineBanner';
+import { SessionExpiredBanner } from '@/components/ui/SessionExpiredBanner';
 import { COLORS } from '@/theme/colors';
 
 export default function TabsLayout() {
@@ -137,6 +138,7 @@ export default function TabsLayout() {
       <Tabs.Screen name="facturas" options={{ href: null }} />
     </Tabs>
     <OfflineBanner />
+    <SessionExpiredBanner />
     </View>
     </ErrorBoundary>
   );

--- a/apps/mobile-app/app/(tabs)/sync.tsx
+++ b/apps/mobile-app/app/(tabs)/sync.tsx
@@ -21,6 +21,36 @@ function formatLastSync(timestamp: number | null, dateTimeFmt: (d: Date) => stri
   return dateTimeFmt(new Date(timestamp));
 }
 
+/**
+ * Audit 2026-05-19: vendedor@jeyma vio "Network Error" cuando en realidad
+ * el device estaba conectado (banner verde "Conectado") pero el refresh
+ * de tokens había fallado por race condition server-side. El mensaje
+ * técnico no era accionable. Esta función traduce:
+ * - "Network Error" + online → "Reintentando..." (probable race/timeout
+ *   transient; el SessionExpiredBanner se encarga si es auth)
+ * - "Network Error" + offline → mostrar offline-genuine (raro porque
+ *   ya tenemos OfflineBanner pero defensivo)
+ * - 401/sesión → mensaje claro de re-login (también cubierto por
+ *   SessionExpiredBanner pero útil aquí también)
+ * - Otros → mensaje original
+ */
+function translateSyncError(rawError: string, isOnline: boolean): string {
+  const msg = rawError.toLowerCase();
+  if (msg.includes('network error') && isOnline) {
+    return 'Reintentando conexión con el servidor...';
+  }
+  if (msg.includes('network error') || msg.includes('timeout')) {
+    return 'Sin conexión estable. Reintentaremos cuando haya señal.';
+  }
+  if (msg.includes('401') || msg.includes('session_revoked') || msg.includes('unauthorized')) {
+    return 'Tu sesión necesita renovarse. Toca "Iniciar sesión" en el banner rojo.';
+  }
+  if (msg.includes('500') || msg.includes('502') || msg.includes('503')) {
+    return 'Servidor temporalmente no disponible. Reintenta en un momento.';
+  }
+  return rawError;
+}
+
 export default function SyncScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -64,11 +94,13 @@ export default function SyncScreen() {
         </View>
       </Animated.View>
 
-      {/* Error banner */}
+      {/* Error banner — audit 2026-05-19: traducir mensajes técnicos
+          (axios "Network Error" / "Request failed status 401") a algo
+          accionable para el vendedor en campo. */}
       {status === 'error' && error && (
         <View style={styles.errorBanner}>
           <AlertTriangle size={18} color="#dc2626" />
-          <Text style={styles.errorText}>{error}</Text>
+          <Text style={styles.errorText}>{translateSyncError(error, isOnline)}</Text>
         </View>
       )}
 

--- a/apps/mobile-app/metro-stubs/empty-module.js
+++ b/apps/mobile-app/metro-stubs/empty-module.js
@@ -1,0 +1,16 @@
+// Audit 2026-05-20 — Stub vacío para css-tree y mdn-data.
+//
+// Ver metro.config.js para el contexto. Estas deps son arrastradas por
+// react-native-svg para inline-styles dentro de <svg> — feature que no
+// usamos en este app — pero su tamaño (~10K líneas de CSS data) hace que
+// Hermes dev fail a parsear el bundle.
+//
+// Si algún componente eventualmente importa css-tree directamente y trata
+// de usarlo, se rompe en runtime obvio (csstree.parse is not a function).
+
+module.exports = {};
+module.exports.default = {};
+module.exports.List = class {};
+module.exports.parse = () => {
+  throw new Error('css-tree stubbed in dev bundle (see metro.config.js)');
+};

--- a/apps/mobile-app/metro.config.js
+++ b/apps/mobile-app/metro.config.js
@@ -16,4 +16,30 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+// Audit 2026-05-20 — Stub css-tree y mdn-data en bundle dev.
+//
+// Causa: react-native-svg/css/css.js importa `css-tree` para "SVG style
+// element inlining" (parsea <style> dentro de <svg>). Esa feature no la
+// usamos — solo usamos <Svg> con props nativos. Pero el require eager
+// jala el bundle de mdn-data (~10K líneas CSS data) que Hermes dev parser
+// no logra parsear (errores cambiantes "'}' expected", "non-terminated
+// string", etc. dentro del módulo de datos CSS).
+//
+// Producción (EAS Build con bytecode pre-compilado) NO se ve afectada
+// porque Hermes solo parsea una vez al build, no en runtime.
+//
+// Stub: devolvemos un módulo vacío en lugar de css-tree/mdn-data. Si
+// algún día usamos SVG con <style> embebido el código fallará en runtime
+// (csstree.parse() = undefined) y será obvio. Sin esto, dev mode no carga.
+const emptyStub = path.resolve(__dirname, 'metro-stubs/empty-module.js');
+const previousResolver = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === 'css-tree' || moduleName === 'mdn-data' ||
+      moduleName.startsWith('css-tree/') || moduleName.startsWith('mdn-data/')) {
+    return { type: 'sourceFile', filePath: emptyStub };
+  }
+  if (previousResolver) return previousResolver(context, moduleName, platform);
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = withNativeWind(config, { input: './global.css' });

--- a/apps/mobile-app/src/api/client.ts
+++ b/apps/mobile-app/src/api/client.ts
@@ -245,17 +245,12 @@ apiInstance.interceptors.response.use(
       if (!originalRequest._retry && !isAuthEndpoint) {
         originalRequest._retry = true;
 
-        if (!isRefreshing) {
-          isRefreshing = true;
-          refreshPromise = tryRefreshToken();
-          refreshPromise.finally(() => {
-            isRefreshing = false;
-            refreshPromise = null;
-          });
-        }
-
+        // Coalesce: si useSessionRefresh u otro 401 ya disparó refresh,
+        // reusamos el mismo promise. Sin esto teníamos 2 fuentes paralelas
+        // (interceptor + hook) hitting /refresh server-side al mismo tiempo
+        // → orphan tokens (incident vendedor@jeyma 2026-05-19).
         try {
-          const newToken = await refreshPromise;
+          const newToken = await coalesceRefresh();
           if (newToken) {
             originalRequest.headers.Authorization = `Bearer ${newToken}`;
             processQueue(newToken);
@@ -315,6 +310,32 @@ async function tryRefreshToken(): Promise<string | null> {
   }
 
   return null;
+}
+
+/**
+ * Audit 2026-05-19: coalesce de refresh calls cross-source.
+ *
+ * Antes: `useSessionRefresh` hook hacía raw `axios.post('/refresh')` paralelo
+ * al interceptor, causando dos /refresh server-side simultáneas que producían
+ * orphan tokens (incident vendedor@jeyma 2026-05-19). El backend ahora atrapa
+ * el race con DbUpdateConcurrencyException, pero igual queremos coalescer
+ * client-side para ahorrar request + ancho de banda.
+ *
+ * Esta función reusa el mismo `refreshPromise` que el interceptor cuando hay
+ * un refresh in-flight; si no, lo dispara. Result: 1 sola POST a /refresh
+ * sin importar cuántos callers paralelos (hook + interceptor + N requests).
+ */
+export async function coalesceRefresh(): Promise<string | null> {
+  if (isRefreshing && refreshPromise) {
+    return refreshPromise;
+  }
+  isRefreshing = true;
+  refreshPromise = tryRefreshToken();
+  refreshPromise.finally(() => {
+    isRefreshing = false;
+    refreshPromise = null;
+  });
+  return refreshPromise;
 }
 
 function processQueue(token: string) {

--- a/apps/mobile-app/src/components/ui/SessionExpiredBanner.tsx
+++ b/apps/mobile-app/src/components/ui/SessionExpiredBanner.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Text, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { AlertCircle } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+import { useAuthStore } from '@/stores';
+
+const BANNER_HEIGHT = 44;
+const TAB_BAR_HEIGHT = 60;
+
+/**
+ * Audit 2026-05-19 — Banner persistente cuando authStore.sessionExpired === true.
+ *
+ * El redesign de sesiones (audit 2026-05-18) introdujo soft-logout: cuando el
+ * backend retorna 401 SESSION_REVOKED o el refresh falla irrecuperablemente,
+ * el cliente NO limpia tokens ni hace logout brusco — solo prende
+ * `authStore.sessionExpired = true` para preservar WatermelonDB pending data.
+ *
+ * Pero NADIE leía esa bandera en la UI. Resultado: el user veía "Network Error"
+ * genérico en pantallas como Sincronización y no sabía qué hacer (incident
+ * vendedor@jeyma 2026-05-19 — 12 pedidos pendientes con flag activa pero sin
+ * banner visible).
+ *
+ * Este componente consume `sessionExpired` y muestra banner persistente con
+ * CTA "Iniciar sesión" que navega al login (preservando WDB local). Una vez
+ * en login screen, el user re-loguea y la nueva sesión + tokens limpios
+ * permiten que el sync engine retome los 12 pedidos pendientes.
+ */
+export function SessionExpiredBanner() {
+  const sessionExpired = useAuthStore(s => s.sessionExpired);
+  const router = useRouter();
+
+  if (!sessionExpired) return null;
+
+  return (
+    <View style={styles.banner}>
+      <AlertCircle size={16} color="#ffffff" />
+      <Text style={styles.text} numberOfLines={1}>
+        Tu sesión necesita renovarse
+      </Text>
+      <TouchableOpacity
+        onPress={() => router.push('/(auth)/login' as any)}
+        style={styles.button}
+        accessibilityRole="button"
+        accessibilityLabel="Iniciar sesión de nuevo"
+      >
+        <Text style={styles.buttonText}>Iniciar sesión</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    position: 'absolute',
+    bottom: TAB_BAR_HEIGHT,
+    left: 0,
+    right: 0,
+    zIndex: 1000,
+    minHeight: BANNER_HEIGHT,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    backgroundColor: '#dc2626',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  text: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+  button: {
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  buttonText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#dc2626',
+  },
+});

--- a/apps/mobile-app/src/components/ui/index.ts
+++ b/apps/mobile-app/src/components/ui/index.ts
@@ -7,5 +7,6 @@ export { EmptyState } from './EmptyState';
 export { ConfirmModal } from './ConfirmModal';
 export { BottomSheet } from './BottomSheet';
 export { OfflineBanner } from './OfflineBanner';
+export { SessionExpiredBanner } from './SessionExpiredBanner';
 export { UserAvatar } from './UserAvatar';
 export type { UserAvatarProps } from './UserAvatar';

--- a/apps/mobile-app/src/hooks/useSessionRefresh.ts
+++ b/apps/mobile-app/src/hooks/useSessionRefresh.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
-import axios from 'axios';
 import { secureStorage } from '@/utils/storage';
 import { useAuthStore } from '@/stores';
-import { API_CONFIG, STORAGE_KEYS } from '@/utils/constants';
+import { STORAGE_KEYS } from '@/utils/constants';
+import { coalesceRefresh } from '@/api/client';
 
 const LAST_ACTIVITY_KEY = '@auth/lastActivityAt';
 
@@ -12,18 +12,17 @@ const LAST_ACTIVITY_KEY = '@auth/lastActivityAt';
  * estar en background >5 min, intenta renovar el token silenciosamente para
  * evitar el flow de 401 → refresh → posible force-logout transient.
  *
- * Funciona en conjunto con JWT TTL extendido a 8h en backend (appsettings.json).
- * Antes: TTL 30 min hacía que la app pidiera credenciales tras 30+ min en
- * background. Ahora: TTL 8h cubre toda la jornada laboral; este hook hace pre-
- * emptive refresh por si el user dejó la app abierta toda la noche.
+ * Audit 2026-05-19: ahora usa `coalesceRefresh()` del interceptor en lugar
+ * de raw `axios.post('/refresh')`. Eso evita que dos refresh paralelos (hook
+ * mount + interceptor 401 simultáneos) terminen creando 2 requests al server
+ * que generaban orphan tokens (incident vendedor@jeyma 2026-05-19).
  *
- * Si el refresh falla (network/auth), NO fuerza logout — la próxima request
- * real cae al interceptor de axios que maneja 401 con su flow normal. Esto
- * evita logouts inesperados por errores transients de red al volver a la app.
+ * Si hay un refresh in-flight, esta función espera al mismo promise. Si no,
+ * dispara uno nuevo. Sólo 1 POST /refresh al backend sin importar cuántos
+ * triggers paralelos.
  */
 export function useSessionRefresh() {
   const isAuthenticated = useAuthStore(s => s.isAuthenticated);
-  const login = useAuthStore(s => s.login);
   const lastRefreshAt = useRef<number>(0);
 
   useEffect(() => {
@@ -40,21 +39,15 @@ export function useSessionRefresh() {
       if (!refreshToken) return;
 
       try {
-        const response = await axios.post(
-          `${API_CONFIG.BASE_URL}/api/mobile/auth/refresh`,
-          { RefreshToken: refreshToken },
-          { timeout: 10000 },
-        );
-        if (response.data?.success && response.data?.data) {
-          const { user, token, refreshToken: newRefresh } = response.data.data;
-          await login(user, token, newRefresh);
+        const newToken = await coalesceRefresh();
+        if (newToken) {
           lastRefreshAt.current = now;
           await secureStorage.set(LAST_ACTIVITY_KEY, String(now));
         }
       } catch {
         // Soft fail: logout NO se dispara aquí. El próximo request real
-        // hará el flow normal (interceptor 401 → tryRefreshToken → si falla
-        // ahí sí logout legítimo).
+        // hará el flow normal (interceptor 401 → coalesceRefresh → si falla
+        // ahí sí emite sessionRevoked legítimo).
       }
     };
 
@@ -70,5 +63,5 @@ export function useSessionRefresh() {
     trySilentRefresh();
 
     return () => sub.remove();
-  }, [isAuthenticated, login]);
+  }, [isAuthenticated]);
 }

--- a/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Endpoints/MobileAuthEndpoints.cs
@@ -342,7 +342,13 @@ public static class MobileAuthEndpoints
 
             return Results.Ok(new { success = true, data = result });
         })
-        .RequireRateLimiting("mobile-auth")
+        // Audit 2026-05-19: removido RequireRateLimiting("mobile-auth").
+        // Esa policy es 5/min POR IP — causaba 429 a oficinas con varios
+        // vendedores compartiendo NAT (vendedor@jeyma incident). Refresh es
+        // flow OAuth normal (no brute-force target — el RFC 2.1 lo trata
+        // como tal), basta el global limiter de 120/min/IP. Si quisiéramos
+        // per-user, necesitaríamos extraer userId del refresh token antes de
+        // que el middleware corra, lo cual no es trivial — mejor sin policy.
         .WithSummary("Refrescar token")
         .WithDescription("Obtiene un nuevo access token usando el refresh token.")
         .Produces<object>(StatusCodes.Status200OK)

--- a/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
+++ b/apps/mobile/HandySuites.Mobile.Api/Services/MobileAuthService.cs
@@ -333,7 +333,8 @@ public class MobileAuthService
         if (string.IsNullOrEmpty(refreshToken))
             return null;
 
-        // Hash incoming token to compare with stored hash
+        // Hash incoming token to compare with stored hash. AsTracking() es
+        // necesario para que el concurrency token (xmin) se compare en el UPDATE.
         var tokenHash = HashToken(refreshToken);
         var tokenEntity = await _db.RefreshTokens
             .Include(rt => rt.Usuario)
@@ -373,12 +374,32 @@ public class MobileAuthService
 
         var newAccessToken = _jwt.GenerateTokenWithRoles(
             tokenEntity.Usuario.Id.ToString(), tokenEntity.Usuario.TenantId,
-            tokenEntity.Usuario.Rol);
+            tokenEntity.Usuario.Rol,
+            sessionId: tokenEntity.DeviceSessionId);
 
-        var (newTokenEntity, newPlainToken) = await CreateRefreshTokenAsync(tokenEntity.UserId);
-        tokenEntity.ReplacedByToken = newTokenEntity.Token;
-
-        await _db.SaveChangesAsync();
+        // Audit 2026-05-19: pasar DeviceSessionId preserva el linkage 1:1 que
+        // armamos en el redesign. Sin esto, los refresh tokens post-login
+        // quedaban con sid=NULL (visible en datos prod 1026/1027/1029) y
+        // CreateRefreshTokenAsync revocaba TODOS los tokens del user, no solo
+        // los de esta sesión. También: en CreateRefreshTokenAsync el filtro
+        // .Where(rt => rt.DeviceSessionId == sid) reduce el alcance del UPDATE
+        // y minimiza la ventana de race.
+        (RefreshToken newTokenEntity, string newPlainToken) newToken;
+        try
+        {
+            newToken = await CreateRefreshTokenAsync(tokenEntity.UserId, tokenEntity.DeviceSessionId);
+            tokenEntity.ReplacedByToken = newToken.newTokenEntity.Token;
+            await _db.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Otra request paralela ya rotó este mismo refresh token (xmin mismatch).
+            // El cliente debe reintentar con el token nuevo que la otra call ya
+            // emitió. Devolvemos null → endpoint /refresh responde 401 → interceptor
+            // del cliente reintenta (con el nuevo token que ya guardó). Esto evita
+            // el orphan token problem que vimos en prod (vendedor@jeyma 2026-05-19).
+            return null;
+        }
 
         // Fetch company logo for the tenant (nullable)
         var companyLogo = await _db.CompanySettings
@@ -400,7 +421,7 @@ public class MobileAuthService
                 mustChangePassword = tokenEntity.Usuario.MustChangePassword
             },
             token = newAccessToken,
-            refreshToken = newPlainToken
+            refreshToken = newToken.newPlainToken
         };
     }
 

--- a/libs/HandySuites.Infrastructure/Migrations/20260520031401_AddRefreshTokenConcurrencyXmin.Designer.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260520031401_AddRefreshTokenConcurrencyXmin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HandySuites.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace HandySuites.Infrastructure.Migrations
 {
     [DbContext(typeof(HandySuitesDbContext))]
-    partial class HandySuitesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520031401_AddRefreshTokenConcurrencyXmin")]
+    partial class AddRefreshTokenConcurrencyXmin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/HandySuites.Infrastructure/Migrations/20260520031401_AddRefreshTokenConcurrencyXmin.cs
+++ b/libs/HandySuites.Infrastructure/Migrations/20260520031401_AddRefreshTokenConcurrencyXmin.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HandySuites.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenConcurrencyXmin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Audit 2026-05-19: NO-OP migration. EF Core detectó la shadow
+            // property `xmin` que agregamos en HandySalesDbContext.OnModelCreating
+            // como un cambio de modelo y quiso emitir `AddColumn xmin`, pero
+            // en PostgreSQL `xmin` ya existe como columna sistema en TODAS
+            // las tablas — no requiere creación. La shadow property solo
+            // mapea esa columna existente para que EF Core la use como
+            // concurrency token. Marker migration solo para que EF Core
+            // registre el cambio de modelo en __EFMigrationsHistory.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // NO-OP. Ver Up.
+        }
+    }
+}

--- a/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
+++ b/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
@@ -228,11 +228,18 @@ public class HandySuitesDbContext : DbContext
             // DbUpdateConcurrencyException (capturada en RefreshTokenAsync → null).
             // Sin esto: ambas creaban tokens nuevos, uno quedaba huérfano y el
             // device terminaba con un token revocado (incident vendedor@jeyma 2026-05-19).
-            // Patrón moderno (UseXminAsConcurrencyToken obsoleto): shadow property.
-            entity.Property<uint>("xmin")
-                  .HasColumnType("xid")
-                  .ValueGeneratedOnAddOrUpdate()
-                  .IsConcurrencyToken();
+            //
+            // Solo se aplica cuando el provider es Npgsql (PostgreSQL). En tests
+            // que corren contra SQLite el xmin no existe como columna sistema y
+            // EF intentaría crearlo como NOT NULL plain → INSERT fails con
+            // "NOT NULL constraint failed: RefreshTokens.xmin". Skip en non-PG.
+            if (Database.IsNpgsql())
+            {
+                entity.Property<uint>("xmin")
+                      .HasColumnType("xid")
+                      .ValueGeneratedOnAddOrUpdate()
+                      .IsConcurrencyToken();
+            }
         });
 
         // Configure Producto relationships explicitly

--- a/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
+++ b/libs/HandySuites.Infrastructure/Persistence/HandySalesDbContext.cs
@@ -221,6 +221,18 @@ public class HandySuitesDbContext : DbContext
                   .HasForeignKey(rt => rt.DeviceSessionId)
                   .OnDelete(DeleteBehavior.SetNull);
             entity.HasIndex(rt => rt.DeviceSessionId);
+
+            // Audit 2026-05-19: optimistic concurrency vía xmin (system column PG).
+            // Race fix: dos /refresh paralelas con el mismo source token ahora
+            // serializan a nivel DB — solo una UPDATE pasa, la otra recibe
+            // DbUpdateConcurrencyException (capturada en RefreshTokenAsync → null).
+            // Sin esto: ambas creaban tokens nuevos, uno quedaba huérfano y el
+            // device terminaba con un token revocado (incident vendedor@jeyma 2026-05-19).
+            // Patrón moderno (UseXminAsConcurrencyToken obsoleto): shadow property.
+            entity.Property<uint>("xmin")
+                  .HasColumnType("xid")
+                  .ValueGeneratedOnAddOrUpdate()
+                  .IsConcurrencyToken();
         });
 
         // Configure Producto relationships explicitly


### PR DESCRIPTION
## Resumen

Promote a produccion del fix de race condition en refresh tokens + UI sessionExpired (incident vendedor@jeyma 2026-05-19).

## Commits incluidos (5)

- a82b8a2a fix(mobile-auth): refresh token race + sessionExpired UI
- 9d6a451a fix(mobile-dev): stub css-tree/mdn-data en bundle dev para que Hermes parsee
- 52275019 fix(infra): guard xmin shadow property a Postgres-only (SQLite tests fix)
- 75fe165e Merge PR #76
- e1a95b67 Merge PR #77

## Verificacion en staging (post-merge a staging hace ~5 min)

- Mobile API staging healthy + version 1.0.0
- Migration 20260520031401_AddRefreshTokenConcurrencyXmin aplicada (marker no-op, xmin es columna sistema PG)
- Login flow: JWT con claim sid correctly emitido (sid=36 ej.)
- Refresh flow: sid PRESERVADO en rotation (login sid=36 -> refresh sid=36)
- DB: token nuevo post-refresh tiene DeviceSessionId FK correcta (no NULL)
- **Race test paralelo**: 5 POST /refresh paralelas con mismo source token -> 1 winner (success + token), 4 losers (401 limpio), 0 orphans

## Pre-deploy checklist production

- [x] Sin env vars nuevas en Railway/Vercel
- [x] Migration EF Core auto-aplica al startup (idempotente; marker no-op)
- [x] Sin cambios en CI/CD ni docker-compose
- [x] Sin endpoints removidos
- [x] No breaking API contract (/refresh response shape igual)
- [x] CI tests 500/501 main + 46/46 mobile pass (1 skip pre-existente)
- [x] Backward compat: si xmin no esta en provider PG (improbable en prod), guard salta el concurrency token

## Action post-merge production

1. Verificar Railway prod redeploy aplica migration
2. Smoke test contra mobile-api-production-f934.up.railway.app (login + refresh + race)
3. EAS update --branch production (cuando autorices, regla feedback_no_auto_eas_build)
4. Monitor: errors 401 SESSION_REVOKED en logs Railway 24h post-deploy