### PR TITLE
fix(automations): destinatario=admin notifica a TODOS los admins del …

### DIFF
--- a/apps/api/src/HandySuites.Api/Automations/IAutomationHandler.cs
+++ b/apps/api/src/HandySuites.Api/Automations/IAutomationHandler.cs
@@ -95,8 +95,7 @@ public record AutomationContext(
 
         if (Destinatario is "admin" or "ambos")
         {
-            var adminId = await GetAdminUserIdAsync(ct);
-            if (adminId.HasValue) ids.Add(adminId.Value);
+            ids.AddRange(await GetAdminUserIdsAsync(ct));
         }
 
         if (Destinatario is "vendedores" or "ambos")
@@ -268,6 +267,23 @@ public record AutomationContext(
                 && u.RolExplicito == RoleNames.Admin)
             .Select(u => (int?)u.Id)
             .FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>
+    /// Lista TODOS los user IDs con rol ADMIN activos en el tenant. SuperAdmin
+    /// queda fuera (es admin del sistema, no del tenant operativo). Usado por
+    /// ResolveDestinatarioIdsAsync para que las automatizaciones con
+    /// destinatario=admin notifiquen a todos los admins del tenant, no solo
+    /// al primero (audit 2026-05-22, ticket vendedor@jeyma).
+    /// </summary>
+    public async Task<List<int>> GetAdminUserIdsAsync(CancellationToken ct)
+    {
+        return await Db.Usuarios
+            .Where(u => u.TenantId == TenantId && u.Activo
+                && u.RolExplicito == RoleNames.Admin)
+            .OrderBy(u => u.Id)
+            .Select(u => u.Id)
+            .ToListAsync(ct);
     }
 }
 


### PR DESCRIPTION
…tenant

Reporte xjoshmenx (2026-05-22): el email del Resumen del Día en jeyma llegaba al admin generico admin@jeyma.com (id=2) creado en el seed, no a los admins operativos reales (Josue id=6, Abraham id=7).

## Causa raiz

ResolveDestinatarioIdsAsync (IAutomationHandler.cs:96-100) usaba GetAdminUserIdAsync singular con FirstOrDefaultAsync -> solo el admin con id mas bajo recibia. En jeyma:

  id=2 admin@jeyma.com    (generico del seed, nadie revisa)
  id=6 josuemendozasegovia (real)
  id=7 mendozasegoviaabraham (real)

Solo id=2 recibia.

## Fix

Nuevo metodo GetAdminUserIdsAsync (plural, mismo filtro pero ToListAsync
+ OrderBy id). ResolveDestinatarioIdsAsync agrega todos los IDs en lugar de uno solo.

GetAdminUserIdAsync (singular) se mantiene sin cambios para los ~10 handlers que esperan "un admin" en contextos no-multi-recipient (ej. atribuir un evento a un usuario).

SUPER_ADMIN sigue fuera del query (es admin del sistema, no del tenant operativo, segun direccion del user).

## Verificacion

- dotnet build clean
- dotnet test API 500/501 pass (1 skip pre-existente)
- Post-deploy: click "Probar ahora" en Resumen Diario desde el web prod ->
  admin@jeyma.com, Josue y Abraham reciben email.