### PR TITLE
fix(metas): header contador coherente con tabla (sorted.length)

### DIFF
--- a/apps/web/src/app/(dashboard)/metas/page.tsx
+++ b/apps/web/src/app/(dashboard)/metas/page.tsx
@@ -357,7 +357,7 @@ export default function MetasPage() {
         { label: t('vendorGoals') },
       ]}
       title={t('vendorGoals')}
-      subtitle={metas.length > 0 ? t('metaCount', { count: metas.length, plural: metas.length !== 1 ? 's' : '' }) : undefined}
+      subtitle={sorted.length > 0 ? t('metaCount', { count: sorted.length, plural: sorted.length !== 1 ? 's' : '' }) : undefined}
       actions={
         isAdmin ? (
           <button


### PR DESCRIPTION
…antes mostraba 3 metas pero tabla mostraba 1 por filtro implicito showInactive=false