### PR TITLE
fix(mobile/sync): dedupe changeset y conflictResolver explicito (prod…

### DIFF
--- a/apps/mobile-app/src/sync/__tests__/dedupeChangeset.test.ts
+++ b/apps/mobile-app/src/sync/__tests__/dedupeChangeset.test.ts
@@ -1,0 +1,88 @@
+import { dedupeChangeset } from '../dedupeChangeset';
+
+/**
+ * Bug prod 2026-06-03 ("Cannot update a record with pending changes
+ * pedidos#qQyLko2m8rS8z4fb"): WDB.synchronize() llama prepareUpdate sobre
+ * cada raw en `updated[]`. Si el mismo id aparece dos veces el segundo
+ * prepareUpdate dispara el invariant y aborta el batch entero, atascando
+ * los pending del vendedor.
+ *
+ * dedupeChangeset() garantiza que cada raw aparece a lo mas una vez.
+ */
+describe('dedupeChangeset', () => {
+  it('deduplica updated[] por id (last write gana)', () => {
+    const result = dedupeChangeset({
+      created: [],
+      updated: [
+        { id: 'qQyLko2m8rS8z4fb', total: 50, updated_at: 100 },
+        { id: 'qQyLko2m8rS8z4fb', total: 68, updated_at: 200 }, // mas nuevo
+        { id: 'otroId', total: 10, updated_at: 100 },
+      ],
+      deleted: [],
+    });
+
+    expect(result.updated).toHaveLength(2);
+    const pedido = result.updated.find((r) => r.id === 'qQyLko2m8rS8z4fb');
+    expect(pedido?.total).toBe(68);
+    expect(pedido?.updated_at).toBe(200);
+  });
+
+  it('deduplica created[] por id', () => {
+    const result = dedupeChangeset({
+      created: [
+        { id: 'a1', nombre: 'primero' },
+        { id: 'a1', nombre: 'segundo' }, // ultimo gana
+        { id: 'a2', nombre: 'otro' },
+      ],
+      updated: [],
+      deleted: [],
+    });
+
+    expect(result.created).toHaveLength(2);
+    expect(result.created.find((r) => r.id === 'a1')?.nombre).toBe('segundo');
+  });
+
+  it('deduplica deleted[] (Set)', () => {
+    const result = dedupeChangeset({
+      created: [],
+      updated: [],
+      deleted: ['x', 'y', 'x', 'z', 'y'],
+    });
+
+    expect(result.deleted.sort()).toEqual(['x', 'y', 'z']);
+  });
+
+  it('no toca arrays sin duplicados', () => {
+    const input = {
+      created: [{ id: 'a' }, { id: 'b' }],
+      updated: [{ id: 'c' }, { id: 'd' }],
+      deleted: ['e', 'f'],
+    };
+    const result = dedupeChangeset(input);
+
+    expect(result.created).toHaveLength(2);
+    expect(result.updated).toHaveLength(2);
+    expect(result.deleted).toHaveLength(2);
+  });
+
+  it('filtra entradas con id vacio en updated/created', () => {
+    const result = dedupeChangeset({
+      created: [{ id: '', nombre: 'broken' }, { id: 'valid' }],
+      updated: [{ id: '', total: 0 }, { id: 'real', total: 10 }],
+      deleted: ['', 'real-deleted', ''],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.id).toBe('valid');
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0]?.id).toBe('real');
+    expect(result.deleted).toEqual(['real-deleted']);
+  });
+
+  it('maneja arrays vacios sin throw', () => {
+    const result = dedupeChangeset({ created: [], updated: [], deleted: [] });
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+});

--- a/apps/mobile-app/src/sync/dedupeChangeset.ts
+++ b/apps/mobile-app/src/sync/dedupeChangeset.ts
@@ -1,0 +1,52 @@
+import type { DirtyRaw } from '@nozbe/watermelondb/RawRecord';
+
+/**
+ * Dedupe del changeset por `id` antes de pasarlo a WDB.synchronize().
+ *
+ * BUG prod 2026-06-03 ("Cannot update a record with pending changes
+ * pedidos#qQyLko2m8rS8z4fb"): WDB llama prepareUpdate sobre cada raw en
+ * `updated[]`. Si el mismo id aparece dos veces, el segundo prepareUpdate
+ * dispara el invariant porque el record ya tiene `_hasPendingUpdate=true`
+ * del primero — y el batch entero se aborta. Eso atascaba 39 pendientes en
+ * el celular del vendedor en una sola APK.
+ *
+ * Causas posibles de duplicados:
+ *  - Backend emite el mismo pedido dos veces en `/sync/pull` (joins sin DISTINCT)
+ *  - `pedidoMap` (server_id -> local_id) colisiona si hay records locales
+ *    corruptos con el mismo server_id
+ *  - `p.localId` y `pedidoMap.get(p.id)` resuelven al mismo string desde dos
+ *    iteraciones diferentes
+ *
+ * Estrategia: el ULTIMO write gana en `updated[]` y `created[]` (los items
+ * suelen venir ordenados por `actualizado_en` ASC, asi que el ultimo es el
+ * mas reciente). Para `deleted[]` basta un Set.
+ *
+ * Importante: NO toca el `_status` local del record. WDB sigue resolviendo
+ * conflictos en sus internals (per-column client-wins) y los pending locales
+ * se pushean en el siguiente pushChanges.
+ *
+ * Extraido a su propio archivo para poder testearlo unitariamente sin pull-in
+ * de `db/database.ts` (que importa expo-constants y rompe ts-jest puro).
+ */
+export function dedupeChangeset(
+  changeset: { created: DirtyRaw[]; updated: DirtyRaw[]; deleted: string[] }
+): { created: DirtyRaw[]; updated: DirtyRaw[]; deleted: string[] } {
+  const updatedById = new Map<string, DirtyRaw>();
+  for (const raw of changeset.updated) {
+    const id = String(raw.id);
+    if (!id) continue;
+    updatedById.set(id, raw); // last write wins
+  }
+  const createdById = new Map<string, DirtyRaw>();
+  for (const raw of changeset.created) {
+    const id = String(raw.id);
+    if (!id) continue;
+    createdById.set(id, raw);
+  }
+  const deletedSet = new Set<string>(changeset.deleted.filter(Boolean));
+  return {
+    created: Array.from(createdById.values()),
+    updated: Array.from(updatedById.values()),
+    deleted: Array.from(deletedSet),
+  };
+}

--- a/apps/mobile-app/src/sync/mappers.ts
+++ b/apps/mobile-app/src/sync/mappers.ts
@@ -2,6 +2,7 @@ import type { SyncDatabaseChangeSet } from '@nozbe/watermelondb/sync';
 import type { DirtyRaw } from '@nozbe/watermelondb/RawRecord';
 import { Q } from '@nozbe/watermelondb';
 import { database } from '@/db/database';
+import { dedupeChangeset } from './dedupeChangeset';
 
 // ────────────────────────────────────────────────────────────────
 // PULL: Server → WatermelonDB
@@ -161,7 +162,7 @@ function splitByOperation(
     }
   }
 
-  return { created: [], updated, deleted };
+  return dedupeChangeset({ created: [], updated, deleted });
 }
 
 // ── Entity Mappers (server DTO → WatermelonDB raw) ──
@@ -313,7 +314,7 @@ function extractDetallesPedido(
     }
   }
 
-  return { created, updated, deleted: [] };
+  return dedupeChangeset({ created, updated, deleted: [] });
 }
 
 function mapRutaToRaw(r: any, rutaMap: Map<number, string>): DirtyRaw {
@@ -387,7 +388,7 @@ function extractRutaPedidos(
       });
     }
   }
-  return { created: [], updated, deleted: [] };
+  return dedupeChangeset({ created: [], updated, deleted: [] });
 }
 
 /**
@@ -427,7 +428,7 @@ function extractRutaCarga(
       });
     }
   }
-  return { created: [], updated, deleted: [] };
+  return dedupeChangeset({ created: [], updated, deleted: [] });
 }
 
 function extractDetallesRuta(
@@ -472,7 +473,7 @@ function extractDetallesRuta(
     }
   }
 
-  return { created, updated, deleted: [] };
+  return dedupeChangeset({ created, updated, deleted: [] });
 }
 
 function mapVisitaToRaw(v: any, visitaMap: Map<number, string>, clienteMap: Map<number, string>): DirtyRaw {
@@ -606,7 +607,7 @@ function extractDetallesDevolucion(devs: any[] | undefined, isFirstSync: boolean
       }
     }
   }
-  return { created, updated, deleted };
+  return dedupeChangeset({ created, updated, deleted });
 }
 
 function mapDetalleDevolucionToRaw(dd: any, detalleDevMap: Map<number, string>, devMap: Map<number, string>,

--- a/apps/mobile-app/src/sync/syncEngine.ts
+++ b/apps/mobile-app/src/sync/syncEngine.ts
@@ -169,6 +169,20 @@ async function doPerformSync(options?: SyncOptions): Promise<void> {
       },
 
       sendCreatedAsUpdated: true,
+
+      // Default explicito: per-column client-wins (lo que WDB hace por default
+      // pero ahora es visible).
+      //  - `resolved` ya viene calculado por WDB: remote prevalece EXCEPTO en
+      //    columnas que el cliente editó desde el ultimo sync (esas ganan).
+      //  - El record queda marcado _status='updated' si tenia cambios locales,
+      //    lo que garantiza que se pushean en el siguiente pushChanges sin
+      //    perder el trabajo offline del vendedor.
+      // Bug prod 2026-06-03: sin esto el pull podia abortar con
+      // `Cannot update a record with pending changes pedidos#qQyLko2m8rS8z4fb`
+      // — combinado con el dedupe en mappers.ts ese error queda resuelto.
+      conflictResolver: (_table, _local, _remote, resolved) => {
+        return resolved;
+      },
     });
 
     // Phase 2b: Server ID mappings — log only, don't modify records


### PR DESCRIPTION
… 2026-06-03)

Bug reportado en prod hoy: el vendedor (Rodrigo, Jeyma) tenia 39 registros pendientes de sincronizar bloqueados con el error WDB:

  Cannot update a record with pending changes (pedidos#qQyLko2m8rS8z4fb)

Causa: WDB.synchronize() llama prepareUpdate sobre cada raw en updated[]. Si el mismo id aparece dos veces el segundo prepareUpdate dispara el invariant (record ya tiene _hasPendingUpdate=true). El batch ENTERO se aborta y los pending quedan stuck.

El duplicado en updated[] viene de:
- splitByOperation/extract* mappers NO deduplican por id
- El server puede emitir el mismo pedido dos veces en /sync/pull
- pedidoMap (server_id -> local_id) puede colisionar con records locales corruptos
- p.localId y pedidoMap.get(p.id) resolviendo al mismo string en iteraciones distintas

Fix (defense-in-depth, basado en docs WDB via context7):
1. dedupeChangeset helper en archivo aparte (sync/dedupeChangeset.ts):
   - Map<string, DirtyRaw> con last-write-wins para updated[]/created[]
   - Set<string> para deleted[]
   - Filtra ids vacios para robustez
2. Aplicado en 6 sitios de mappers.ts: splitByOperation, extractDetallesPedido, extractRutaPedidos, extractRutaCarga, extractDetallesRuta, extractDetallesDevolucion
3. conflictResolver explicito en syncEngine.ts (return resolved):
   - Documenta el client-wins per-column default de WDB
   - El record queda _status='updated' si tenia cambios locales
   - Los 39 pendings del vendedor se pushean en el pushChanges siguiente
   - NO se pierde trabajo offline

Tests: 6 nuevos casos en dedupeChangeset.test.ts cubriendo duplicados en updated/created/deleted, ids vacios, arrays sin duplicados, arrays vacios. tsc --noEmit ok. 13/13 jest pass.