### PR TITLE
chore(mobile): APK 1.0.1 + disable OTA + metro stub gated + version display

### DIFF
--- a/apps/mobile-app/app.json
+++ b/apps/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Handy Suites",
     "slug": "handy-suites",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "handysuites",
@@ -11,7 +11,7 @@
     "runtimeVersion": { "policy": "appVersion" },
     "updates": {
       "url": "https://u.expo.dev/e6259b5a-35d9-4b87-b700-5520b113fa68",
-      "enabled": true,
+      "enabled": false,
       "fallbackToCacheTimeout": 0,
       "checkAutomatically": "ON_LOAD"
     },
@@ -29,7 +29,8 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#2563eb"
       },
-      "package": "com.handysuites.app"
+      "package": "com.handysuites.app",
+      "versionCode": 2
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/apps/mobile-app/app/(auth)/login.tsx
+++ b/apps/mobile-app/app/(auth)/login.tsx
@@ -20,6 +20,15 @@ import { HandyLogo } from '@/components/shared/HandyLogo';
 import { COLORS } from '@/theme/colors';
 import { secureStorage } from '@/utils/storage';
 import { STORAGE_KEYS } from '@/utils/constants';
+import * as Application from 'expo-application';
+
+// Audit 2026-05-20: pantalla de login muestra version del APK debajo del
+// subtitle. Necesario porque el user dejo de usar OTA channel (EAS update)
+// y ahora distribuye APKs directamente — vendedor necesita ver que version
+// tiene instalada para reportar a soporte si hay bugs.
+const APP_VERSION = Application.nativeApplicationVersion || '1.0.0';
+const APP_BUILD = Application.nativeBuildVersion || '';
+const ENV_LABEL = process.env.EXPO_PUBLIC_ENV === 'production' ? '' : (process.env.EXPO_PUBLIC_ENV || '');
 
 export default function LoginScreen() {
   const [email, setEmail] = useState('');
@@ -200,6 +209,9 @@ export default function LoginScreen() {
             <Text style={styles.title}>Handy Suites®</Text>
             <Text style={styles.subtitle}>
               Gestiona tus ventas desde cualquier lugar
+            </Text>
+            <Text style={styles.versionText}>
+              Versión {APP_VERSION}{APP_BUILD ? ` (${APP_BUILD})` : ''}{ENV_LABEL ? ` · ${ENV_LABEL}` : ''}
             </Text>
           </View>
           <Text style={styles.formTitle}>{totpRequired ? 'Verificación 2FA' : 'Iniciar Sesión'}</Text>
@@ -388,6 +400,12 @@ const styles = StyleSheet.create({
     color: '#475569',
     marginBottom: 16,
     lineHeight: 18,
+  },
+  versionText: {
+    fontSize: 11,
+    color: '#94a3b8',
+    textAlign: 'center',
+    marginTop: 6,
   },
   takeoverHint: {
     backgroundColor: '#fef3c7',

--- a/apps/mobile-app/metro.config.js
+++ b/apps/mobile-app/metro.config.js
@@ -16,30 +16,29 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
-// Audit 2026-05-20 — Stub css-tree y mdn-data en bundle dev.
+// Audit 2026-05-20 — Stub css-tree y mdn-data SOLO con env var explícito.
 //
-// Causa: react-native-svg/css/css.js importa `css-tree` para "SVG style
-// element inlining" (parsea <style> dentro de <svg>). Esa feature no la
-// usamos — solo usamos <Svg> con props nativos. Pero el require eager
-// jala el bundle de mdn-data (~10K líneas CSS data) que Hermes dev parser
-// no logra parsear (errores cambiantes "'}' expected", "non-terminated
-// string", etc. dentro del módulo de datos CSS).
+// HOTFIX incident 2026-05-20: este stub se aplicaba a TODOS los bundles
+// (incluyendo EAS Update production), causando crash en startup en
+// vendedores que descargaron el bundle nuevo ("error de conexión" porque
+// react-native-svg fallaba al cargar css-tree stubbeado). Rollback
+// inmediato a group 5b819849 + ahora detrás de env var explícito.
 //
-// Producción (EAS Build con bytecode pre-compilado) NO se ve afectada
-// porque Hermes solo parsea una vez al build, no en runtime.
-//
-// Stub: devolvemos un módulo vacío en lugar de css-tree/mdn-data. Si
-// algún día usamos SVG con <style> embebido el código fallará en runtime
-// (csstree.parse() = undefined) y será obvio. Sin esto, dev mode no carga.
-const emptyStub = path.resolve(__dirname, 'metro-stubs/empty-module.js');
-const previousResolver = config.resolver.resolveRequest;
-config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (moduleName === 'css-tree' || moduleName === 'mdn-data' ||
-      moduleName.startsWith('css-tree/') || moduleName.startsWith('mdn-data/')) {
-    return { type: 'sourceFile', filePath: emptyStub };
-  }
-  if (previousResolver) return previousResolver(context, moduleName, platform);
-  return context.resolveRequest(context, moduleName, platform);
-};
+// USO en dev local cuando Expo Go dev parser Hermes falla con mdn-data:
+//   STUB_CSS_TREE=1 npx expo start --go
+// EAS Update / EAS Build NUNCA setean esta var → siempre incluyen
+// css-tree y mdn-data como deps reales en el bundle production.
+if (process.env.STUB_CSS_TREE === '1') {
+  const emptyStub = path.resolve(__dirname, 'metro-stubs/empty-module.js');
+  const previousResolver = config.resolver.resolveRequest;
+  config.resolver.resolveRequest = (context, moduleName, platform) => {
+    if (moduleName === 'css-tree' || moduleName === 'mdn-data' ||
+        moduleName.startsWith('css-tree/') || moduleName.startsWith('mdn-data/')) {
+      return { type: 'sourceFile', filePath: emptyStub };
+    }
+    if (previousResolver) return previousResolver(context, moduleName, platform);
+    return context.resolveRequest(context, moduleName, platform);
+  };
+}
 
 module.exports = withNativeWind(config, { input: './global.css' });


### PR DESCRIPTION
## Contexto

Post-incident 2026-05-20: lanzamos eas update production con metro.config.js
que stubbeaba css-tree/mdn-data sin gate. Bundle production rompio en startup
porque react-native-svg cargaba el stub vacio. Rollback al bundle de ayer +
hotfix gateando el stub detras de env var STUB_CSS_TREE=1.

Ahora dejamos de depender del canal EAS Update (vendedores reportaban
unreliability) y generamos APK directo con todo bakeado.

## Commits incluidos

- 929a6e32 hotfix(mobile): metro stub css-tree solo con env var explicito
- 9a4c2f97 chore(mobile): version 1.0.1 + disable OTA + version display en login

## Cambios

apps/mobile-app/metro.config.js (commit 929a6e32):
- Stub css-tree/mdn-data ahora solo se aplica con STUB_CSS_TREE=1 env var
- EAS Update / EAS Build nunca setean esa var -> bundle prod siempre completo
- USO dev: STUB_CSS_TREE=1 npx expo start --go (cuando Expo Go dev parser falla)

apps/mobile-app/app.json (commit 9a4c2f97):
- version: 1.0.0 -> 1.0.1
- updates.enabled: true -> false (APK auto-contenido, no mas OTA)
- android.versionCode: 2 (explicito)

apps/mobile-app/app/(auth)/login.tsx (commit 9a4c2f97):
- Import expo-application
- Muestra "Version 1.0.1 (build) - env" bajo el subtitle del logo
- Estilo discreto: fontSize 11, gris suave, center, marginTop 6

## Verificacion

- tsc --noEmit en apps/mobile-app: 0 errors en codigo nuevo
- Backend prod ya tiene race fix activo (PRs #76-#78), no se toca
- metro stub gating evita repetir el incident de hoy

## Next steps post-merge

1. PR staging -> main
2. eas build --platform android --profile production-apk --non-interactive
3. ~15 min, EAS devuelve URL del APK
4. Distribuir APK a vendedores por link directo
5. Vendedores reinstalan APK (mismo bundleId + keystore EAS-managed)
6. Smoke en emulador: instalar APK, ver "Version 1.0.1" en login