### PR TITLE
fix(sync): normalizar DateTime a UTC en UpsertGasto/Devolucion/Pedido…

### DIFF
--- a/apps/api/tests/HandySuites.Tests/Application/Common/DateTimeNormalizationTests.cs
+++ b/apps/api/tests/HandySuites.Tests/Application/Common/DateTimeNormalizationTests.cs
@@ -1,0 +1,82 @@
+using HandySuites.Application.Common.Time;
+using Xunit;
+
+namespace HandySuites.Tests.Application.Common;
+
+/// <summary>
+/// Bug prod 2026-06-02: fecha_gasto de mobile aparecia 7h adelantada en BD.
+/// Causa: mobile envia .toISOString() UTC pero ASP.NET deserializa con
+/// Kind=Unspecified (la 'Z' se pierde). EF Core + Npgsql legacy lo guarda
+/// literal en columna timestamp without time zone.
+///
+/// Fix: DateTimeNormalization.EnsureUtc fuerza Kind=Utc antes de persistir.
+/// </summary>
+public class DateTimeNormalizationTests
+{
+    [Fact]
+    public void EnsureUtc_ReturnsUtcUnchanged_WhenAlreadyUtc()
+    {
+        var utc = new DateTime(2026, 6, 2, 17, 3, 30, DateTimeKind.Utc);
+
+        var result = DateTimeNormalization.EnsureUtc(utc);
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        Assert.Equal(utc, result);
+    }
+
+    [Fact]
+    public void EnsureUtc_AssumesUtc_WhenKindIsUnspecified()
+    {
+        // Caso real del bug: mobile envia "2026-06-02T17:03:30Z" y ASP.NET
+        // deserializa como Unspecified (la 'Z' se pierde).
+        var unspecified = new DateTime(2026, 6, 2, 17, 3, 30, DateTimeKind.Unspecified);
+
+        var result = DateTimeNormalization.EnsureUtc(unspecified);
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        // El valor NO debe cambiar — solo el Kind. Asumimos que era UTC originalmente.
+        Assert.Equal(2026, result.Year);
+        Assert.Equal(6, result.Month);
+        Assert.Equal(2, result.Day);
+        Assert.Equal(17, result.Hour);
+        Assert.Equal(3, result.Minute);
+        Assert.Equal(30, result.Second);
+    }
+
+    [Fact]
+    public void EnsureUtc_ConvertsLocalToUtc_WhenKindIsLocal()
+    {
+        // Local sera convertido a UTC restando el offset del runner.
+        // Test solo verifica que Kind cambia y se aplica ToUniversalTime.
+        var local = new DateTime(2026, 6, 2, 10, 3, 30, DateTimeKind.Local);
+
+        var result = DateTimeNormalization.EnsureUtc(local);
+
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+        // El valor convertido depende del TZ del runner; verificar via comparacion.
+        var expected = local.ToUniversalTime();
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void EnsureUtc_Nullable_ReturnsNull_WhenInputIsNull()
+    {
+        DateTime? input = null;
+
+        var result = DateTimeNormalization.EnsureUtc(input);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void EnsureUtc_Nullable_NormalizesValue_WhenInputHasValue()
+    {
+        DateTime? input = new DateTime(2026, 6, 2, 17, 3, 30, DateTimeKind.Unspecified);
+
+        var result = DateTimeNormalization.EnsureUtc(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(DateTimeKind.Utc, result.Value.Kind);
+        Assert.Equal(17, result.Value.Hour);
+    }
+}

--- a/libs/HandySuites.Application/Common/Time/DateTimeNormalization.cs
+++ b/libs/HandySuites.Application/Common/Time/DateTimeNormalization.cs
@@ -1,0 +1,40 @@
+namespace HandySuites.Application.Common.Time;
+
+/// <summary>
+/// Helpers para normalizar DateTime entrantes desde mobile sync push.
+///
+/// Mobile siempre envia fechas via Date.prototype.toISOString() que produce
+/// strings UTC con sufijo 'Z'. Pero ASP.NET Core Minimal APIs deserializa el
+/// JSON con System.Text.Json y devuelve DateTime con Kind=Unspecified — la 'Z'
+/// se pierde porque .NET no preserva Kind sin configuracion explicita.
+///
+/// Combinado con Npgsql.EnableLegacyTimestampBehavior=true (Program.cs:17) que
+/// acepta DateTimeKind.Unspecified en columnas timestamp without time zone, el
+/// resultado es que el valor se almacena tal cual sin saber que era UTC.
+///
+/// Esto causo bug prod (2026-06-02): fecha_gasto de mobile aparecia 7h
+/// adelantada en BD para vendedores en Mazatlan (UTC-7).
+///
+/// La normalizacion aqui asume UTC para cualquier DateTime con Kind=Unspecified
+/// — defensive contra la deserializacion default de System.Text.Json. Los
+/// timestamps Local se convierten a UTC con ToUniversalTime().
+/// </summary>
+public static class DateTimeNormalization
+{
+    /// <summary>
+    /// Garantiza que el valor tenga Kind=Utc. Si llega Unspecified asume UTC
+    /// (caso normal de mobile sync push tras deserializacion JSON).
+    /// </summary>
+    public static DateTime EnsureUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    };
+
+    /// <summary>
+    /// Overload nullable. Devuelve null si entrada es null.
+    /// </summary>
+    public static DateTime? EnsureUtc(DateTime? value) =>
+        value.HasValue ? EnsureUtc(value.Value) : null;
+}

--- a/libs/HandySuites.Infrastructure/Repositories/Sync/SyncRepository.cs
+++ b/libs/HandySuites.Infrastructure/Repositories/Sync/SyncRepository.cs
@@ -1,4 +1,5 @@
 using HandySuites.Application.Common;
+using HandySuites.Application.Common.Time;
 using HandySuites.Application.Sync.DTOs;
 using HandySuites.Application.Sync.Interfaces;
 using HandySuites.Domain.Entities;
@@ -461,7 +462,7 @@ public class SyncRepository : ISyncRepository
                 UsuarioId = usuarioId,
                 ClienteId = dto.ClienteId,
                 NumeroPedido = numeroPedido,
-                FechaPedido = dto.FechaPedido,
+                FechaPedido = DateTimeNormalization.EnsureUtc(dto.FechaPedido),
                 FechaEntregaEstimada = dto.FechaEntregaEstimada,
                 Estado = (EstadoPedido)dto.Estado,
                 TipoVenta = (TipoVenta)dto.TipoVenta,
@@ -1016,7 +1017,7 @@ public class SyncRepository : ISyncRepository
                 existing.TipoGasto = (TipoGasto)dto.TipoGasto;
                 existing.Concepto = dto.Concepto;
                 existing.Notas = dto.Notas;
-                existing.FechaGasto = dto.FechaGasto != default ? dto.FechaGasto : existing.FechaGasto;
+                existing.FechaGasto = dto.FechaGasto != default ? DateTimeNormalization.EnsureUtc(dto.FechaGasto) : existing.FechaGasto;
                 // ComprobanteUrl: server-side stamp tiene preferencia (MobileAttachmentEndpoints).
                 // Solo aceptamos URL desde mobile push si existing.ComprobanteUrl es null — esto
                 // resuelve race condition cuando el stamp fallo y mobile stampeo localmente la URL.
@@ -1074,7 +1075,7 @@ public class SyncRepository : ISyncRepository
             MobileRecordId = dto.LocalId,
             UsuarioId = usuarioId,
             RutaId = resolvedRutaId,
-            FechaGasto = dto.FechaGasto != default ? dto.FechaGasto : DateTime.UtcNow,
+            FechaGasto = dto.FechaGasto != default ? DateTimeNormalization.EnsureUtc(dto.FechaGasto) : DateTime.UtcNow,
             Monto = dto.Monto,
             TipoGasto = (TipoGasto)dto.TipoGasto,
             Concepto = dto.Concepto,
@@ -1271,7 +1272,7 @@ public class SyncRepository : ISyncRepository
             ClienteId = dto.ClienteId > 0 ? dto.ClienteId : pedido.ClienteId,
             UsuarioId = usuarioId,
             RutaId = resolvedRutaId,
-            FechaDevolucion = dto.FechaDevolucion != default ? dto.FechaDevolucion : DateTime.UtcNow,
+            FechaDevolucion = dto.FechaDevolucion != default ? DateTimeNormalization.EnsureUtc(dto.FechaDevolucion) : DateTime.UtcNow,
             Motivo = (MotivoDevolucion)dto.Motivo,
             Notas = dto.Notas,
             TipoReembolso = (TipoReembolso)dto.TipoReembolso,


### PR DESCRIPTION
… (TZ bug prod 2026-06-02)

Bug prod: gastos creados desde mobile en Mazatlan (UTC-7) aparecian 7h adelantados en fecha_gasto. Causa: mobile envia .toISOString() UTC con Z, pero ASP.NET deserializa con Kind=Unspecified (la Z se pierde). Combinado con Npgsql.EnableLegacyTimestampBehavior=true, el valor se guarda literal en columna timestamp without time zone sin saber que era UTC.

Fix: nuevo helper DateTimeNormalization.EnsureUtc(value) que fuerza Kind=Utc antes de persistir. Aplicado en 4 callsites de SyncRepository.