### PR TITLE
fix(orders): badge legible, wizard funcional, badge TipoVenta + acces…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1196,7 +1196,9 @@
       "statusReadyShip": "Ready to ship",
       "statusEnRoute": "In transit",
       "statusDelivered": "Delivered",
-      "statusCancelled": "Cancelled"
+      "statusCancelled": "Cancelled",
+      "tipoVentaDirecta": "Direct sale",
+      "tipoVentaPreventa": "Pre-sale"
     }
   },
   "clients": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1196,7 +1196,9 @@
       "statusReadyShip": "Lista envío",
       "statusEnRoute": "En ruta",
       "statusDelivered": "Entregado",
-      "statusCancelled": "Cancelado"
+      "statusCancelled": "Cancelado",
+      "tipoVentaDirecta": "Venta directa",
+      "tipoVentaPreventa": "Preventa"
     }
   },
   "clients": {

--- a/apps/web/src/app/(dashboard)/orders/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Loader2, AlertCircle } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
-import { orderService, type OrderDetail } from '@/services/api/orders';
+import { orderService, type OrderDetail, estadoIntToStatus } from '@/services/api/orders';
 import { OrderStatus } from '@/types';
 import { toast } from '@/hooks/useToast';
 
@@ -34,6 +34,16 @@ function StatusBadge({ status, label }: { status: string; label: string }) {
   const cfg = STATUS_STYLES[status] ?? { color: 'text-foreground/80', bg: 'bg-surface-3' };
   return (
     <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${cfg.color} ${cfg.bg}`}>
+      {label}
+    </span>
+  );
+}
+
+function TipoVentaBadge({ tipoVenta, label }: { tipoVenta: number; label: string }) {
+  const isDirecta = tipoVenta === 1;
+  const cls = isDirecta ? 'text-orange-700 bg-orange-100' : 'text-cyan-700 bg-cyan-100';
+  return (
+    <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${cls}`}>
       {label}
     </span>
   );
@@ -168,13 +178,16 @@ export default function OrderDetailPage() {
     );
   }
 
-  const isCancelled = order.estado === OrderStatus.CANCELADA;
-  const isDelivered = order.estado === OrderStatus.ENTREGADA;
+  // Backend serializa Estado como int; normalizamos al string del enum frontend
+  // para que STATUS_LABELS/STEPPER_STEPS comparen contra el mismo tipo.
+  const estadoNorm = estadoIntToStatus(order.estado);
+  const isCancelled = estadoNorm === OrderStatus.CANCELADA;
+  const isDelivered = estadoNorm === OrderStatus.ENTREGADA;
 
   // Determine which step is active for the stepper
   const activeStepIndex = isCancelled
     ? -1
-    : STEPPER_STEPS.indexOf(order.estado as OrderStatus);
+    : STEPPER_STEPS.indexOf(estadoNorm);
 
   return (
     <div className="min-h-screen bg-[#F9FAFB]">
@@ -191,11 +204,12 @@ export default function OrderDetailPage() {
             <h1 className="text-[22px] font-bold text-foreground">
               {t('orderTitle', { number: order.numeroPedido })}
             </h1>
-            <StatusBadge status={order.estado} label={STATUS_LABELS[order.estado] ?? order.estado} />
+            <StatusBadge status={estadoNorm} label={STATUS_LABELS[estadoNorm] ?? estadoNorm} />
+            <TipoVentaBadge tipoVenta={order.tipoVenta} label={order.tipoVenta === 1 ? t('tipoVentaDirecta') : t('tipoVentaPreventa')} />
           </div>
 
           <div className="flex items-center gap-2">
-            {order.estado === OrderStatus.PENDIENTE && (
+            {estadoNorm === OrderStatus.PENDIENTE && (
               <button
                 onClick={() => handleAction('confirmar')}
                 disabled={!!actionLoading}
@@ -205,7 +219,7 @@ export default function OrderDetailPage() {
                 {t('confirmBtn')}
               </button>
             )}
-            {order.estado === OrderStatus.CONFIRMADA && (
+            {estadoNorm === OrderStatus.CONFIRMADA && (
               <button
                 onClick={() => handleAction('en-ruta')}
                 disabled={!!actionLoading}
@@ -215,7 +229,7 @@ export default function OrderDetailPage() {
                 {t('enRouteBtn')}
               </button>
             )}
-            {order.estado === OrderStatus.ENVIADA && (
+            {estadoNorm === OrderStatus.ENVIADA && (
               <button
                 onClick={() => handleAction('entregar')}
                 disabled={!!actionLoading}

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -404,7 +404,7 @@ export default function OrdersPage() {
   };
 
   const handleEditOrder = (orderId: string) => openOrderDrawer(orderId, true);
-  const handleViewDetails = (orderId: string) => openOrderDrawer(orderId, false);
+  const handleViewDetails = (orderId: string) => router.push(`/orders/${orderId}`);
 
   const handleDeleteOrder = (orderId: string) => {
     // Reemplaza window.confirm() nativo por Modal (consistencia con cancelar y

--- a/apps/web/src/services/api/orders.ts
+++ b/apps/web/src/services/api/orders.ts
@@ -2,6 +2,24 @@
 import { api, handleApiError } from '@/lib/api';
 import { OrderStatus } from '@/types';
 
+// ============ MAPPERS ============
+
+// Backend serializa EstadoPedido como int (0=Borrador, 2=Confirmado, 4=EnRuta,
+// 5=Entregado, 6=Cancelado). Frontend usa OrderStatus enum de strings.
+// Pass-through si ya es string (defensivo para StringEnumConverter).
+const ESTADO_INT_TO_STATUS: Record<number, OrderStatus> = {
+  0: OrderStatus.PENDIENTE,
+  2: OrderStatus.CONFIRMADA,
+  4: OrderStatus.ENVIADA,
+  5: OrderStatus.ENTREGADA,
+  6: OrderStatus.CANCELADA,
+};
+
+export function estadoIntToStatus(estado: number | OrderStatus): OrderStatus {
+  if (typeof estado === 'string') return estado;
+  return ESTADO_INT_TO_STATUS[estado] ?? OrderStatus.PENDIENTE;
+}
+
 // ============ TIPOS ============
 
 export interface OrdersListResponse {
@@ -40,7 +58,10 @@ export interface OrderDetail {
   clienteDireccion?: string;
   usuarioId: number;
   usuarioNombre: string;
-  estado: OrderStatus;
+  estado: OrderStatus | number;
+  estadoNombre?: string;
+  tipoVenta: number;
+  tipoVentaNombre: string;
   subtotal: number;
   descuento: number;
   impuestos: number;


### PR DESCRIPTION
…o desde lista

Reporte vendedor@jeyma (2026-05-22 sobre pedido 256 PED-20260522-0001 VentaDirecta Entregado).

## Problemas

1. La pagina /orders/[id] (dedicada, con wizard + badges) solo era alcanzable desde el link de GPS. Desde /orders el row click abria un Drawer lateral con el form, no la pagina standalone.

2. Badge mostraba "5" (valor numerico del enum EstadoPedido.Entregado) en vez del label "Entregado".

3. Wizard horizontal de 4 pasos se veia todo gris (ningun paso completado ni activo) aunque el pedido estaba Entregado.

4. No habia indicador de TipoVenta (Preventa vs VentaDirecta). El wizard "Borrador -> Confirmado -> En ruta -> Entregado" es del flujo Preventa; confundia en pedidos VentaDirecta (nacen ya Entregado).

## Causas raiz

- Backend serializa EstadoPedido como int (5). Frontend tiene OrderStatus enum de strings (ENTREGADA). STATUS_LABELS[5] y STEPPER_STEPS.indexOf(5) retornan undefined / -1.
- OrderDetail interface no incluia tipoVenta/tipoVentaNombre aunque el backend los emite.
- handleViewDetails en /orders abria openOrderDrawer en vez de navegar a /orders/[id].

## Fix

1. apps/web/src/services/api/orders.ts:
   - estadoIntToStatus mapper (numero -> OrderStatus string, pass-through si ya es string).
   - OrderDetail extendido: estado puede ser number o OrderStatus, agregados estadoNombre/tipoVenta/tipoVentaNombre.

2. apps/web/src/app/(dashboard)/orders/[id]/page.tsx:
   - estadoNorm = estadoIntToStatus(order.estado) usado en todos los condicionales y el stepper.
   - Para VentaDirecta Entregado, indexOf(ENTREGADA)=3 -> los 4 pasos se marcan como completados (check verde).
   - Nuevo TipoVentaBadge al lado del StatusBadge.

3. apps/web/src/app/(dashboard)/orders/page.tsx:
   - handleViewDetails ahora hace router.push(`/orders/${id}`) en vez de openOrderDrawer.
   - Drawer sigue siendo usado para edicion de Borrador (handleEditOrder no cambia).

4. apps/web/messages/{es,en}.json:
   - tipoVentaDirecta + tipoVentaPreventa bajo orders.detailPage.

## Verificacion

- npm run type-check apps/web: 0 errors
- Row click en /orders (estado != Borrador): navega a /orders/[id]
- /orders/256: badge "Entregado", badge "Venta directa", 4 pasos en verde
- Pedido Preventa intermedio: wizard muestra progreso parcial correcto
- Pedido Borrador: row click abre drawer de edicion (sin cambio)