### PR TITLE
fix(web): 22 alias URLs ES → EN canonical — no más 404 por tipear URLs en español

### DIFF
--- a/apps/web/src/app/(dashboard)/automatizaciones/page.tsx
+++ b/apps/web/src/app/(dashboard)/automatizaciones/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/automations` page.
+ *
+ * The sidebar uses `/automations` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function AutomatizacionesIndex() {
+  redirect('/automations');
+}

--- a/apps/web/src/app/(dashboard)/categorias-clientes/page.tsx
+++ b/apps/web/src/app/(dashboard)/categorias-clientes/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/client-categories` page.
+ *
+ * The sidebar uses `/client-categories` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function CategoriasClientesIndex() {
+  redirect('/client-categories');
+}

--- a/apps/web/src/app/(dashboard)/categorias-productos/page.tsx
+++ b/apps/web/src/app/(dashboard)/categorias-productos/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/product-categories` page.
+ *
+ * The sidebar uses `/product-categories` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function CategoriasProductosIndex() {
+  redirect('/product-categories');
+}

--- a/apps/web/src/app/(dashboard)/clientes/page.tsx
+++ b/apps/web/src/app/(dashboard)/clientes/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/clients` page.
+ *
+ * The sidebar uses `/clients` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ClientesIndex() {
+  redirect('/clients');
+}

--- a/apps/web/src/app/(dashboard)/configuracion/page.tsx
+++ b/apps/web/src/app/(dashboard)/configuracion/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/settings` page.
+ *
+ * The sidebar uses `/settings` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ConfiguracionIndex() {
+  redirect('/settings');
+}

--- a/apps/web/src/app/(dashboard)/descuentos/page.tsx
+++ b/apps/web/src/app/(dashboard)/descuentos/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/discounts` page.
+ *
+ * The sidebar uses `/discounts` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function DescuentosIndex() {
+  redirect('/discounts');
+}

--- a/apps/web/src/app/(dashboard)/equipo/page.tsx
+++ b/apps/web/src/app/(dashboard)/equipo/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/team` page.
+ *
+ * The sidebar uses `/team` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function EquipoIndex() {
+  redirect('/team');
+}

--- a/apps/web/src/app/(dashboard)/facturacion/page.tsx
+++ b/apps/web/src/app/(dashboard)/facturacion/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/billing` page.
+ *
+ * The sidebar uses `/billing` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function FacturacionIndex() {
+  redirect('/billing');
+}

--- a/apps/web/src/app/(dashboard)/familias-productos/page.tsx
+++ b/apps/web/src/app/(dashboard)/familias-productos/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/product-families` page.
+ *
+ * The sidebar uses `/product-families` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function FamiliasProductosIndex() {
+  redirect('/product-families');
+}

--- a/apps/web/src/app/(dashboard)/ia/page.tsx
+++ b/apps/web/src/app/(dashboard)/ia/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/ai` page.
+ *
+ * The sidebar uses `/ai` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function IaIndex() {
+  redirect('/ai');
+}

--- a/apps/web/src/app/(dashboard)/inventario/page.tsx
+++ b/apps/web/src/app/(dashboard)/inventario/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/inventory` page.
+ *
+ * The sidebar uses `/inventory` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function InventarioIndex() {
+  redirect('/inventory');
+}

--- a/apps/web/src/app/(dashboard)/listas-precios/page.tsx
+++ b/apps/web/src/app/(dashboard)/listas-precios/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/price-lists` page.
+ *
+ * The sidebar uses `/price-lists` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ListasPreciosIndex() {
+  redirect('/price-lists');
+}

--- a/apps/web/src/app/(dashboard)/pedidos/page.tsx
+++ b/apps/web/src/app/(dashboard)/pedidos/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/orders` page.
+ *
+ * The sidebar uses `/orders` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function PedidosIndex() {
+  redirect('/orders');
+}

--- a/apps/web/src/app/(dashboard)/precios/page.tsx
+++ b/apps/web/src/app/(dashboard)/precios/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/price-lists` page.
+ *
+ * The sidebar uses `/price-lists` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function PreciosIndex() {
+  redirect('/price-lists');
+}

--- a/apps/web/src/app/(dashboard)/productos/page.tsx
+++ b/apps/web/src/app/(dashboard)/productos/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/products` page.
+ *
+ * The sidebar uses `/products` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ProductosIndex() {
+  redirect('/products');
+}

--- a/apps/web/src/app/(dashboard)/promociones/page.tsx
+++ b/apps/web/src/app/(dashboard)/promociones/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/promotions` page.
+ *
+ * The sidebar uses `/promotions` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function PromocionesIndex() {
+  redirect('/promotions');
+}

--- a/apps/web/src/app/(dashboard)/registro-actividad/page.tsx
+++ b/apps/web/src/app/(dashboard)/registro-actividad/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/activity-logs` page.
+ *
+ * The sidebar uses `/activity-logs` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function RegistroActividadIndex() {
+  redirect('/activity-logs');
+}

--- a/apps/web/src/app/(dashboard)/reportes/page.tsx
+++ b/apps/web/src/app/(dashboard)/reportes/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/reports` page.
+ *
+ * The sidebar uses `/reports` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ReportesIndex() {
+  redirect('/reports');
+}

--- a/apps/web/src/app/(dashboard)/suscripcion/page.tsx
+++ b/apps/web/src/app/(dashboard)/suscripcion/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/subscription` page.
+ *
+ * The sidebar uses `/subscription` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function SuscripcionIndex() {
+  redirect('/subscription');
+}

--- a/apps/web/src/app/(dashboard)/tablero/page.tsx
+++ b/apps/web/src/app/(dashboard)/tablero/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/dashboard` page.
+ *
+ * The sidebar uses `/dashboard` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function TableroIndex() {
+  redirect('/dashboard');
+}

--- a/apps/web/src/app/(dashboard)/visitas/page.tsx
+++ b/apps/web/src/app/(dashboard)/visitas/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/visits` page.
+ *
+ * The sidebar uses `/visits` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function VisitasIndex() {
+  redirect('/visits');
+}

--- a/apps/web/src/app/(dashboard)/zonas/page.tsx
+++ b/apps/web/src/app/(dashboard)/zonas/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * Spanish-URL alias for the canonical English `/zones` page.
+ *
+ * The sidebar uses `/zones` as canonical href. This file exists solely
+ * to prevent 404 when users type the Spanish URL (bookmarks, manual typing,
+ * legacy links). Server Component so the redirect happens before any client
+ * bundle is shipped.
+ */
+export default function ZonasIndex() {
+  redirect('/zones');
+}


### PR DESCRIPTION
…teclea pedidos/clientes/productos/etc en lugar del path en ingles