### PR TITLE
release: promote staging -> main (remove channel de production-apk)

### DIFF
--- a/apps/mobile-app/eas.json
+++ b/apps/mobile-app/eas.json
@@ -43,12 +43,11 @@
     },
     "production-apk": {
       "distribution": "internal",
-      "channel": "production",
       "android": {
         "buildType": "apk"
       },
       "env": {
-        "_comment": "production-apk apunta a PROD APIs pero genera APK para distribucion directa al cliente (sin pasar por Play Store). Mismas URLs que production.",
+        "_comment": "production-apk apunta a PROD APIs pero genera APK para distribucion directa al cliente (sin pasar por Play Store). Mismas URLs que production. Audit 2026-05-20: removido `channel` para que la APK NO se asocie con ningun canal EAS Update (combinado con app.json updates.enabled=false hace que la APK sea totalmente auto-contenida).",
         "EXPO_PUBLIC_API_URL": "https://mobile-api-production-f934.up.railway.app",
         "EXPO_PUBLIC_MAIN_API_URL": "https://main-api-production-7566.up.railway.app",
         "EXPO_PUBLIC_ENV": "production"


### PR DESCRIPTION
## Resumen

Promote del fix final del cleanup post-incident 2026-05-20. PR #81 ya
mergeado a staging trae el cambio cosmetico que pidio el user:
remover channel: production del profile production-apk en eas.json.

## Commits incluidos

- 9e77bb6a chore(mobile/eas): remove channel field de production-apk

## Impacto

- Funcional: ninguno. Channel era metadata muerta dado app.json
  updates.enabled=false (PR #80).
- Cosmetico: el profile production-apk ya no esta asociado a ningun
  canal EAS Update. APK totalmente auto-contenida.

## Post-merge

Sync worktree handysales-easup a main HEAD y lanzar:
  npx eas-cli build --platform android --profile production-apk --non-interactive

EAS Cloud Build ~15 min, devuelve URL del .apk para distribuir directo
a vendedores. version 1.0.1, versionCode 2, sin OTA.