### PR TITLE
chore(mobile/eas): remove channel field de production-apk profile

### DIFF
--- a/apps/mobile-app/eas.json
+++ b/apps/mobile-app/eas.json
@@ -43,12 +43,11 @@
     },
     "production-apk": {
       "distribution": "internal",
-      "channel": "production",
       "android": {
         "buildType": "apk"
       },
       "env": {
-        "_comment": "production-apk apunta a PROD APIs pero genera APK para distribucion directa al cliente (sin pasar por Play Store). Mismas URLs que production.",
+        "_comment": "production-apk apunta a PROD APIs pero genera APK para distribucion directa al cliente (sin pasar por Play Store). Mismas URLs que production. Audit 2026-05-20: removido `channel` para que la APK NO se asocie con ningun canal EAS Update (combinado con app.json updates.enabled=false hace que la APK sea totalmente auto-contenida).",
         "EXPO_PUBLIC_API_URL": "https://mobile-api-production-f934.up.railway.app",
         "EXPO_PUBLIC_MAIN_API_URL": "https://main-api-production-7566.up.railway.app",
         "EXPO_PUBLIC_ENV": "production"


### PR DESCRIPTION
## Contexto

Continuacion del post-incident 2026-05-20. PR previos (#79, #80) ya tenian:
- app.json version 1.0.1 + updates.enabled=false + versionCode 2
- login.tsx muestra version bajo HandyLogo
- metro.config.js stub gated detras de env var

Sin embargo el profile production-apk en eas.json conservaba channel=production
(metadata muerta dado updates.enabled=false, pero confunde visualmente — el user
pidio quitarlo para no quedar asociado a ningun canal EAS Update).

## Cambio

apps/mobile-app/eas.json:
- Remove channel: production del profile production-apk
- Comment actualizado explicando el contexto

## Impacto

- Funcional: ninguno (channel era metadata muerta con updates.enabled=false)
- Cosmetico: la APK que salga de este profile no estara asociada a ningun
  channel EAS Update. Totalmente auto-contenida.

## Next step

Cuando merge a staging+main, sync worktree easup y lanzar:
  npx eas-cli build --platform android --profile production-apk --non-interactive