### PR TITLE
feat(sync): robustness — retry exponencial + pending banner + toast transiciones (Reliability Fase 2)

### DIFF
--- a/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
+++ b/apps/mobile-app/src/components/dashboard/VendedorDashboard.tsx
@@ -23,6 +23,7 @@ import { api } from '@/api/client';
 import { Target } from 'lucide-react-native';
 import { JornadaCard } from './JornadaCard';
 import { useCreateOrderFlow } from '@/hooks/useCreateOrderFlow';
+import { PendingDataBanner } from '@/components/shared/PendingDataBanner';
 
 export function VendedorDashboard() {
   const insets = useSafeAreaInsets();
@@ -203,6 +204,9 @@ export function VendedorDashboard() {
           />
         </View>
       </View>
+
+      {/* Reliability Fase 2: banner alert si datos sin subir >24h */}
+      <PendingDataBanner />
 
       {/* KPI Cards — white bg, no pastel, no icon circles */}
       <Animated.View entering={FadeInDown.delay(100).duration(400)}>

--- a/apps/mobile-app/src/components/shared/PendingDataBanner.tsx
+++ b/apps/mobile-app/src/components/shared/PendingDataBanner.tsx
@@ -1,0 +1,78 @@
+import { useRouter } from 'expo-router';
+import { TouchableOpacity, Text, StyleSheet, View } from 'react-native';
+import { AlertTriangle } from 'lucide-react-native';
+import { usePendingCount } from '@/hooks/usePendingCount';
+import { useOldestPendingAge } from '@/hooks/useOldestPendingAge';
+
+/**
+ * Banner visible cuando hay datos sin subir desde hace > 24h.
+ * Tap navega al sync tab para ver detalle + forzar push.
+ *
+ * Reliability Sprint Fase 2 — visibilidad para el vendedor. Antes el badge
+ * en Sync tab solo contaba items pero no indicaba antigüedad. Datos atascados
+ * por dias quedaban invisibles hasta el proximo open del sync tab.
+ *
+ * Colores:
+ * - amarillo: > 24h sin subir (recordatorio amable)
+ * - rojo: > 72h sin subir (algo está mal, intervención recomendada)
+ *
+ * No renderiza si no hay datos pendientes o si <24h.
+ */
+export function PendingDataBanner() {
+  const router = useRouter();
+  const { data: pendingCount } = usePendingCount();
+  const oldestAgeHours = useOldestPendingAge();
+  const count = pendingCount ?? 0;
+
+  if (count === 0 || oldestAgeHours === null || oldestAgeHours < 24) {
+    return null;
+  }
+
+  const isCritical = oldestAgeHours > 72;
+  const days = Math.floor(oldestAgeHours / 24);
+  const containerStyle = isCritical ? styles.critical : styles.warning;
+  const textStyle = isCritical ? styles.criticalText : styles.warningText;
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push('/(tabs)/sync' as any)}
+      style={[styles.container, containerStyle]}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${count} datos pendientes de sincronizar hace ${days} dias`}
+    >
+      <AlertTriangle size={18} color={isCritical ? '#dc2626' : '#b45309'} />
+      <View style={styles.textWrap}>
+        <Text style={[styles.title, textStyle]}>
+          {count} {count === 1 ? 'dato sin subir' : 'datos sin subir'}
+        </Text>
+        <Text style={[styles.subtitle, textStyle]}>
+          {isCritical
+            ? `Hace ${days} dias. Verifica tu conexion o contacta a soporte.`
+            : `Hace ${days} dia${days === 1 ? '' : 's'}. Verifica tu conexion.`}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  warning: { backgroundColor: '#fffbeb', borderColor: '#fcd34d' },
+  critical: { backgroundColor: '#fef2f2', borderColor: '#fca5a5' },
+  textWrap: { flex: 1, gap: 2 },
+  title: { fontSize: 13, fontWeight: '700' },
+  subtitle: { fontSize: 12 },
+  warningText: { color: '#92400e' },
+  criticalText: { color: '#991b1b' },
+});

--- a/apps/mobile-app/src/hooks/useAutoSync.ts
+++ b/apps/mobile-app/src/hooks/useAutoSync.ts
@@ -61,6 +61,8 @@ export function useAutoSync() {
     return () => subscription.remove();
   }, []);
 
-  // Initial sync on mount
-  useEffect(() => { sync(); }, []);
+  // Initial sync on mount — Reliability Fase 2: gated por NetInfo. Antes
+  // disparaba sync() siempre que el (tabs) layout montara, incluyendo offline,
+  // generando un error state silencioso. Ahora respeta conexion.
+  useEffect(() => { syncIfOnline(); }, []);
 }

--- a/apps/mobile-app/src/hooks/useOldestPendingAge.ts
+++ b/apps/mobile-app/src/hooks/useOldestPendingAge.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { Q } from '@nozbe/watermelondb';
+import { database } from '@/db/database';
+
+/**
+ * Edad del registro pendiente mas viejo en horas.
+ * null si no hay pendientes.
+ *
+ * Reliability Sprint Fase 2: visibilidad para el vendedor cuando datos llevan
+ * mucho tiempo sin subir al backend. Banner amarillo > 24h, rojo > 72h.
+ *
+ * Implementacion: query MIN(created_at) across las tablas syncables.
+ * Polling cada 5min porque created_at no cambia con _status (no es buen
+ * candidato para subscribe-on-changes); el banner no necesita reactividad
+ * sub-segundo.
+ */
+
+const SYNCABLE_TABLES = [
+  'clientes', 'pedidos', 'detalle_pedidos', 'visitas', 'cobros',
+  'ruta_detalles', 'gastos', 'devoluciones_pedido', 'detalle_devoluciones',
+] as const;
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+export function useOldestPendingAge(): number | null {
+  const [oldestAgeHours, setOldestAgeHours] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const computeOldest = async () => {
+      try {
+        const now = Date.now();
+        let oldestMs: number | null = null;
+
+        for (const tableName of SYNCABLE_TABLES) {
+          const records = await database.collections
+            .get(tableName)
+            .query(
+              Q.or(Q.where('_status', 'created'), Q.where('_status', 'updated')),
+              Q.sortBy('created_at', Q.asc),
+              Q.take(1),
+            )
+            .fetch();
+          if (records.length > 0) {
+            const ts = (records[0] as { createdAt?: Date | number }).createdAt;
+            const tsMs = ts instanceof Date ? ts.getTime() : Number(ts ?? 0);
+            if (tsMs > 0 && (oldestMs === null || tsMs < oldestMs)) {
+              oldestMs = tsMs;
+            }
+          }
+        }
+
+        if (cancelled) return;
+        if (oldestMs === null) {
+          setOldestAgeHours(null);
+        } else {
+          const ageHours = (now - oldestMs) / (1000 * 60 * 60);
+          setOldestAgeHours(ageHours);
+        }
+      } catch (err) {
+        if (__DEV__) console.warn('[useOldestPendingAge] failed:', err);
+      }
+    };
+
+    computeOldest();
+    const interval = setInterval(computeOldest, POLL_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
+
+  return oldestAgeHours;
+}

--- a/apps/mobile-app/src/hooks/usePendingCount.ts
+++ b/apps/mobile-app/src/hooks/usePendingCount.ts
@@ -4,7 +4,27 @@ import { combineLatest, map } from 'rxjs';
 import { database } from '@/db/database';
 import { useObservable } from './useObservable';
 
-const SYNCABLE_TABLES = ['clientes', 'pedidos', 'detalle_pedidos', 'visitas', 'cobros'] as const;
+/**
+ * Lista de tablas WDB que se empujan al backend via sync push.
+ * Reliability Sprint Fase 2: ampliada de 5 a 10 tablas. Antes solo cobertura
+ * basica (clientes/pedidos/detalles/visitas/cobros); ahora incluye gastos,
+ * devoluciones y ruta_detalles que tambien participan del push y el vendedor
+ * no estaba viendo si quedaban pendientes.
+ *
+ * attachments NO esta aqui — usa su propio campo uploadStatus en lugar de
+ * _status. Si se necesita, agregar via useAttachmentsPendingCount aparte.
+ */
+const SYNCABLE_TABLES = [
+  'clientes',
+  'pedidos',
+  'detalle_pedidos',
+  'visitas',
+  'cobros',
+  'ruta_detalles',
+  'gastos',
+  'devoluciones_pedido',
+  'detalle_devoluciones',
+] as const;
 
 export function usePendingCount() {
   const observable = useMemo(() => {

--- a/apps/mobile-app/src/stores/syncStore.ts
+++ b/apps/mobile-app/src/stores/syncStore.ts
@@ -1,10 +1,15 @@
 import { create } from 'zustand';
+import Toast from 'react-native-toast-message';
 import { performSync } from '@/sync/syncEngine';
 import { syncCursors } from '@/sync/cursors';
 import type { SyncSummary } from '@/sync/syncEngine';
 
 type SyncStatus = 'idle' | 'syncing' | 'success' | 'error';
 let _statusTimeout: ReturnType<typeof setTimeout> | null = null;
+// Reliability Fase 2: rastrear ultima transicion para Toast pasivo.
+// Solo mostrar Toast cuando hay un cambio real (failure -> success o tras
+// retries exhaustos). Sin esto, cada sync exitoso lanzaria Toast spammy.
+let _lastShownStatus: SyncStatus | null = null;
 
 interface SyncState {
   status: SyncStatus;
@@ -33,6 +38,18 @@ export const useSyncStore = create<SyncState>((set, get) => ({
         onFinish: (summary) => {
           const now = Date.now();
           set({ status: 'success', lastSyncAt: now, lastSummary: summary, error: null });
+          // Reliability Fase 2: Toast pasivo solo en transicion error → success.
+          // No spam en cada sync.
+          if (_lastShownStatus === 'error' && summary.pushed + summary.pulled > 0) {
+            Toast.show({
+              type: 'success',
+              text1: 'Datos sincronizados',
+              text2: 'Los pendientes ya estan en el servidor.',
+              visibilityTime: 2500,
+              position: 'bottom',
+            });
+          }
+          _lastShownStatus = 'success';
           if (_statusTimeout) clearTimeout(_statusTimeout);
           _statusTimeout = setTimeout(() => {
             _statusTimeout = null;
@@ -41,6 +58,20 @@ export const useSyncStore = create<SyncState>((set, get) => ({
         },
         onError: (err) => {
           set({ status: 'error', error: err.message });
+          // Reliability Fase 2: Toast solo en transicion (no spam si ya estaba en error).
+          if (_lastShownStatus !== 'error') {
+            const isNetworkError = /network|timeout|fetch|abort|ECONN/i.test(err.message);
+            Toast.show({
+              type: isNetworkError ? 'info' : 'error',
+              text1: isNetworkError ? 'Sin conexion' : 'Sincronizacion fallida',
+              text2: isNetworkError
+                ? 'Tus datos se mantienen localmente. Sincronizaremos al recuperar la red.'
+                : 'Reintentaremos en breve. Tus datos siguen seguros localmente.',
+              visibilityTime: 3500,
+              position: 'bottom',
+            });
+          }
+          _lastShownStatus = 'error';
         },
       });
     } catch (err) {

--- a/apps/mobile-app/src/sync/retry.ts
+++ b/apps/mobile-app/src/sync/retry.ts
@@ -1,0 +1,77 @@
+/**
+ * Retry helper con exponential backoff para fases del syncEngine.
+ *
+ * Reliability Sprint Fase 2 — antes el syncEngine no reintentaba ante 5xx ni
+ * network timeouts. Throw bubbleaba a setState('error') y el vendedor tenia
+ * que reiniciar la app o esperar al proximo trigger (debounce 2s + foreground
+ * change). Con esto, una falla transitoria se recupera transparente sin
+ * intervencion del usuario.
+ */
+
+import type { AxiosError } from 'axios';
+
+export interface RetryConfig {
+  /** Numero total de intentos incluyendo el primero. Default 3. */
+  maxAttempts?: number;
+  /** Backoff base en ms (2x cada intento). Default 2000ms. */
+  baseDelayMs?: number;
+  /** Cap del delay total. Default 30000ms. */
+  maxDelayMs?: number;
+}
+
+/**
+ * Determina si un error vale la pena reintentar.
+ * - true: network errors (sin response), 5xx server, 408 timeout, 429 throttle.
+ * - false: 4xx client errors (validation, auth, not found) — re-intentar no
+ *   los va a arreglar; el row queda como pending hasta intervencion manual.
+ */
+export function isRetryableError(err: unknown): boolean {
+  if (!err) return false;
+  // Axios network error (sin response del server)
+  const axErr = err as AxiosError & { isNetworkError?: boolean };
+  if (axErr.isNetworkError === true || !axErr.response) {
+    // Sin response = timeout, DNS, conexion abortada, etc.
+    return true;
+  }
+  const status = axErr.response.status;
+  if (status >= 500) return true;     // 5xx server fault
+  if (status === 408) return true;    // request timeout
+  if (status === 429) return true;    // rate limit (idealmente respetar Retry-After)
+  return false;                        // 4xx client error: no vale la pena
+}
+
+export async function withRetry<T>(
+  name: string,
+  fn: () => Promise<T>,
+  config: RetryConfig = {}
+): Promise<T> {
+  const maxAttempts = config.maxAttempts ?? 3;
+  const baseDelayMs = config.baseDelayMs ?? 2000;
+  const maxDelayMs = config.maxDelayMs ?? 30000;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const retryable = isRetryableError(err);
+      if (!retryable || attempt === maxAttempts) {
+        if (__DEV__ && attempt > 1) {
+          console.warn(`[Sync.${name}] giving up after ${attempt} attempts:`, err);
+        }
+        throw err;
+      }
+      // Exponential backoff con jitter pequeño para evitar thundering herd
+      const exp = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
+      const jitter = Math.floor(exp * 0.1 * Math.random()); // 0-10% jitter
+      const delay = exp + jitter;
+      if (__DEV__) {
+        console.warn(`[Sync.${name}] attempt ${attempt}/${maxAttempts} failed (retryable), waiting ${delay}ms`);
+      }
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  // Unreachable but TS needs it
+  throw lastError;
+}

--- a/apps/mobile-app/src/sync/syncEngine.ts
+++ b/apps/mobile-app/src/sync/syncEngine.ts
@@ -6,6 +6,7 @@ import { mapPullToWatermelon, mapPushFromWatermelon } from './mappers';
 import { uploadPendingAttachments, cleanUploadedFiles, recoverOrphanAttachmentStamps } from '@/services/evidenceManager';
 import { crashReporter } from '@/services/crashReporter';
 import { useAuthStore } from '@/stores/authStore';
+import { withRetry } from './retry';
 
 /**
  * Strips records whose tenantId doesn't match the authenticated user's tenant.
@@ -77,10 +78,12 @@ async function doPerformSync(options?: SyncOptions): Promise<void> {
           : null;
 
         if (__DEV__) console.log('[Sync] Pull lastSync:', lastSync);
-        const response = await api.post('/api/mobile/sync/pull', {
+        // Reliability Fase 2: retry exponencial ante 5xx/network. Sin esto un
+        // 503 transitorio dejaba la sync en estado error hasta el proximo trigger.
+        const response = await withRetry('pull', () => api.post('/api/mobile/sync/pull', {
           lastSyncTimestamp: lastSync,
           entityTypes: null,
-        });
+        }));
 
         // Defensive parse: pull endpoint puede devolver `{data: {...}}` o
         // directamente `{...}` legado. Si body es null/undefined (network falla
@@ -150,7 +153,9 @@ async function doPerformSync(options?: SyncOptions): Promise<void> {
         const hasChanges = pushCount > 0;
         if (!hasChanges) return;
 
-        const response = await api.post('/api/mobile/sync/push', payload);
+        // Reliability Fase 2: retry exponencial. Backend 503/timeout transitorio
+        // no debe dejar datos locales en limbo — el siguiente intent recupera.
+        const response = await withRetry('push', () => api.post('/api/mobile/sync/push', payload));
         const body = response.data as any;
 
         // Count conflicts from server response
@@ -237,6 +242,13 @@ async function doPerformSync(options?: SyncOptions): Promise<void> {
     if (__DEV__) {
       if (isNetworkError) console.warn('[Sync] Network unavailable:', err.message);
       else console.warn('[Sync] Failed:', err.message);
+    }
+    // Reliability Fase 2: telemetry — solo reportar errores NO-red (los de red
+    // son normales offline-first y harian ruido). El crashReporter ya tiene
+    // PII redaction + offline queue, asi que esto integra al pipeline de Sentry
+    // si esta configurado, o queda en queue local para next flush.
+    if (!isNetworkError) {
+      crashReporter.reportCrash(err, 'SyncEngine', 'WARNING').catch(() => { /* never block sync */ });
     }
     options?.onError?.(err);
     throw err;


### PR DESCRIPTION
## Promoción a prod
Merge de PR #142 ya validado en staging (commit `32093c9e`).

## Reliability Sprint Fase 2 — Sync Robustness

Sigue al Fase 1 (Session Hardening). Ataca los gaps de visibilidad y recuperación del sync engine identificados en el discovery:

### 7 mejoras

1. **Retry exponencial** (`src/sync/retry.ts` NUEVO + wrapping pull/push)
   - `withRetry(name, fn, config)` — maxAttempts=3, baseDelay=2s, cap=30s + jitter 0-10%
   - `isRetryableError`: true para network/5xx/408/429 — false para 4xx/401
   - 503/timeouts transitorios se recuperan sin esperar al próximo trigger

2. **Telemetry** (`syncEngine.ts` catch block)
   - Errores NO-red → `crashReporter.reportCrash(err, 'SyncEngine', 'WARNING')`
   - Integra con queue offline existente + Sentry si configurado

3. **`usePendingCount` expandido** (5 → 9 tablas)
   - Antes: solo clientes/pedidos/detalles/visitas/cobros
   - Ahora incluye: ruta_detalles, gastos, devoluciones_pedido, detalle_devoluciones
   - Vendedor ya ve devoluciones offline pendientes en el badge

4. **`useOldestPendingAge`** (NUEVO)
   - Poll 5min de `MIN(created_at)` con `_status IN ('created','updated')`
   - Returns null si no hay pendientes; horas si hay

5. **`PendingDataBanner`** (NUEVO)
   - Amarillo > 24h, rojo > 72h
   - Tap navega a `/(tabs)/sync`
   - Integrado en VendedorDashboard arriba del KPI row

6. **Toast pasivo** (`syncStore.ts`)
   - `error → success`: "Datos sincronizados"
   - `idle → error`: "Sin conexión" (info) o "Sincronización fallida" (error)
   - Tracking modulo-scope para evitar spam

7. **NetInfo gate en initial mount sync** (`useAutoSync.ts:65`)
   - Antes: `sync()` siempre que (tabs) layout montara, incluso offline → error silencioso
   - Ahora: `syncIfOnline()` respeta NetInfo

## Pre-Push Deployment Checklist

| | Item | Estado |
|---|---|---|
| 1 | Env vars nuevos | ✅ Ninguno |
| 2 | DB migration | ✅ Ninguna |
| 3 | CI/CD pipeline | ✅ Sin cambios |
| 4 | Breaking API contract | ✅ Pure mobile-only — backend SIN cambios |
| 5 | APK rebuild | ⚠️ **Sí cuando el usuario lo pida** — empaquetar junto con Fase 1 + devolución en próximo build |
| 6 | Backend redeploy | ✅ No |

## Validación staging

- [x] PR #142 mergeado a staging
- [x] TypeScript apps/mobile-app type-check: 0 errors
- [x] Unit tests retry (`test-retry.mjs` Node): **17/17 PASS**
  - `isRetryableError` correcto para network, 5xx, 408, 429, 401, 404, 400, 422, null (11 casos)
  - `withRetry` success first try
  - 503 then success: 2 attempts, backoff respected
  - persistent 503: 3 attempts then throw
  - 4xx: 1 attempt, immediate throw (no retry)
- [x] App carga limpia en emulator + sync corre (`[Sync] Mapped changes for 25 tables`)
- [x] `PendingDataBanner` returns null safe sin data vieja
- [x] Sin redbox ni regresiones detectadas

## Deploy

- 100% mobile-only — backend SIN cambios, sin migration, sin env vars
- Cambios JS empaquetados en próximo APK release (cuando el usuario lo solicite)
- No afecta usuarios actuales con APK 1.0.7
