### PR TITLE
release: promote staging -> main (pull sync incluye CantidadVendida/Entregada en DTO)

### DIFF
--- a/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
+++ b/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
@@ -437,6 +437,13 @@ public class SyncRutaCargaDto
     public double PrecioUnitario { get; set; }
     public bool Activo { get; set; } = true;
     public DateTime? CreadoEn { get; set; }
+    // Audit 2026-05-21: estos 2 campos son los CONSUMIDOS (no la capacidad).
+    // Faltaban en el pull sync DTO desde la migration 20260506062036, asi que
+    // aunque el backend incrementaba CantidadVendida/CantidadEntregada en
+    // RutasCarga, el mobile nunca los recibia y la barra "Productos
+    // (vendidos + entregados)" siempre se quedaba en 0 (incident vendedor@jeyma).
+    public int CantidadVendida { get; set; }
+    public int CantidadEntregada { get; set; }
 }
 
 public class SyncRutaDetalleDto

--- a/libs/HandySuites.Application/Sync/Services/SyncService.cs
+++ b/libs/HandySuites.Application/Sync/Services/SyncService.cs
@@ -578,6 +578,10 @@ public class SyncService
                             PrecioUnitario = rc.PrecioUnitario,
                             Activo = rc.Activo,
                             CreadoEn = rc.CreadoEn,
+                            // Audit 2026-05-21: incluir progreso consumido para que el
+                            // mobile pueda mostrar barra "Productos (vendidos + entregados)".
+                            CantidadVendida = rc.CantidadVendida,
+                            CantidadEntregada = rc.CantidadEntregada,
                         }).ToList();
                     }
                 }


### PR DESCRIPTION
## Resumen

Completa el fix del incident vendedor@jeyma. PR previo (#83) hizo que el backend INCREMENTE RutasCarga al sync push. Pero la barra seguia en 0 porque el pull DTO no enviaba los campos al mobile.

Este PR arregla el DTO + projection del pull para que mobile reciba los valores.

## Commits

- ba958b94 fix(sync): pull sync incluye CantidadVendida/CantidadEntregada en SyncRutaCargaDto

## Verificacion staging

- Backend actual ya tiene increment (PR #83)
- Mobile espera los campos (mappers.ts:406-407)
- Falta solo que el pull DTO los envie

## Impacto APK

Cero. Solo cambia el shape del response server-side. APK 1.0.0/1.0.1 cualquiera lo recibe.

## Post-merge prod

1. Railway redeploy automatico (~3-5 min)
2. Rodrigo's proximo pull sync (cada 5 min auto o al entrar a Ruta) traerá CantidadVendida=265+ correcto
3. Barra pasa de 0/1056 a ~265-291/1056 (25-27%)
4. Sin tocar APK