### PR TITLE
fix(gastos): gastos desaparecian al pull sync (usuario_id=0 hardcoded)

### DIFF
--- a/apps/mobile-app/app.json
+++ b/apps/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Handy Suites",
     "slug": "handy-suites",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "handysuites",
@@ -30,7 +30,7 @@
         "backgroundColor": "#2563eb"
       },
       "package": "com.handysuites.app",
-      "versionCode": 7
+      "versionCode": 8
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/apps/mobile-app/src/sync/mappers.ts
+++ b/apps/mobile-app/src/sync/mappers.ts
@@ -539,7 +539,10 @@ function mapGastoToRaw(g: any, gastoMap: Map<number, string>, rutaMap: Map<numbe
     server_id: g.id,
     ruta_id: g.rutaId ? (rutaMap.get(g.rutaId) || String(g.rutaId)) : null,
     ruta_server_id: g.rutaId ?? null,
-    usuario_id: 0,
+    // Bug 30/5: antes hardcodeado a 0 -> gastos desaparecian de "Mis gastos" al pull
+    // porque useOfflineGastos filtra por usuario_id == userIdNum. Server ahora envia
+    // usuarioId en SyncGastoDto; fallback a 0 si por alguna razon no llega.
+    usuario_id: g.usuarioId ?? 0,
     fecha_gasto: toTimestamp(g.fechaGasto ?? g.actualizadoEn),
     monto: g.monto ?? 0,
     tipo_gasto: g.tipoGasto ?? 99,

--- a/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
+++ b/libs/HandySuites.Application/Sync/DTOs/SyncDtos.cs
@@ -531,6 +531,11 @@ public class SyncGastoDto
 {
     public int Id { get; set; }
     public string? LocalId { get; set; }
+    /// <summary>UsuarioId del vendedor que creo el gasto. Critico para que mobile
+    /// pueda mapear correctamente el gasto al usuario actual y mostrarlo en lista.
+    /// Bug 30/5: faltaba en pull -> mobile asignaba usuario_id=0 -> gastos
+    /// desaparecian de la lista al hacer pull sync.</summary>
+    public int UsuarioId { get; set; }
     public int? RutaId { get; set; }
     /// <summary>Mobile WDB id de la ruta cuando aún no tiene ServerId (offline create).</summary>
     public string? RutaLocalId { get; set; }

--- a/libs/HandySuites.Application/Sync/Services/SyncService.cs
+++ b/libs/HandySuites.Application/Sync/Services/SyncService.cs
@@ -722,6 +722,7 @@ public class SyncService
             {
                 Id = g.Id,
                 LocalId = g.MobileRecordId,
+                UsuarioId = g.UsuarioId, // Bug fix 30/5: faltaba -> mobile mapeaba usuario_id=0
                 RutaId = g.RutaId,
                 FechaGasto = g.FechaGasto,
                 Monto = g.Monto,


### PR DESCRIPTION
BUG reportado prod 30/5 por vendedor jeyma: tras hacer pull sync los gastos desaparecen de "Mis gastos" — no ve ninguno aunque en server hay 4 gastos (id=1..4) para su usuario_id=3.

Root cause:
1. SyncGastoDto en server NO incluia campo UsuarioId
2. SyncService pull serializer no lo enviaba al mobile
3. mapGastoToRaw en mobile hardcodeaba usuario_id: 0
4. useOfflineGastos(userIdNum=3) filtra por usuario_id == 3
5. -> 0 records match -> lista vacia

Mismo patron olvidado en rawToGastoDto (push side), donde usuario_id viene del WDB record (correcto). Pero en pull la cadena estaba rota.

Fix:
- SyncGastoDto.UsuarioId field agregado (server DTO)
- SyncService.cs pull serializer envia g.UsuarioId
- mapGastoToRaw usa g.usuarioId ?? 0 (fallback defensivo)

Bump app.json 1.0.6 -> 1.0.7 / versionCode 7 -> 8.

Tras este fix el APK 1.0.7 recupera los gastos en la lista local inmediatamente despues del primer pull post-deploy.