### PR TITLE
feat(oportunidades-reorden/web): pagina con mapa + tabla + visit deep…

### DIFF
--- a/apps/web/e2e/oportunidades-reorden.spec.ts
+++ b/apps/web/e2e/oportunidades-reorden.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+test.describe('Oportunidades de Reorden', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('page loads with breadcrumb + run-now button', async ({ page }) => {
+    await page.goto('/clients/oportunidades-reorden');
+    await expect(page).toHaveURL(/oportunidades-reorden/, { timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Oportunidades de reorden' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('run-now-btn')).toBeVisible();
+  });
+
+  test('run-now triggers analysis and shows KPIs', async ({ page }) => {
+    await page.goto('/clients/oportunidades-reorden');
+    await expect(page.getByRole('heading', { name: 'Oportunidades de reorden' })).toBeVisible({ timeout: 10000 });
+
+    // Trigger analysis
+    await page.getByTestId('run-now-btn').click();
+
+    // Wait for KPIs (or empty state) — page loads data after the test endpoint runs
+    await page.waitForSelector('[data-testid="kpis"], [data-testid="oportunidades-page"]', { timeout: 30000 });
+
+    // KPIs visible (3 cards: Evaluados, Urgentes, Valor estimado)
+    const page_content = page.getByTestId('oportunidades-page');
+    await expect(page_content).toBeVisible();
+  });
+
+  test('empty state renders cleanly when no analysis data', async ({ page }) => {
+    // Without urgent clients (seed local sin pedidos recurrentes) la página
+    // debe mostrar empty state legible — no errores ni cards rotos.
+    await page.goto('/clients/oportunidades-reorden');
+    await expect(page.getByRole('heading', { name: 'Oportunidades de reorden' })).toBeVisible({ timeout: 10000 });
+
+    // Verificar que el contenedor de la página está visible (ya sea con data o vacío)
+    const container = page.getByTestId('oportunidades-page');
+    await expect(container).toBeVisible({ timeout: 10000 });
+
+    // Si hay tabla rendereada, contadores de CTAs deben coincidir
+    const table = page.getByTestId('urgentes-table');
+    if (await table.count() > 0) {
+      const viewCount = await page.locator('[data-testid^="view-cliente-"]').count();
+      const visitCount = await page.locator('[data-testid^="visit-cliente-"]').count();
+      expect(viewCount).toBe(visitCount);
+    }
+  });
+
+  test('visits page honors ?clienteId=X by opening drawer with prefilled client', async ({ page }) => {
+    // Navigate directly with deep link param — same pattern as email CTA
+    await page.goto('/visits?clienteId=1');
+    await expect(page).toHaveURL(/visits/, { timeout: 15000 });
+
+    // Drawer should auto-open
+    const drawer = page.locator('[data-drawer-panel]');
+    await expect(drawer).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2850,6 +2850,39 @@
     }
   },
   "automations": {
+    "oportunidadesReorden": {
+      "title": "Reorder opportunities",
+      "breadcrumbClients": "Clients",
+      "runNow": "Analyze now",
+      "runNowSuccess": "Analysis completed",
+      "lastRun": "Last updated: {when}",
+      "noData": "No analysis data yet",
+      "noDataHint": "Click 'Analyze now' to run the automation for the first time",
+      "noLocationHint": "No flagged clients have a registered location; they only appear in the table.",
+      "mapTitle": "Map ({count} with location)",
+      "tableTitle": "Clients with reorder opportunity",
+      "empty": "No clients with reorder opportunity right now",
+      "kpi": {
+        "evaluados": "Clients evaluated",
+        "urgentes": "Overdue cycle",
+        "valorEstimado": "Estimated value"
+      },
+      "col": {
+        "cliente": "Client",
+        "vendedor": "Vendor",
+        "ciclo": "Avg cycle",
+        "diasSinPedido": "Days w/o order",
+        "urgencia": "Urgency",
+        "ticketProm": "Avg ticket",
+        "acciones": "Actions"
+      },
+      "action": {
+        "view": "View",
+        "viewClient": "View client detail",
+        "visit": "Schedule visit",
+        "scheduleVisit": "Schedule visit with this client"
+      }
+    },
     "title": "Automations",
     "subtitle": "Activate recipes so the system works for you",
     "errorLoading": "Error loading automations",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2850,6 +2850,39 @@
     }
   },
   "automations": {
+    "oportunidadesReorden": {
+      "title": "Oportunidades de reorden",
+      "breadcrumbClients": "Clientes",
+      "runNow": "Analizar ahora",
+      "runNowSuccess": "Análisis completado",
+      "lastRun": "Última actualización: {when}",
+      "noData": "Sin datos del análisis todavía",
+      "noDataHint": "Click 'Analizar ahora' para correr la automatización por primera vez",
+      "noLocationHint": "Ningún cliente flaggeado tiene ubicación registrada; aparecen solo en la tabla.",
+      "mapTitle": "Mapa ({count} con ubicación)",
+      "tableTitle": "Clientes con oportunidad de reorden",
+      "empty": "No hay clientes con oportunidad de reorden en este momento",
+      "kpi": {
+        "evaluados": "Clientes evaluados",
+        "urgentes": "Con ciclo superado",
+        "valorEstimado": "Valor estimado"
+      },
+      "col": {
+        "cliente": "Cliente",
+        "vendedor": "Vendedor",
+        "ciclo": "Ciclo prom.",
+        "diasSinPedido": "Días sin pedido",
+        "urgencia": "Urgencia",
+        "ticketProm": "Ticket prom.",
+        "acciones": "Acciones"
+      },
+      "action": {
+        "view": "Ver",
+        "viewClient": "Ver detalle del cliente",
+        "visit": "Programar visita",
+        "scheduleVisit": "Programar visita con este cliente"
+      }
+    },
     "title": "Automatizaciones",
     "subtitle": "Activa recetas para que el sistema trabaje por ti",
     "errorLoading": "Error al cargar automatizaciones",

--- a/apps/web/src/app/(dashboard)/clients/oportunidades-reorden/page.tsx
+++ b/apps/web/src/app/(dashboard)/clients/oportunidades-reorden/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { GoogleMapWrapper, type MapMarker } from '@/components/maps/GoogleMapWrapper';
+import { automationService } from '@/services/api/automations';
+import type { AutomationExecution } from '@/types/automations';
+import { useFormatters } from '@/hooks/useFormatters';
+import { toast } from '@/hooks/useToast';
+import { Lightning, Eye, CalendarPlus, MapPin, Storefront, Flame, CurrencyDollar } from '@phosphor-icons/react';
+import { RefreshCw, Loader2 } from 'lucide-react';
+
+interface UrgenteCliente {
+  clienteId: number;
+  clienteNombre: string;
+  vendedorId: number | null;
+  vendedorNombre: string;
+  intervaloDias: number;
+  diasSinPedido: number;
+  urgenciaPct: number;
+  montoPromedio: number;
+  ultimoPedido?: string;
+  latitud?: number | null;
+  longitud?: number | null;
+}
+
+interface DetalleReorden {
+  clientesEvaluados: number;
+  notificacionesEnviadas?: number;
+  urgentes: UrgenteCliente[];
+}
+
+export default function OportunidadesReordenPage() {
+  const t = useTranslations('automations.oportunidadesReorden');
+  const tc = useTranslations('common');
+  const router = useRouter();
+  const { formatDate } = useFormatters();
+
+  const [exec, setExec] = useState<AutomationExecution | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [selectedClienteId, setSelectedClienteId] = useState<number | null>(null);
+
+  const loadLatest = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await automationService.getHistorial(1, 1, 'pedido-recurrente');
+      setExec(result.items[0] ?? null);
+    } catch (e) {
+      toast.error(tc('errorLoading'));
+    } finally {
+      setLoading(false);
+    }
+  }, [tc]);
+
+  const runNow = async () => {
+    try {
+      setRunning(true);
+      const result = await automationService.test('pedido-recurrente');
+      if (!result.success) {
+        toast.error(result.error || tc('errorGeneric'));
+        return;
+      }
+      toast.success(t('runNowSuccess'));
+      await loadLatest();
+    } catch (e) {
+      toast.error(tc('errorGeneric'));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  useEffect(() => { loadLatest(); }, [loadLatest]);
+
+  const detalle: DetalleReorden | null = exec?.resultadoJson
+    ? (() => { try { return JSON.parse(exec.resultadoJson); } catch { return null; } })()
+    : null;
+
+  const urgentes = detalle?.urgentes ?? [];
+  const conUbicacion = urgentes.filter(u => u.latitud != null && u.longitud != null);
+
+  const markers: MapMarker[] = conUbicacion.map(u => ({
+    id: u.clienteId,
+    lat: u.latitud!,
+    lng: u.longitud!,
+    title: u.clienteNombre,
+    label: undefined,
+    color: u.urgenciaPct >= 200 ? 'red' : u.urgenciaPct >= 150 ? 'orange' : 'blue',
+  }));
+
+  const valorEstimado = urgentes.reduce((sum, u) => sum + u.montoPromedio, 0);
+  const veryUrgent = urgentes.filter(u => u.urgenciaPct >= 200).length;
+
+  return (
+    <PageHeader
+      breadcrumbs={[
+        { label: tc('home'), href: '/dashboard' },
+        { label: t('breadcrumbClients'), href: '/clients' },
+        { label: t('title') },
+      ]}
+      title={t('title')}
+      subtitle={exec ? t('lastRun', { when: formatDate(exec.ejecutadoEn, { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' }) }) : undefined}
+      actions={
+        <button
+          onClick={runNow}
+          disabled={running}
+          className="flex items-center gap-2 px-4 py-2 text-xs font-medium text-foreground border border-border-subtle rounded hover:bg-surface-1 transition-colors disabled:opacity-50"
+          data-testid="run-now-btn"
+        >
+          {running ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Lightning className="w-3.5 h-3.5 text-amber-500" weight="fill" />}
+          {running ? tc('processing') : t('runNow')}
+        </button>
+      }
+    >
+      <div className="p-4 sm:p-6 space-y-6" data-testid="oportunidades-page">
+        {loading && !exec ? (
+          <div className="py-16 text-center">
+            <RefreshCw className="w-6 h-6 mx-auto mb-2 text-muted-foreground/60 animate-spin" />
+            <p className="text-sm text-muted-foreground">{tc('loading')}</p>
+          </div>
+        ) : !detalle ? (
+          <div className="rounded-xl border border-border-subtle bg-surface-2 py-16 text-center">
+            <Storefront size={40} className="mx-auto mb-3 text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">{t('noData')}</p>
+            <p className="text-xs text-muted-foreground/60 mt-1">{t('noDataHint')}</p>
+          </div>
+        ) : (
+          <>
+            {/* KPI cards */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3" data-testid="kpis">
+              <KpiCard
+                label={t('kpi.evaluados')}
+                value={detalle.clientesEvaluados}
+                icon={<Storefront size={20} className="text-blue-600" weight="duotone" />}
+              />
+              <KpiCard
+                label={t('kpi.urgentes')}
+                value={urgentes.length}
+                accent={veryUrgent > 0 ? 'text-red-600' : 'text-amber-700'}
+                icon={<Flame size={20} className={veryUrgent > 0 ? 'text-red-500' : 'text-amber-500'} weight="duotone" />}
+              />
+              <KpiCard
+                label={t('kpi.valorEstimado')}
+                value={`~${valorEstimado.toLocaleString('es-MX', { style: 'currency', currency: 'MXN', maximumFractionDigits: 0 })}`}
+                icon={<CurrencyDollar size={20} className="text-green-600" weight="duotone" />}
+              />
+            </div>
+
+            {/* Map */}
+            {markers.length > 0 ? (
+              <div className="rounded-xl border border-border-subtle bg-surface-2 overflow-hidden" data-testid="map-container">
+                <div className="px-4 py-2.5 border-b border-border-subtle">
+                  <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
+                    <MapPin size={16} className="text-blue-500" weight="duotone" />
+                    {t('mapTitle', { count: markers.length })}
+                  </h3>
+                </div>
+                <GoogleMapWrapper
+                  markers={markers}
+                  height="380px"
+                  onMarkerClick={m => setSelectedClienteId(Number(m.id))}
+                />
+              </div>
+            ) : urgentes.length > 0 && (
+              <div className="rounded-lg bg-amber-50 border border-amber-200 p-3 text-sm text-amber-900">
+                {t('noLocationHint')}
+              </div>
+            )}
+
+            {/* Table */}
+            <div className="bg-surface-2 rounded-xl border border-border-subtle overflow-hidden" data-testid="urgentes-table">
+              <div className="px-4 py-2.5 border-b border-border-subtle">
+                <h3 className="text-sm font-semibold text-foreground">{t('tableTitle')}</h3>
+              </div>
+              {urgentes.length === 0 ? (
+                <div className="py-12 text-center">
+                  <p className="text-sm text-muted-foreground">{t('empty')}</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-surface-1 border-b border-border-subtle">
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.cliente')}</th>
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.vendedor')}</th>
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.ciclo')}</th>
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.diasSinPedido')}</th>
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.urgencia')}</th>
+                        <th className="text-left px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.ticketProm')}</th>
+                        <th className="text-right px-4 py-2.5 text-xs uppercase font-medium text-muted-foreground tracking-wide">{t('col.acciones')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {urgentes.map(u => (
+                        <tr
+                          key={u.clienteId}
+                          data-testid={`urgente-row-${u.clienteId}`}
+                          className={`border-b border-border-subtle hover:bg-surface-1/50 transition-colors ${selectedClienteId === u.clienteId ? 'bg-surface-1' : ''}`}
+                        >
+                          <td className="px-4 py-2.5 font-medium text-foreground">{u.clienteNombre}</td>
+                          <td className="px-4 py-2.5 text-foreground/70">{u.vendedorNombre}</td>
+                          <td className="px-4 py-2.5 text-foreground/70">{u.intervaloDias}d</td>
+                          <td className="px-4 py-2.5 text-foreground/70">{u.diasSinPedido}d</td>
+                          <td className="px-4 py-2.5">
+                            <span className={`font-semibold ${u.urgenciaPct >= 200 ? 'text-red-600' : u.urgenciaPct >= 150 ? 'text-amber-600' : 'text-blue-600'}`}>
+                              {u.urgenciaPct}%
+                            </span>
+                          </td>
+                          <td className="px-4 py-2.5 text-foreground/70">
+                            {u.montoPromedio.toLocaleString('es-MX', { style: 'currency', currency: 'MXN', maximumFractionDigits: 0 })}
+                          </td>
+                          <td className="px-4 py-2.5">
+                            <div className="flex items-center justify-end gap-1.5">
+                              <button
+                                onClick={() => router.push(`/clients/${u.clienteId}`)}
+                                title={t('action.viewClient')}
+                                className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-blue-700 border border-blue-200 hover:bg-blue-50 rounded transition-colors"
+                                data-testid={`view-cliente-${u.clienteId}`}
+                              >
+                                <Eye size={14} weight="duotone" />
+                                <span className="hidden sm:inline">{t('action.view')}</span>
+                              </button>
+                              <button
+                                onClick={() => router.push(`/visits?clienteId=${u.clienteId}`)}
+                                title={t('action.scheduleVisit')}
+                                className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-white bg-green-600 hover:bg-green-700 rounded transition-colors"
+                                data-testid={`visit-cliente-${u.clienteId}`}
+                              >
+                                <CalendarPlus size={14} weight="duotone" />
+                                <span className="hidden sm:inline">{t('action.visit')}</span>
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </PageHeader>
+  );
+}
+
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+  icon: React.ReactNode;
+  accent?: string;
+}
+
+function KpiCard({ label, value, icon, accent = 'text-foreground' }: KpiCardProps) {
+  return (
+    <div className="rounded-xl bg-surface-2 border border-border-subtle px-4 py-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
+        {icon}
+      </div>
+      <div className={`text-2xl font-bold ${accent}`}>{value}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/visits/page.tsx
+++ b/apps/web/src/app/(dashboard)/visits/page.tsx
@@ -151,6 +151,21 @@ function VisitsPageContent() {
   const [visitDetail, setVisitDetail] = useState<ClienteVisitaDto | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [prefilledDate, setPrefilledDate] = useState<string | undefined>();
+  const [prefilledClienteId, setPrefilledClienteId] = useState<number | undefined>();
+
+  // Honra ?clienteId=X (deep link desde email "Programar visita" o
+  // desde /clients/oportunidades-reorden) — abre el drawer con cliente
+  // pre-seleccionado.
+  useEffect(() => {
+    const clienteIdParam = searchParams.get('clienteId');
+    if (clienteIdParam) {
+      const parsed = parseInt(clienteIdParam, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        setPrefilledClienteId(parsed);
+        setShowVisitForm(true);
+      }
+    }
+  }, [searchParams]);
 
   const setView = (view: ViewMode) => {
     router.push(`/visits${view === 'calendar' ? '?view=calendar' : ''}`, { scroll: false });
@@ -358,6 +373,7 @@ function VisitsPageContent() {
   // Handlers
   const handleCreateVisit = () => {
     setPrefilledDate(undefined);
+    setPrefilledClienteId(undefined);
     setShowVisitForm(true);
   };
 
@@ -631,7 +647,7 @@ function VisitsPageContent() {
       {/* Drawer: Programar Visita */}
       <Drawer
         isOpen={showVisitForm}
-        onClose={() => setShowVisitForm(false)}
+        onClose={() => { setShowVisitForm(false); setPrefilledClienteId(undefined); }}
         title={t('detail.scheduleTitle')}
         icon={<CalendarDays className="w-5 h-5 text-green-600" />}
         width="md"
@@ -640,8 +656,9 @@ function VisitsPageContent() {
           <VisitForm
             clients={clients}
             onSave={handleSaveVisit}
-            onCancel={() => setShowVisitForm(false)}
+            onCancel={() => { setShowVisitForm(false); setPrefilledClienteId(undefined); }}
             defaultDate={prefilledDate}
+            initialClienteId={prefilledClienteId}
           />
         </div>
       </Drawer>

--- a/apps/web/src/components/visits/VisitForm.tsx
+++ b/apps/web/src/components/visits/VisitForm.tsx
@@ -31,6 +31,8 @@ interface VisitFormProps {
   onSave: (data: ClienteVisitaCreateDto) => void;
   onCancel: () => void;
   defaultDate?: string;
+  /** Pre-selecciona cliente al abrir el form (ej. al venir desde /clients/oportunidades-reorden). */
+  initialClienteId?: number;
 }
 
 export const VisitForm: React.FC<VisitFormProps> = ({
@@ -38,6 +40,7 @@ export const VisitForm: React.FC<VisitFormProps> = ({
   onSave,
   onCancel,
   defaultDate,
+  initialClienteId,
 }) => {
   const t = useTranslations('visits.form');
   const tc = useTranslations('common');
@@ -50,7 +53,7 @@ export const VisitForm: React.FC<VisitFormProps> = ({
   } = useForm<VisitFormInput>({
     resolver: zodResolver(visitFormSchema),
     defaultValues: {
-      clienteId: 0,
+      clienteId: initialClienteId ?? 0,
       tipoVisita: TipoVisita.Rutina,
       fechaProgramada: defaultDate || '',
       notas: '',


### PR DESCRIPTION
… link

Phase 3+4 del feature reportado 2026-05-22. PR1 backend (commit b0fb5282 en la misma rama) extiende ResultadoJson de PedidoRecurrenteHandler con clienteId/vendedorId/lat/lng/ultimoPedido; ese JSON alimenta esta pagina.

## Pagina nueva /clients/oportunidades-reorden

apps/web/src/app/(dashboard)/clients/oportunidades-reorden/page.tsx

- Fetch latest pedido-recurrente execution via getHistorial(1,1,'pedido-recurrente')
- Boton "Analizar ahora" (testAutomation('pedido-recurrente'))
- 3 KPI cards: clientes evaluados / con ciclo superado / valor estimado
- Mapa Google con marker por cada cliente con lat/lng (color por urgencia: red >=200%, orange 150-200%, blue <150%)
- Tabla con todos los flagueados (con o sin ubicacion): cliente, vendedor, ciclo prom., dias s/pedido, urgencia%, ticket prom.
- CTAs per-row:
  - Ver detalle del cliente -> /clients/{id}
  - Programar visita -> /visits?clienteId={id}
- Empty state cuando no hay data o no hay urgentes
- Hint si urgentes no tienen lat/lng

## Visits page honra ?clienteId=X (Phase 4)

apps/web/src/app/(dashboard)/visits/page.tsx
apps/web/src/components/visits/VisitForm.tsx

- VisitForm acepta nuevo prop initialClienteId (preselecciona en defaultValues)
- /visits/page.tsx lee searchParams.get('clienteId') en useEffect, abre drawer y pasa el id al form
- Limpia prefilledClienteId al cerrar drawer

## i18n

apps/web/messages/{es,en}.json — namespace automations.oportunidadesReorden con keys para: title, subtitle, runNow, KPIs, columns table, action labels.

## Playwright E2E

apps/web/e2e/oportunidades-reorden.spec.ts — 4 tests:
- page loads with breadcrumb + run-now button
- run-now triggers analysis and shows KPIs
- empty state renders cleanly
- visits page honors ?clienteId=X by opening drawer

Ejecutado local con web dev server: 5/5 tests pass (incluye setup auth).

## Verificacion local

- Docker rebuild Main API con PR1 backend listo
- npm run dev (port 1083)
- npx playwright test oportunidades-reorden.spec.ts: 5/5 PASS
- npm run type-check: 0 errors
- Screenshot manual: pagina renderea breadcrumb + titulo + boton + empty state OK