### PR TITLE
fix(mobile/ui): OfflineBanner respeta safe-area inset del tab bar

### DIFF
--- a/apps/mobile-app/src/components/ui/OfflineBanner.tsx
+++ b/apps/mobile-app/src/components/ui/OfflineBanner.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Text, StyleSheet, Animated } from 'react-native';
 import { WifiOff, Wifi } from 'lucide-react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNetworkStatus } from '../../hooks/useNetworkStatus';
 
 const BANNER_HEIGHT = 30;
+// El tab bar de (tabs)/_layout.tsx mide TAB_BAR_HEIGHT + insets.bottom.
+// En RN `position: absolute + bottom: X` mide desde el borde de la pantalla,
+// no desde el tab bar, asi que hay que sumar insets.bottom para sentarnos
+// justo arriba del tab bar (sino quedariamos detras del home indicator iOS
+// o de la gesture nav Android). Mismo fix aplicado en SessionExpiredBanner.
 const TAB_BAR_HEIGHT = 60;
 
 export function OfflineBanner() {
+  const insets = useSafeAreaInsets();
   const { isConnected } = useNetworkStatus();
   const [showReconnected, setShowReconnected] = useState(false);
   const [wasOffline, setWasOffline] = useState(false);
@@ -53,6 +60,7 @@ export function OfflineBanner() {
     <Animated.View
       style={[
         styles.banner,
+        { bottom: TAB_BAR_HEIGHT + insets.bottom },
         isOffline ? styles.offlineBanner : styles.reconnectedBanner,
         { transform: [{ translateY: slideAnim }] },
       ]}
@@ -74,7 +82,7 @@ export function OfflineBanner() {
 const styles = StyleSheet.create({
   banner: {
     position: 'absolute',
-    bottom: TAB_BAR_HEIGHT,
+    // bottom se sobrescribe inline con TAB_BAR_HEIGHT + insets.bottom
     left: 0,
     right: 0,
     zIndex: 999,


### PR DESCRIPTION
Follow-up del PR fix/session-banner-bounce-loop, donde se descubrio que el OfflineBanner tenia el mismo bug que el SessionExpiredBanner: usaba `bottom: TAB_BAR_HEIGHT` plano (60) sin sumar `insets.bottom`.

En React Native `position: absolute + bottom: X` mide desde el borde de la pantalla, no desde el tab bar. El tab bar real mide 60 + insets.bottom (ver app/(tabs)/_layout.tsx tabBarStyle.height), asi que con bottom=60 el banner queda PARCIALMENTE DETRAS del home indicator iOS o de la gesture nav Android (los 34dp de safe-area inferior que el tab bar ya absorbe).

FIX
---
- import useSafeAreaInsets from 'react-native-safe-area-context'
- const insets = useSafeAreaInsets()
- inline style `bottom: TAB_BAR_HEIGHT + insets.bottom` para sentar el banner JUSTO arriba del borde superior del tab bar.

ARCHIVO TOCADO
--------------
- apps/mobile-app/src/components/ui/OfflineBanner.tsx

VALIDACION
----------
- npx tsc --noEmit: 0 errores
- Consistente con SessionExpiredBanner.tsx que ya usa el mismo patron desde el PR fix/session-banner-bounce-loop.
- Cuando ambos banners coexisten (offline + session-expired), el SessionExpiredBanner se desplaza 30dp arriba (OFFLINE_BANNER_HEIGHT) para no ocluir al OfflineBanner — comportamiento sin cambios, ahora ambos respetan la misma coord-space.