### PR TITLE
fix(sync): incrementar RutasCarga en UpsertPedidoAsync (vendedor@jeyma incident 2026-05-21)

### DIFF
--- a/libs/HandySuites.Infrastructure/Repositories/Sync/SyncRepository.cs
+++ b/libs/HandySuites.Infrastructure/Repositories/Sync/SyncRepository.cs
@@ -527,6 +527,65 @@ public class SyncRepository : ISyncRepository
                     }
                 }
 
+                // BR-RUTA-CARGA (audit 2026-05-21, incident vendedor@jeyma):
+                // Replicar incremento de RutasCarga que hacen los endpoints directos
+                // /api/mobile/ventas-directas (CantidadVendida) y
+                // /api/mobile/pedidos/{id}/entregar (CantidadEntregada). El offline-first
+                // del mobile pushea via /sync/push → UpsertPedidoAsync, que ANTES de este
+                // fix saltaba este incremento. Resultado: barra "Productos (vendidos +
+                // entregados)" en pantalla Ruta del Día se quedaba en 0 aunque los
+                // pedidos sí se guardaban (counters de Pedidos hoy + Ventas hoy SÍ
+                // funcionaban porque vienen de local WDB).
+                if (pedido.Estado == EstadoPedido.Entregado && newDetalles.Count > 0)
+                {
+                    int? rutaId = null;
+
+                    // Caso 1: Pedido con RutasPedidos pre-link (preventa entregada en ruta)
+                    var rutaPedidoLink = await _db.RutasPedidos
+                        .AsNoTracking()
+                        .Where(rp => rp.PedidoId == pedido.Id && rp.Activo)
+                        .Select(rp => (int?)rp.RutaId)
+                        .FirstOrDefaultAsync();
+                    if (rutaPedidoLink.HasValue)
+                    {
+                        rutaId = rutaPedidoLink;
+                    }
+                    else if (pedido.TipoVenta == TipoVenta.VentaDirecta)
+                    {
+                        // Caso 2: VentaDirecta sin pre-link — buscar ruta activa del vendedor.
+                        // Mismo filtro que MobileVentaDirectaEndpoints.cs:213-219.
+                        rutaId = await _db.RutasVendedor
+                            .AsNoTracking()
+                            .Where(r => r.UsuarioId == usuarioId
+                                     && r.TenantId == tenantId
+                                     && r.Activo
+                                     && (r.Estado == EstadoRuta.EnProgreso || r.Estado == EstadoRuta.CargaAceptada))
+                            .Select(r => (int?)r.Id)
+                            .FirstOrDefaultAsync();
+                    }
+
+                    if (rutaId.HasValue)
+                    {
+                        foreach (var detalle in newDetalles)
+                        {
+                            var carga = await _db.RutasCarga
+                                .FirstOrDefaultAsync(c => c.RutaId == rutaId.Value
+                                    && c.ProductoId == detalle.ProductoId
+                                    && c.TenantId == tenantId
+                                    && c.Activo);
+                            if (carga != null)
+                            {
+                                if (pedido.TipoVenta == TipoVenta.VentaDirecta)
+                                    carga.CantidadVendida += (int)detalle.Cantidad;
+                                else
+                                    carga.CantidadEntregada += (int)detalle.Cantidad;
+                                carga.ActualizadoEn = DateTime.UtcNow;
+                                carga.ActualizadoPor = userId;
+                            }
+                        }
+                    }
+                }
+
                 return (pedido, wasConflict);
             }
             catch (DbUpdateException ex) when (


### PR DESCRIPTION
## Incident

Rodrigo (vendedor@jeyma) reporto que la barra "Productos (vendidos + entregados)" en pantalla Ruta del Dia mostraba 0/1056 aunque habia hecho 9 ventas directas hoy (~$1751, 103 unidades).

### Datos confirmados en prod (ruta_id=13, RUTA JUEVES)

- 9 Pedidos creados (estado=5 Entregado, tipo_venta=1 VentaDirecta) — guardados ok
- 9 SALIDAs en MovimientosInventario (motivo=VENTA) — inventario descontado ok
- DetallePedidos: 103 unidades producto_id=1 — ok
- **RutasCarga.cantidad_vendida = 0** ❌ deberia ser 103

### Causa raiz

El mobile offline-first crea ventas directas localmente y las pushea via /api/mobile/sync/push → SyncService → SyncRepository.UpsertPedidoAsync. Esta funcion guardaba todo correctamente PERO no replicaba el incremento de RutasCarga que hacen los endpoints directos:

- /api/mobile/ventas-directas (MobileVentaDirectaEndpoints.cs:231) — CantidadVendida
- /api/mobile/pedidos/{id}/entregar (MobilePedidoEndpoints.cs:325) — CantidadEntregada

Los pedidos llegan numerados "PED-YYYYMMDD-NNNN" (no "VD-..."), confirmando que el offline-first NO hitting /ventas-directas.

Bug analogo se reporto 2026-05-05 (comentario MobileVentaDirectaEndpoints.cs:211) pero el fix se aplico al endpoint directo, dejando el sync push roto.

## Fix

Agregado bloque BR-RUTA-CARGA en SyncRepository.UpsertPedidoAsync (libs/HandySuites.Infrastructure/Repositories/Sync/SyncRepository.cs) justo despues del bloque BR-VD-INV existente. Logica:

1. Solo aplica con Estado=Entregado y detalles > 0 (path CREATE).
2. Busca rutaId en 2 pasos:
   a. RutasPedidos pre-link (preventa entregada)
   b. Si VentaDirecta sin pre-link: ruta activa del vendedor (EnProgreso o CargaAceptada)
3. Por cada detalle, incrementa RutasCarga.CantidadVendida (VentaDirecta) o CantidadEntregada (otro tipo).

## Verificacion

- dotnet build clean
- dotnet test mobile 46/46 pass
- dotnet test main API 500/501 pass (1 skip pre-existente)
- Logica copy-paste del path probado en MobileVentaDirectaEndpoints.cs:213-235 (ya en prod desde 2026-05-05)

## Impacto APK

Cero. Mobile lee ruta_carga via pull sync; cuando backend incremente correcto, proxima pull actualiza WDB local y barra refleja avance. APK 1.0.1 actual sirve.

## Post-deploy

Backfill SQL para reparar estado actual:

`+++sql
WITH ventas_por_ruta AS (
  SELECT rv.id AS ruta_id, rv.tenant_id, dp.producto_id,
         SUM(dp.cantidad)::int AS total_vendida
  FROM "RutasVendedor" rv
  JOIN "Pedidos" p ON p.usuario_id=rv.usuario_id AND p.tenant_id=rv.tenant_id
                  AND p.creado_en::date = rv.fecha::date
                  AND p.tipo_venta = 1 AND p.estado = 5 AND p.activo
  JOIN "DetallePedidos" dp ON dp.pedido_id = p.id AND dp.activo
  WHERE rv.activo AND rv.fecha >= CURRENT_DATE - INTERVAL '7 days'
  GROUP BY rv.id, rv.tenant_id, dp.producto_id
)
UPDATE "RutasCarga" rc
SET cantidad_vendida = v.total_vendida, actualizado_en = NOW()
FROM ventas_por_ruta v
WHERE rc.ruta_id=v.ruta_id AND rc.producto_id=v.producto_id
  AND rc.tenant_id=v.tenant_id AND rc.activo;
`+++