### PR TITLE
fix(mobile): bug timezone en auto-detect ruta activa para gastos (1.0…

### DIFF
--- a/apps/mobile-app/app.json
+++ b/apps/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Handy Suites",
     "slug": "handy-suites",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "handysuites",
@@ -30,7 +30,7 @@
         "backgroundColor": "#2563eb"
       },
       "package": "com.handysuites.app",
-      "versionCode": 4
+      "versionCode": 5
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/apps/mobile-app/app/(tabs)/ruta/gastos/nuevo.tsx
+++ b/apps/mobile-app/app/(tabs)/ruta/gastos/nuevo.tsx
@@ -66,19 +66,25 @@ function NuevoGastoScreen() {
   }, [diasAtras]);
 
   // Detectar ruta activa del dia. Si no hay, no se permite crear gasto.
+  // FIX bug 29/5: backend guarda ruta.fecha como UTC midnight del calendar date
+  // (ej. "2026-05-29 00:00:00Z"). Si comparamos con `setHours(0,0,0,0)` (local TZ),
+  // en CDMX (UTC-6) eso es "2026-05-29 06:00 UTC" → ruta queda ANTES del rango y la
+  // query no la encuentra. Solucion: usar Date.UTC(year, month, day) del calendar
+  // date local — produce el mismo UTC midnight que el backend guarda.
   useEffect(() => {
     (async () => {
       if (!user) { setRutaLoading(false); return; }
       try {
         const userIdNum = typeof user.id === 'number' ? user.id : parseInt(String(user.id), 10);
-        const todayMs = new Date(); todayMs.setHours(0, 0, 0, 0);
-        const tomorrowMs = todayMs.getTime() + 24 * 3600 * 1000;
+        const now = new Date();
+        const todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+        const tomorrowMs = todayMs + 24 * 3600 * 1000;
         const rutas = await database.get<Ruta>('rutas')
           .query(
             Q.where('usuario_id', userIdNum),
             Q.where('activo', true),
             Q.where('estado', Q.oneOf([1, 5])),
-            Q.where('fecha', Q.gte(todayMs.getTime())),
+            Q.where('fecha', Q.gte(todayMs)),
             Q.where('fecha', Q.lt(tomorrowMs)),
           ).fetch();
         if (rutas.length > 0) {

--- a/apps/mobile-app/src/db/actions.ts
+++ b/apps/mobile-app/src/db/actions.ts
@@ -499,14 +499,17 @@ export async function createGastoOffline(params: {
     let rutaServerId: number | null = null;
     if (rutaLocalId === null) {
       try {
-        const todayMs = new Date(); todayMs.setHours(0, 0, 0, 0);
-        const tomorrowMs = todayMs.getTime() + 24 * 3600 * 1000;
+        // FIX bug 29/5: ver nuevo.tsx — backend guarda fecha como UTC midnight del
+        // calendar date. Usar Date.UTC del calendar date local para que match exacto.
+        const now = new Date();
+        const todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+        const tomorrowMs = todayMs + 24 * 3600 * 1000;
         const rutas = await database.get<Ruta>('rutas')
           .query(
             Q.where('usuario_id', params.usuarioId),
             Q.where('activo', true),
             Q.where('estado', Q.oneOf([1, 5])),
-            Q.where('fecha', Q.gte(todayMs.getTime())),
+            Q.where('fecha', Q.gte(todayMs)),
             Q.where('fecha', Q.lt(tomorrowMs)),
           )
           .fetch();


### PR DESCRIPTION
….4 / vc5)

Bug reportado prod 29/5: vendedor con ruta activa abre form "Nuevo gasto" y ve empty state "No tienes ruta activa".

Causa: backend guarda ruta.fecha como UTC midnight del calendar date (ej. "2026-05-29 00:00:00Z"). El form usaba `setHours(0,0,0,0)` que produce midnight en LOCAL TZ del device (en CDMX = 06:00 UTC). La comparacion `fecha >= todayMs` falla porque ruta.fecha (00:00 UTC) queda ANTES del rango (06:00 UTC).

Fix: usar Date.UTC(year, month, day) del calendar date local — produce el mismo UTC ms que el backend guarda, sin importar la TZ del device.

Aplicado en:
- apps/mobile-app/app/(tabs)/ruta/gastos/nuevo.tsx (useEffect detect)
- apps/mobile-app/src/db/actions.ts createGastoOffline (auto-attach)

Bump app.json 1.0.3 -> 1.0.4 / versionCode 4 -> 5.