### PR TITLE
fix(sync): pull sync incluye CantidadVendida/Entregada en SyncRutaCargaDto

### DIFF
--- a/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
+++ b/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
@@ -437,6 +437,13 @@ public class SyncRutaCargaDto
     public double PrecioUnitario { get; set; }
     public bool Activo { get; set; } = true;
     public DateTime? CreadoEn { get; set; }
+    // Audit 2026-05-21: estos 2 campos son los CONSUMIDOS (no la capacidad).
+    // Faltaban en el pull sync DTO desde la migration 20260506062036, asi que
+    // aunque el backend incrementaba CantidadVendida/CantidadEntregada en
+    // RutasCarga, el mobile nunca los recibia y la barra "Productos
+    // (vendidos + entregados)" siempre se quedaba en 0 (incident vendedor@jeyma).
+    public int CantidadVendida { get; set; }
+    public int CantidadEntregada { get; set; }
 }
 
 public class SyncRutaDetalleDto

--- a/libs/HandySuites.Application/Sync/Services/SyncService.cs
+++ b/libs/HandySuites.Application/Sync/Services/SyncService.cs
@@ -578,6 +578,10 @@ public class SyncService
                             PrecioUnitario = rc.PrecioUnitario,
                             Activo = rc.Activo,
                             CreadoEn = rc.CreadoEn,
+                            // Audit 2026-05-21: incluir progreso consumido para que el
+                            // mobile pueda mostrar barra "Productos (vendidos + entregados)".
+                            CantidadVendida = rc.CantidadVendida,
+                            CantidadEntregada = rc.CantidadEntregada,
                         }).ToList();
                     }
                 }


### PR DESCRIPTION
## Continuacion del incident vendedor@jeyma

Tras el fix anterior (PR #83) el backend incrementa RutasCarga correctamente. Pero Rodrigo SEGUIA viendo la barra en 0/1056.

## Causa raiz nueva

SyncRutaCargaDto (libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs:429) NO incluia los campos CantidadVendida y CantidadEntregada. Solo enviaba capacidad asignada (CantidadEntrega/CantidadVenta/CantidadTotal) pero no lo consumido.

El mobile esperaba estos campos en mappers.ts:406-407 con default ?? 0, por eso la barra se quedaba en 0 aunque el backend tuviera los valores correctos.

## Verificacion en prod previo al fix

- ruta_id=13, producto_id=1 cantidad_vendida = 265 ✓ (backend tenia el valor)
- Mobile bar mostraba 0/1056 ❌ (pull nunca recibia el valor)

## Cambios

- SyncRutaCargaDto: + CantidadVendida + CantidadEntregada
- SyncService.cs:570-581: incluir esos 2 campos en la proyeccion

## Verificacion

- dotnet build clean
- dotnet test mobile 46/46 pass
- dotnet test main API 500/501 pass

## Impacto APK

Cero. Solo fix server-side. Mobile cualquier version recibira los campos.