### PR TITLE
feat(auth): session hardening — try/catch SecureStore + JWT exp proactive refresh + atomic login + fix invalid key

### DIFF
--- a/apps/mobile-app/.maestro/auth/03-session-survives-screen-lock.yaml
+++ b/apps/mobile-app/.maestro/auth/03-session-survives-screen-lock.yaml
@@ -1,0 +1,52 @@
+appId: host.exp.exponent
+name: "Session survives screen lock + power button"
+---
+
+# Reliability Sprint Fase 1: validar que bloquear/desbloquear pantalla NO
+# kickea al vendedor a /login. Token persiste en SecureStore (hardware Keystore)
+# y restoreSession() rehidrata al cold start.
+#
+# PRE-REQUISITO: vendedor ya logged in (dashboard "Hoy" visible).
+# Si está logged out, hay que hacer login manual antes — el bug de Gboard
+# autocomplete en password rompe Maestro login automatico (ver
+# memory/emulator_metro_setup.md "Login automation Gboard autocomplete bypass").
+
+# Verificar estado inicial: vendedor en dashboard
+- extendedWaitUntil:
+    visible: "Hoy"
+    timeout: 30000
+
+- takeScreenshot: pre-lock
+
+# Bloquear pantalla con power button
+- pressKey: Power
+
+# Esperar 30 segundos con pantalla bloqueada
+- waitForAnimationToEnd:
+    timeout: 30000
+
+# Desbloquear con power button
+- pressKey: Power
+
+# Despues del unlock, swipe up para dismiss el lockscreen (Android default)
+- swipe:
+    start: 50%, 90%
+    end: 50%, 10%
+    duration: 500
+
+# Verificar que la app sigue en su pantalla, no en /login
+- assertVisible: "Hoy"
+- assertNotVisible:
+    id: "login-button"
+
+- takeScreenshot: post-unlock
+
+# Hacer un tap en cualquier elemento para forzar request al backend.
+# Si el token estaba muerto, este tap dispara 401 → flow refresh → eventualmente
+# logged in. Si todo OK, navega sin issues.
+- tapOn: "Hoy"
+- waitForAnimationToEnd
+- assertNotVisible:
+    id: "login-button"
+
+- takeScreenshot: post-unlock-tap-ok

--- a/apps/mobile-app/src/hooks/useSessionRefresh.ts
+++ b/apps/mobile-app/src/hooks/useSessionRefresh.ts
@@ -4,8 +4,13 @@ import { secureStorage } from '@/utils/storage';
 import { useAuthStore } from '@/stores';
 import { STORAGE_KEYS } from '@/utils/constants';
 import { coalesceRefresh } from '@/api/client';
+import { isJwtNearExpiry, secondsUntilJwtExpiry } from '@/utils/jwt';
 
-const LAST_ACTIVITY_KEY = '@auth/lastActivityAt';
+// SecureStore rechaza keys con caracteres fuera de [a-zA-Z0-9._-]. El @ y / del
+// nombre anterior @auth/lastActivityAt causaban Invalid key exception en cada
+// write — silently swallowed antes del try/catch del Fase 1 que lo detecto.
+const LAST_ACTIVITY_KEY = 'auth_lastActivityAt';
+const PROACTIVE_REFRESH_WINDOW_SECONDS = 600; // 10 min
 
 /**
  * Silent refresh on AppState='active'. Cuando la app vuelve a foreground tras
@@ -30,10 +35,18 @@ export function useSessionRefresh() {
 
     const REFRESH_THROTTLE_MS = 5 * 60 * 1000; // 5 min — no spam refresh
 
-    const trySilentRefresh = async () => {
+    const trySilentRefresh = async (opts: { force?: boolean } = {}) => {
       // Throttle: no más de 1 refresh per 5 min para evitar spam.
+      // EXCEPCIÓN: si el access token está por expirar (< 10 min), refrescar
+      // aunque pase el throttle. La latencia post-expiry de 401 round-trip
+      // es peor UX que un POST /refresh extra.
       const now = Date.now();
-      if (now - lastRefreshAt.current < REFRESH_THROTTLE_MS) return;
+      const accessToken = await secureStorage.get(STORAGE_KEYS.ACCESS_TOKEN);
+      const tokenNearExpiry = accessToken
+        ? isJwtNearExpiry(accessToken, PROACTIVE_REFRESH_WINDOW_SECONDS)
+        : false;
+
+      if (!opts.force && !tokenNearExpiry && now - lastRefreshAt.current < REFRESH_THROTTLE_MS) return;
 
       const refreshToken = await secureStorage.get(STORAGE_KEYS.REFRESH_TOKEN);
       if (!refreshToken) return;
@@ -43,6 +56,10 @@ export function useSessionRefresh() {
         if (newToken) {
           lastRefreshAt.current = now;
           await secureStorage.set(LAST_ACTIVITY_KEY, String(now));
+          if (__DEV__ && tokenNearExpiry) {
+            const newRemaining = secondsUntilJwtExpiry(newToken);
+            console.log(`[Session] proactive refresh OK — new token expires in ${newRemaining}s`);
+          }
         }
       } catch {
         // Soft fail: logout NO se dispara aquí. El próximo request real

--- a/apps/mobile-app/src/stores/authStore.ts
+++ b/apps/mobile-app/src/stores/authStore.ts
@@ -42,7 +42,10 @@ export const useAuthStore = create<AuthState>((set) => ({
   sessionExpired: false,
 
   login: async (user, token, refreshToken) => {
-    setAccessToken(token);
+    // Reliability Fase 1: persistir a SecureStore PRIMERO. Si OEM Android mata
+    // el proceso entre setAccessToken (in-memory) y el await Promise.all (disk),
+    // el token queda en memoria pero perdido al next boot → restoreSession ve
+    // null → /login. Invertir orden: disk first, memory second.
     await Promise.all([
       secureStorage.set(STORAGE_KEYS.ACCESS_TOKEN, token),
       secureStorage.set(STORAGE_KEYS.REFRESH_TOKEN, refreshToken),
@@ -57,6 +60,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         mustChangePassword: user.mustChangePassword ?? false,
       })),
     ]);
+    setAccessToken(token);
     // Clear sessionExpired flag al hacer login fresh.
     set({ user, isAuthenticated: true, isLoading: false, isLoggingIn: false, sessionExpired: false });
   },

--- a/apps/mobile-app/src/utils/jwt.ts
+++ b/apps/mobile-app/src/utils/jwt.ts
@@ -1,0 +1,57 @@
+/**
+ * JWT payload decoder. Implementación mínima — no valida firma (eso es trabajo
+ * del backend), solo lee el `exp` claim para refresh proactivo.
+ *
+ * Reliability Sprint Fase 1: refresh BEFORE 401 si el token está por expirar.
+ * Sin esto, cada request tras expiración hace round-trip 401 → refresh → retry
+ * (latencia ~500ms-2s en redes lentas). Con esto, refresh silencioso 10min antes
+ * de expirar y el siguiente request va directo.
+ */
+
+interface JwtPayload {
+  exp?: number; // seconds since epoch
+  nbf?: number;
+  iat?: number;
+  sub?: string;
+  [key: string]: unknown;
+}
+
+/** Base64-URL safe decode (handles `-_` instead of `+/` + missing padding). */
+function base64UrlDecode(s: string): string {
+  let str = s.replace(/-/g, '+').replace(/_/g, '/');
+  while (str.length % 4) str += '=';
+  // atob no está nativo en React Native — usar Buffer si disponible, sino fallback.
+  if (typeof globalThis.atob === 'function') {
+    return globalThis.atob(str);
+  }
+  // RN provee Buffer global en runtime (via expo-modules-core polyfill)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const B = (globalThis as any).Buffer;
+  if (B?.from) return B.from(str, 'base64').toString('binary');
+  throw new Error('No base64 decoder available');
+}
+
+export function decodeJwt(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = base64UrlDecode(parts[1]);
+    return JSON.parse(payload) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns seconds until token expires. Negative = already expired. Null = no exp claim. */
+export function secondsUntilJwtExpiry(token: string): number | null {
+  const payload = decodeJwt(token);
+  if (!payload?.exp) return null;
+  return payload.exp - Math.floor(Date.now() / 1000);
+}
+
+/** True si el token expira en menos de `withinSeconds`. False si todavía falta tiempo o si no se puede decodificar. */
+export function isJwtNearExpiry(token: string, withinSeconds: number = 600): boolean {
+  const remaining = secondsUntilJwtExpiry(token);
+  if (remaining === null) return false; // Sin exp claim no podemos saber — confiar en flow reactivo on 401.
+  return remaining < withinSeconds;
+}

--- a/apps/mobile-app/src/utils/storage.ts
+++ b/apps/mobile-app/src/utils/storage.ts
@@ -1,19 +1,50 @@
 import * as SecureStore from 'expo-secure-store';
 
+/**
+ * Wrapper sobre expo-secure-store con try/catch defensivo.
+ *
+ * Razón (Reliability Sprint Fase 1): SecureStore puede rechazar reads en
+ * escenarios borde — OEM Android low-memory durante app suspend, device sin
+ * lock screen configurado (Android requiere keyguard para Keystore en algunos
+ * OEMs), o race con app kill mid-write. Sin try/catch el reject bubbleaba al
+ * interceptor del API client y el siguiente request salía sin Authorization
+ * header → 401 falso → banner "sesión expirada" pese a que el token estaba
+ * intacto en disk.
+ *
+ * Política: ante error, retornar `null` (read) o swallow + warn (write).
+ * El cold boot siguiente intenta de nuevo via restoreSession.
+ */
 export const secureStorage = {
   async get(key: string): Promise<string | null> {
-    return SecureStore.getItemAsync(key);
+    try {
+      return await SecureStore.getItemAsync(key);
+    } catch (err) {
+      if (__DEV__) console.warn(`[secureStorage] read failed for ${key}:`, err);
+      return null;
+    }
   },
 
   async set(key: string, value: string): Promise<void> {
-    await SecureStore.setItemAsync(key, value);
+    try {
+      await SecureStore.setItemAsync(key, value);
+    } catch (err) {
+      if (__DEV__) console.warn(`[secureStorage] write failed for ${key}:`, err);
+      // Re-throw — callers que necesitan saber que el write falló (login)
+      // deben poder reaccionar. Solo el READ es silent-null.
+      throw err;
+    }
   },
 
   async remove(key: string): Promise<void> {
-    await SecureStore.deleteItemAsync(key);
+    try {
+      await SecureStore.deleteItemAsync(key);
+    } catch (err) {
+      if (__DEV__) console.warn(`[secureStorage] delete failed for ${key}:`, err);
+      // Swallow: si el delete falla, el next write o el explicit clear lo cubre.
+    }
   },
 
   async clear(keys: string[]): Promise<void> {
-    await Promise.all(keys.map((k) => SecureStore.deleteItemAsync(k)));
+    await Promise.all(keys.map((k) => this.remove(k)));
   },
 };


### PR DESCRIPTION
## Promoción a prod
Merge de PR #140 ya validado en staging (commit `f054927a`).

## Reliability Sprint Fase 1 — Session Hardening

Defense-in-depth para prevenir kickeo a `/login` en escenarios borde + 1 bug latente que el wrapper diagnostic expuso.

### Cambios

**1. `secureStorage` wrapper defensivo** (`src/utils/storage.ts`)
- `get()`: try/catch + return null silencioso ante reject (OEM Android low-mem suspend, device sin lock screen, race con app kill).
- `set()`: try/catch + re-throw (callers como login necesitan saber).
- `remove()`/`clear()`: try/catch + warn (cubrirá próximo write).

**2. Login atomic order** (`src/stores/authStore.ts`)
- Antes: `setAccessToken(token)` (in-memory) → `await Promise.all(secureStorage.set(...))` (disk).
- Ahora: disk PRIMERO → memory después. Protege contra kill del proceso entre líneas.

**3. JWT decoder mínimo** (`src/utils/jwt.ts` — NUEVO, sin deps externas)
- `decodeJwt`, `secondsUntilJwtExpiry`, `isJwtNearExpiry(withinSeconds)`.
- Solo lee `exp` claim — NO valida firma (trabajo del backend).

**4. Proactive refresh** (`src/hooks/useSessionRefresh.ts`)
- Si access token expira en < 10 min, bypass throttle 5min y refresh silencioso.
- Evita latencia 401→refresh→retry round-trip en red lenta.

**5. 🐛 Bug latente fix** (`src/hooks/useSessionRefresh.ts`)
- `LAST_ACTIVITY_KEY` era `'@auth/lastActivityAt'` con `@` y `/` que SecureStore rechaza.
- Error era silently swallowed pre-Fase 1; el try/catch del nuevo wrapper lo expuso como WARN en validación.
- Renombrado a `'auth_lastActivityAt'` (alphanumeric + `_`).

**6. Maestro E2E** (`.maestro/auth/03-session-survives-screen-lock.yaml` — NUEVO)
- Power lock → wait 30s → unlock → swipe → verify dashboard sigue visible → tap funciona.

## Pre-Push Deployment Checklist

| | Item | Estado |
|---|---|---|
| 1 | Env vars nuevos | ✅ Ninguno |
| 2 | DB migration | ✅ Ninguna |
| 3 | CI/CD pipeline | ✅ Sin cambios |
| 4 | Breaking API contract | ✅ Pure mobile-only — backend SIN cambios |
| 5 | APK rebuild | ⚠️ **Sí cuando el usuario lo pida** — los cambios mobile solo aplican via dev build / EAS production-apk |
| 6 | Backend redeploy | ✅ No |

## Validación staging

- [x] PR #140 mergeado a staging
- [x] TypeScript apps/mobile-app type-check: 0 errors
- [x] JWT decoder unit tests (test-jwt.mjs Node): 4/4 passed
- [x] JWT decoder running live en app: log confirmó `sec=2705` decoded del token real
- [x] try/catch en `secureStorage` capturó bug latente `Invalid key` → fixed inline
- [x] Maestro `03-session-survives-screen-lock.yaml` Desktop Chrome emulator: **13/13 steps PASS**
  - Power lock → wait 30s → unlock → swipe up → dashboard "Hoy" sigue visible → tap funciona (no kicked out)
- [x] Bundle Metro 4736 modules carga limpia post-fix (sin Invalid key warnings)

## Deploy

- 100% mobile-only — backend SIN cambios, sin migration, sin env vars
- Cambios JS empaquetados en próximo APK release (cuando el usuario lo solicite)
- No afecta usuarios actuales con APK 1.0.7 — los devolución + session improvements se entregarán juntos en el próximo build

## Sin impacto en otros sistemas

- APK actual 1.0.7 sigue válido
- Backend `MobileAuthService.cs` + JWT TTL config SIN cambios
- Web admin sin cambios
