### PR TITLE
feat(cobros): merge staging->main — PR 5c mobile pedido picker + PR 6 web FIFO preview & Anticipo gating

### DIFF
--- a/apps/api/src/HandySuites.Api/Endpoints/CobroEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/CobroEndpoints.cs
@@ -3,6 +3,7 @@ using HandySuites.Api.Hubs;
 using Microsoft.AspNetCore.SignalR;
 using HandySuites.Infrastructure.Persistence;
 using HandySuites.Application.Cobranza.DTOs;
+using HandySuites.Application.Cobranza.Interfaces;
 using HandySuites.Application.Cobranza.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -135,5 +136,34 @@ public static class CobroEndpoints
             return estado is null ? Results.NotFound() : Results.Ok(estado);
         })
         .WithSummary("Estado de cuenta detallado de un cliente");
+
+        // 2026-06-09 PR 6 plan eager-drifting cobros (FIFO preview).
+        // Calcula la distribución FIFO SIN persistir — la UI muestra al usuario
+        // cuánto se aplicará a cada pedido antes de hacer submit.
+        group.MapPost("/fifo-preview", async (
+            FifoPreviewRequest req,
+            [FromServices] ICobroFifoAplicadorService fifoService) =>
+        {
+            if (req.Monto <= 0)
+                return Results.BadRequest(new { error = "El monto debe ser mayor a cero." });
+            if (req.ClienteId <= 0)
+                return Results.BadRequest(new { error = "ClienteId es obligatorio." });
+
+            try
+            {
+                var aplicaciones = await fifoService.CalcularSinPersistirAsync(req.ClienteId, req.Monto);
+                return Results.Ok(aplicaciones);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithSummary("Preview FIFO: calcula distribución sin persistir");
     }
+
+    /// <summary>
+    /// 2026-06-09 PR 6: body del endpoint /cobros/fifo-preview.
+    /// </summary>
+    public record FifoPreviewRequest(int ClienteId, decimal Monto);
 }

--- a/apps/api/src/HandySuites.Api/Endpoints/CompanyEndpoints.cs
+++ b/apps/api/src/HandySuites.Api/Endpoints/CompanyEndpoints.cs
@@ -7,6 +7,7 @@ using CompanySettingsDto = HandySuites.Application.CompanySettings.DTOs.CompanyS
 using HandySuites.Application.CompanySettings.DTOs;
 using HandySuites.Application.DatosFacturacion.DTOs;
 using HandySuites.Application.DatosFacturacion.Interfaces;
+using HandySuites.Application.Tracking.Interfaces;
 using HandySuites.Shared.Multitenancy;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -26,16 +27,26 @@ namespace HandySuites.Api.Endpoints
             group.MapGet("/settings", async (
                 HttpContext context,
                 [FromServices] ICompanySettingsService companyService,
-                [FromServices] ICurrentTenant currentTenant) =>
+                [FromServices] ICurrentTenant currentTenant,
+                [FromServices] ISubscriptionFeatureGuard featureGuard) =>
             {
                 try
                 {
                     var tenantId = currentTenant.TenantId;
                     var result = await companyService.GetSettingsAsync(tenantId);
 
-                    return result != null
-                        ? Results.Ok(result)
-                        : Results.NotFound("Configuración no encontrada");
+                    if (result == null)
+                        return Results.NotFound("Configuración no encontrada");
+
+                    // PR 6 plan gating cobros: el web cobranza/page.tsx lee este flag
+                    // para deshabilitar el boton "Anticipo" del selector cuando el
+                    // plan del tenant no lo incluye. Espejo del flag en
+                    // MobileEmpresaEndpoints.cs (mobile useEmpresa). HasFeatureAsync
+                    // no tira si el tenant esta en free trial sin plan — retorna false.
+                    result.PermitirAnticiposEnCampo = await featureGuard
+                        .HasFeatureAsync(tenantId, "anticipos_en_campo");
+
+                    return Results.Ok(result);
                 }
                 catch (Exception ex)
                 {

--- a/apps/mobile-app/app/(tabs)/cobrar/registrar.tsx
+++ b/apps/mobile-app/app/(tabs)/cobrar/registrar.tsx
@@ -4,7 +4,7 @@ import Toast from 'react-native-toast-message';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '@/stores';
-import { useOfflineClientById, useOfflineClients } from '@/hooks';
+import { useOfflineClientById, useOfflineClients, useEstadoCuenta } from '@/hooks';
 import { database } from '@/db/database';
 import { createCobroOffline } from '@/db/actions';
 import { capturePhoto, saveAttachmentRecord } from '@/services/evidenceManager';
@@ -90,6 +90,60 @@ function RegistrarCobroScreen() {
 
   const { data: cliente } = useOfflineClientById(effectiveClienteId);
 
+  // PR 5c: Pedido picker post-PorPedido. Cuando el vendedor elige modo
+  // PorPedido + cliente con saldo, mostramos un segundo picker con los pedidos
+  // abiertos (facturas con saldo > 0) extraidos del estado de cuenta del
+  // servidor. Solo fetch cuando aplica (gate por modo + cliente server_id
+  // disponible). Si el deep link ya trae params.pedidoId el picker se omite
+  // (el modo viene forzado por el pedido padre).
+  const enableEstadoCuenta =
+    !params.pedidoId &&
+    modo === ModoCobro.PorPedido &&
+    !!cliente?.serverId &&
+    (cliente?.serverId ?? 0) > 0;
+  const { data: estadoCuenta, isLoading: estadoCuentaLoading } = useEstadoCuenta(
+    enableEstadoCuenta ? (cliente?.serverId ?? 0) : 0
+  );
+
+  // Pedidos abiertos: facturas en el running ledger con saldo > 0. movimiento.id
+  // corresponde directamente al pedidoId (per EstadoCuentaMovimientoDto: para
+  // tipo='factura' el Id es el pedidoId, rango natural < 1M).
+  const pedidosAbiertos = useMemo(() => {
+    if (!estadoCuenta?.movimientos) return [] as { id: number; concepto: string; saldo: number; fecha: string }[];
+    return estadoCuenta.movimientos
+      .filter((m) => m.tipo === 'factura' && Number(m.saldo) > 0)
+      .map((m) => ({
+        id: m.id,
+        concepto: m.concepto,
+        saldo: Number(m.saldo),
+        fecha: m.fecha,
+      }));
+  }, [estadoCuenta]);
+
+  const [selectedPedido, setSelectedPedido] = useState<{
+    id: number;
+    concepto: string;
+    saldo: number;
+  } | null>(null);
+  const [pedidoPickerOpen, setPedidoPickerOpen] = useState(false);
+
+  // Reset pedido seleccionado al cambiar de modo o cliente (el pedido
+  // seleccionado se vuelve incoherente si el contexto cambia).
+  useEffect(() => {
+    setSelectedPedido(null);
+    setPedidoPickerOpen(false);
+  }, [modo, effectiveClienteId]);
+
+  const handleSelectPedido = (p: { id: number; concepto: string; saldo: number }) => {
+    setSelectedPedido(p);
+    setPedidoPickerOpen(false);
+  };
+
+  const handleClearPedido = () => {
+    setSelectedPedido(null);
+    setPedidoPickerOpen(false);
+  };
+
   const [monto, setMonto] = useState('');
   const [montoError, setMontoError] = useState('');
   const [metodoPago, setMetodoPago] = useState(0);
@@ -127,7 +181,21 @@ function RegistrarCobroScreen() {
   const montoNum = round2(parseFloat(monto) || 0);
   const saldoRounded = round2(effectiveSaldo);
   const MAX_MONTO = 999999.99;
-  const isValid = montoNum > 0 && montoNum <= MAX_MONTO && !!effectiveClienteId;
+  // PR 5c: si esta en modo PorPedido y el cliente tiene pedidos abiertos, el
+  // vendedor DEBE seleccionar un pedido especifico (asi el cobro arrastra
+  // pedido_id != null al backend). Si no hay pedidos abiertos no podemos
+  // exigirlo — la guidance UI redirige a Anticipo/AbonoFifo.
+  const pedidoSelectionRequired =
+    !params.pedidoId &&
+    modo === ModoCobro.PorPedido &&
+    !!effectiveClienteId &&
+    pedidosAbiertos.length > 0;
+  const pedidoSelectionOk = !pedidoSelectionRequired || !!selectedPedido;
+  const isValid =
+    montoNum > 0 &&
+    montoNum <= MAX_MONTO &&
+    !!effectiveClienteId &&
+    pedidoSelectionOk;
   const isOverSaldo = saldoRounded > 0 && montoNum > saldoRounded;
 
   const handleConfirmar = () => {
@@ -145,6 +213,14 @@ function RegistrarCobroScreen() {
       // PR 5 cobros 3 modos: pasamos modo explicito al store local. El sync
       // mapper rawToCobroDto respeta raw.modo si esta presente, sino deriva
       // del pedidoId (retrocompat con cobros pre-PR5).
+      // PR 5c: si el vendedor escogio pedido del picker (post-PorPedido), el
+      // server_id del pedido se persiste como string numerica en pedido_id —
+      // el mapper de sync lo trata como pedido_server_id valido (raw.pedido_id
+      // matches /^\d+$/ → parseInt → DTO.pedidoId). Si viene via deep link
+      // (params.pedidoId, que es un WDB localId) se respeta el flujo legacy.
+      const pedidoIdForCobro = selectedPedido
+        ? String(selectedPedido.id)
+        : (params.pedidoId || null);
       const cobro = await createCobroOffline(
         effectiveClienteId || '',
         cliente?.serverId ?? null,
@@ -153,7 +229,7 @@ function RegistrarCobroScreen() {
         metodoPago,
         referencia || undefined,
         notas || undefined,
-        params.pedidoId || null,
+        pedidoIdForCobro,
         modo
       );
 
@@ -197,6 +273,8 @@ function RegistrarCobroScreen() {
       setNotas('');
       setReceiptPhoto(null);
       setSelectedClient(null);
+      setSelectedPedido(null);
+      setPedidoPickerOpen(false);
     } catch {
       Toast.show({ type: 'error', text1: 'Error', text2: 'No se pudo registrar el cobro' });
     } finally {
@@ -407,6 +485,98 @@ function RegistrarCobroScreen() {
             <ChevronRight size={16} color="#cbd5e1" />
           </TouchableOpacity>
         )}
+
+        {/* PR 5c: Pedido Picker post-PorPedido. Solo cuando:
+            - No es deep link con params.pedidoId.
+            - modo === PorPedido (no aplica a AbonoFifo/Anticipo).
+            - Cliente ya elegido (efectivo + cliente.serverId resuelto).
+            - Cliente picker no esta abierto (evita doble layout activo).
+            testID="cobro-pedido-picker-{trigger|item-N|empty}" para Maestro. */}
+        {!params.pedidoId &&
+          modo === ModoCobro.PorPedido &&
+          !!effectiveClienteId &&
+          !pickerOpen &&
+          (selectedClient || paramClienteId) ? (
+          estadoCuentaLoading ? (
+            <View style={styles.pedidoLoadingCard}>
+              <Text style={styles.pedidoLoadingText}>Cargando pedidos del cliente...</Text>
+            </View>
+          ) : pedidosAbiertos.length === 0 ? (
+            /* Cliente sin pedidos con saldo > 0 → guidance. */
+            <View testID="cobro-pedido-picker-empty" style={styles.pedidoEmptyCard}>
+              <Text style={styles.pedidoEmptyTitle}>Cliente sin pedidos pendientes</Text>
+              <Text style={styles.pedidoEmptyText}>
+                Cambia a Anticipo si quieres registrar saldo a favor, o selecciona otro cliente con saldo pendiente.
+              </Text>
+            </View>
+          ) : selectedPedido && !pedidoPickerOpen ? (
+            /* Pedido elegido → card con saldo + boton cambiar. */
+            <View testID="cobro-pedido-selected" style={styles.pedidoSelectedCard}>
+              <View style={styles.pedidoSelectedIcon}>
+                <Banknote size={18} color="#16a34a" />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.pedidoSelectedConcepto} numberOfLines={1}>
+                  {selectedPedido.concepto}
+                </Text>
+                <Text style={styles.pedidoSelectedSaldo}>
+                  Saldo pendiente: {formatCurrency(selectedPedido.saldo)}
+                </Text>
+              </View>
+              <TouchableOpacity
+                onPress={handleClearPedido}
+                style={styles.changeClientBtn}
+                accessibilityLabel="Cambiar pedido"
+                accessibilityRole="button"
+              >
+                <X size={16} color="#64748b" />
+              </TouchableOpacity>
+            </View>
+          ) : pedidoPickerOpen ? (
+            /* Picker abierto → lista de pedidos abiertos. */
+            <View style={styles.pickerSection}>
+              <Text style={styles.sectionLabel}>Seleccionar Pedido</Text>
+              <View style={styles.clientList}>
+                {pedidosAbiertos.slice(0, 10).map((p, idx) => (
+                  <TouchableOpacity
+                    key={p.id}
+                    testID={`cobro-pedido-picker-item-${idx}`}
+                    style={styles.clientOption}
+                    onPress={() => handleSelectPedido(p)}
+                    activeOpacity={0.7}
+                  >
+                    <View style={styles.clientOptionAvatar}>
+                      <Banknote size={16} color="#64748b" />
+                    </View>
+                    <View style={styles.clientOptionContent}>
+                      <Text style={styles.clientOptionName} numberOfLines={1}>{p.concepto}</Text>
+                      <Text style={styles.clientOptionMeta}>
+                        Saldo: {formatCurrency(p.saldo)}
+                      </Text>
+                    </View>
+                    <ChevronRight size={14} color="#cbd5e1" />
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          ) : (
+            /* Trigger inicial → boton para abrir picker. */
+            <TouchableOpacity
+              testID="cobro-pedido-picker-trigger"
+              style={styles.pickerTrigger}
+              onPress={() => setPedidoPickerOpen(true)}
+              activeOpacity={0.7}
+              accessibilityLabel="Seleccionar pedido"
+              accessibilityRole="button"
+            >
+              <View style={styles.pickerTriggerIcon}>
+                <Banknote size={18} color="#94a3b8" />
+              </View>
+              <Text style={styles.pickerTriggerText}>Seleccionar pedido</Text>
+              <ChevronRight size={16} color="#cbd5e1" />
+            </TouchableOpacity>
+          )
+        ) : null}
 
         {/* Monto */}
         <View style={styles.montoSection}>
@@ -873,6 +1043,72 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     borderTopWidth: 1,
     borderTopColor: '#f1f5f9',
+  },
+  // PR 5c: pedido picker post-PorPedido styles.
+  pedidoLoadingCard: {
+    marginHorizontal: 16,
+    marginBottom: 16,
+    backgroundColor: '#f8fafc',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+  },
+  pedidoLoadingText: {
+    fontSize: 13,
+    color: '#64748b',
+    textAlign: 'center',
+  },
+  pedidoEmptyCard: {
+    marginHorizontal: 16,
+    marginBottom: 16,
+    backgroundColor: '#fffbeb',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#fcd34d',
+  },
+  pedidoEmptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#92400e',
+    marginBottom: 4,
+  },
+  pedidoEmptyText: {
+    fontSize: 12,
+    color: '#92400e',
+    lineHeight: 16,
+  },
+  pedidoSelectedCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginBottom: 16,
+    backgroundColor: '#f0fdf4',
+    borderRadius: 14,
+    padding: 14,
+    gap: 12,
+    borderWidth: 1,
+    borderColor: '#bbf7d0',
+  },
+  pedidoSelectedIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    backgroundColor: '#dcfce7',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pedidoSelectedConcepto: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#166534',
+  },
+  pedidoSelectedSaldo: {
+    fontSize: 12,
+    color: '#15803d',
+    marginTop: 2,
+    fontWeight: '500',
   },
 });
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1586,13 +1586,17 @@
       },
       "fifo": {
         "label": "Account credit",
-        "hint": "Auto-distribute FIFO"
+        "hint": "Auto-distribute FIFO",
+        "previewTitle": "FIFO distribution preview",
+        "previewCalculating": "Calculating distribution...",
+        "previewEmpty": "No pending orders to apply"
       },
       "advance": {
         "label": "Advance",
         "hint": "Generates credit balance",
         "warning": "This payment will generate a credit balance for the client, applicable to future orders. Confirm the amount before continuing.",
-        "confirmMessage": "This payment of {monto} will become a credit balance for the client. Confirm?"
+        "confirmMessage": "This payment of {monto} will become a credit balance for the client. Confirm?",
+        "disabledTooltip": "Available on PRO plan"
       }
     },
     "datePresets": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1586,13 +1586,17 @@
       },
       "fifo": {
         "label": "Abono a cuenta",
-        "hint": "Distribuye automático FIFO"
+        "hint": "Distribuye automático FIFO",
+        "previewTitle": "Preview de distribución FIFO",
+        "previewCalculating": "Calculando distribución...",
+        "previewEmpty": "Sin pedidos pendientes para aplicar"
       },
       "advance": {
         "label": "Anticipo",
         "hint": "Genera saldo a favor",
         "warning": "Este cobro generará saldo a favor del cliente, aplicable a futuros pedidos. Confirma el monto antes de continuar.",
-        "confirmMessage": "Este cobro de {monto} quedará como saldo a favor del cliente. ¿Confirmar?"
+        "confirmMessage": "Este cobro de {monto} quedará como saldo a favor del cliente. ¿Confirmar?",
+        "disabledTooltip": "Disponible en plan PRO"
       }
     },
     "datePresets": {

--- a/apps/web/src/app/(dashboard)/cobranza/page.tsx
+++ b/apps/web/src/app/(dashboard)/cobranza/page.tsx
@@ -37,6 +37,7 @@ import {
   getResumenCartera,
   getSaldos,
   getEstadoCuenta,
+  getFifoPreview,
   createCobro,
   deleteCobro,
   Cobro,
@@ -44,6 +45,7 @@ import {
   SaldoCliente,
   EstadoCuenta,
   EstadoCuentaPedido,
+  FifoAplicacion,
   METODO_PAGO_OPTIONS,
   ModoCobro,
 } from '@/services/api/cobranza';
@@ -55,6 +57,7 @@ import { formatDate } from '@/lib/formatters';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { usePermissions } from '@/hooks/usePermissions';
+import { useCompany } from '@/hooks/useCompany';
 
 // ─── Zod Schema ───────────────────────────────────────
 
@@ -142,6 +145,13 @@ export default function CobranzaPage() {
   const { userRole, isLoading: permsLoading } = usePermissions();
   const allowedRoles = ['ADMIN', 'SUPERVISOR', 'SUPER_ADMIN'];
   const isAuthorized = !!userRole && allowedRoles.includes(userRole);
+
+  // PR 6 plan gating cobros 3 modos (web): leer el flag del plan del tenant
+  // para deshabilitar el boton "Anticipo" del selector cuando el plan no lo
+  // incluye. Default false (fail-closed): si la company aun no carga o
+  // explicitamente vino false del backend, el boton queda gateado.
+  const { companySettings } = useCompany();
+  const permitirAnticiposEnCampo = companySettings?.permitirAnticiposEnCampo === true;
   useEffect(() => {
     if (!permsLoading && !isAuthorized) {
       router.replace('/dashboard');
@@ -182,6 +192,13 @@ export default function CobranzaPage() {
   // Pedidos for selected client in new cobro form
   const [formPedidos, setFormPedidos] = useState<EstadoCuentaPedido[]>([]);
   const [formPedidosLoading, setFormPedidosLoading] = useState(false);
+
+  // 2026-06-09 PR 6: FIFO preview — solo activo cuando modo=AbonoFifo +
+  // cliente seleccionado + monto > 0. Debounce 300ms para no spamear
+  // el endpoint mientras el user teclea el monto.
+  const [fifoPreview, setFifoPreview] = useState<FifoAplicacion[] | null>(null);
+  const [fifoPreviewLoading, setFifoPreviewLoading] = useState(false);
+  const [fifoPreviewError, setFifoPreviewError] = useState<string | null>(null);
 
   // React Hook Form
   const { register, handleSubmit: rhfSubmit, reset: resetForm, watch, setValue, formState: { errors, isDirty } } = useForm<CobroFormData>({
@@ -269,6 +286,8 @@ export default function CobranzaPage() {
 
   // When client changes in form, load their pending pedidos
   const watchedClienteId = watch('clienteId');
+  const watchedMonto = watch('monto');
+  const watchedModo = watch('modo');
 
   useEffect(() => {
     const loadPedidos = async () => {
@@ -285,6 +304,43 @@ export default function CobranzaPage() {
     };
     loadPedidos();
   }, [watchedClienteId]);
+
+  // 2026-06-09 PR 6: FIFO preview — calcula la distribución cada vez
+  // que cambia el monto / cliente, debounced 300ms. Limpia cuando el
+  // modo no es AbonoFifo o cuando faltan inputs.
+  useEffect(() => {
+    const modo = watchedModo ?? ModoCobro.PorPedido;
+    if (modo !== ModoCobro.AbonoFifo || !watchedClienteId || !watchedMonto || watchedMonto <= 0) {
+      setFifoPreview(null);
+      setFifoPreviewError(null);
+      setFifoPreviewLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setFifoPreviewLoading(true);
+      setFifoPreviewError(null);
+      try {
+        const resultado = await getFifoPreview(watchedClienteId, watchedMonto);
+        if (!cancelled) {
+          setFifoPreview(resultado);
+        }
+      } catch (error: any) {
+        if (!cancelled) {
+          setFifoPreviewError(error?.message || t('errorLoadingPayments'));
+          setFifoPreview(null);
+        }
+      } finally {
+        if (!cancelled) setFifoPreviewLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [watchedClienteId, watchedMonto, watchedModo, t]);
 
   // ─── Detail modal ───────────────────────────────────
 
@@ -1453,12 +1509,23 @@ export default function CobranzaPage() {
                 { value: ModoCobro.Anticipo, label: t('modes.advance.label'), hint: t('modes.advance.hint') },
               ].map(opt => {
                 const selected = (watch('modo') ?? ModoCobro.PorPedido) === opt.value;
+                // PR 6 plan gating: solo Anticipo es gateado por feature flag.
+                // Si el plan del tenant no lo incluye, deshabilitamos el boton
+                // y mostramos tooltip "Disponible en plan PRO" — el backend
+                // tambien rechaza con 403 FeatureNotInPlanException, esto es
+                // proactivo para evitar el roundtrip.
+                const isAnticipoDisabled =
+                  opt.value === ModoCobro.Anticipo && !permitirAnticiposEnCampo;
                 return (
                   <button
                     key={opt.value}
                     type="button"
                     data-testid={`cobro-modo-${opt.value}`}
+                    disabled={isAnticipoDisabled}
+                    title={isAnticipoDisabled ? t('modes.advance.disabledTooltip') : undefined}
+                    aria-disabled={isAnticipoDisabled}
                     onClick={() => {
+                      if (isAnticipoDisabled) return;
                       setValue('modo', opt.value, { shouldDirty: true });
                       // Reset pedidoId cuando NO es PorPedido — evita enviar pedidoId+modo incoherentes
                       if (opt.value !== ModoCobro.PorPedido) {
@@ -1466,9 +1533,11 @@ export default function CobranzaPage() {
                       }
                     }}
                     className={`text-left px-3 py-2 border rounded-md text-xs transition-colors ${
-                      selected
-                        ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/20 ring-1 ring-emerald-500'
-                        : 'border-border-default hover:border-emerald-300'
+                      isAnticipoDisabled
+                        ? 'border-amber-200 bg-amber-50/40 text-foreground/40 opacity-60 cursor-not-allowed dark:border-amber-900/30 dark:bg-amber-950/10'
+                        : selected
+                          ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/20 ring-1 ring-emerald-500'
+                          : 'border-border-default hover:border-emerald-300'
                     }`}
                   >
                     <div className="font-semibold">{opt.label}</div>
@@ -1586,6 +1655,47 @@ export default function CobranzaPage() {
               </select>
             </div>
           </div>
+          {/* 2026-06-09 PR 6 plan eager-drifting cobros: FIFO preview panel.
+              Solo visible cuando modo=AbonoFifo + cliente + monto > 0.
+              Mostrar al usuario la distribución calculada ANTES de submit. */}
+          {(watchedModo ?? ModoCobro.PorPedido) === ModoCobro.AbonoFifo && watchedClienteId > 0 && watchedMonto > 0 && (
+            <div data-testid="cobro-fifo-preview">
+              {fifoPreviewLoading && !fifoPreview && !fifoPreviewError && (
+                <div className="p-4 bg-surface-2 border border-border-subtle rounded-lg flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                  {t('modes.fifo.previewCalculating')}
+                </div>
+              )}
+              {fifoPreviewError && !fifoPreviewLoading && (
+                <div className="p-4 bg-red-50 border border-red-300 rounded-lg">
+                  <p className="text-xs text-red-600 font-medium">{fifoPreviewError}</p>
+                </div>
+              )}
+              {fifoPreview && fifoPreview.length > 0 && (
+                <div className="p-4 border border-green-300 bg-green-50/50 rounded-lg space-y-2">
+                  <div className="flex items-center gap-2 mb-2">
+                    <CheckCircle className="w-4 h-4 text-green-600" weight="fill" />
+                    <p className="text-xs font-semibold text-green-800">{t('modes.fifo.previewTitle')}</p>
+                  </div>
+                  <div className="space-y-1.5">
+                    {fifoPreview.map((app) => (
+                      <div key={app.pedidoId} className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">
+                          {app.numeroPedido}: <span className="font-medium text-foreground">{formatCurrency(app.montoAplicado)}</span>
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                  {fifoPreviewLoading && (
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground pt-1 border-t border-green-200">
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                      {t('modes.fifo.previewCalculating')}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           <div>
             <label className="block text-xs font-medium text-foreground/70 mb-1">{t('drawer.paymentDate')} *</label>
             <DateTimePicker

--- a/apps/web/src/app/(dashboard)/cobranza/page.tsx
+++ b/apps/web/src/app/(dashboard)/cobranza/page.tsx
@@ -326,9 +326,10 @@ export default function CobranzaPage() {
         if (!cancelled) {
           setFifoPreview(resultado);
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (!cancelled) {
-          setFifoPreviewError(error?.message || t('errorLoadingPayments'));
+          const msg = error instanceof Error ? error.message : t('errorLoadingPayments');
+          setFifoPreviewError(msg);
           setFifoPreview(null);
         }
       } finally {

--- a/apps/web/src/services/api/cobranza.ts
+++ b/apps/web/src/services/api/cobranza.ts
@@ -105,6 +105,18 @@ export interface CobroResumen {
   referencia: string | null;
 }
 
+/**
+ * 2026-06-09 PR 6 plan eager-drifting cobros (FIFO preview).
+ * Resultado del endpoint /cobros/fifo-preview — calculo SIN persistir.
+ * `cobroId` siempre es 0 en preview (no se ha creado).
+ */
+export interface FifoAplicacion {
+  cobroId: number;
+  pedidoId: number;
+  numeroPedido: string;
+  montoAplicado: number;
+}
+
 // ═══════════════════════════════════════════════════════
 // METODO PAGO OPTIONS
 // ═══════════════════════════════════════════════════════
@@ -199,6 +211,24 @@ export async function getEstadoCuenta(clienteId: number, historico = false): Pro
   try {
     const qs = historico ? '?historico=true' : '';
     const res = await api.get<EstadoCuenta>(`/cobros/cliente/${clienteId}/estado-cuenta${qs}`);
+    return res.data;
+  } catch (error) {
+    throw handleApiError(error);
+  }
+}
+
+/**
+ * 2026-06-09 PR 6: preview de la distribución FIFO sin persistir.
+ * Llama a POST /cobros/fifo-preview con { clienteId, monto } y retorna
+ * la lista de aplicaciones (PED-XXX → $monto) que se generarían si el
+ * usuario hiciera submit del cobro en modo AbonoFifo.
+ *
+ * Throws (con mensaje del backend) si el cliente no tiene pedidos
+ * abiertos o si el monto excede el saldo total pendiente.
+ */
+export async function getFifoPreview(clienteId: number, monto: number): Promise<FifoAplicacion[]> {
+  try {
+    const res = await api.post<FifoAplicacion[]>('/cobros/fifo-preview', { clienteId, monto });
     return res.data;
   } catch (error) {
     throw handleApiError(error);

--- a/apps/web/src/services/api/companyService.ts
+++ b/apps/web/src/services/api/companyService.ts
@@ -50,6 +50,11 @@ export interface CompanySettings {
   diasLaborables?: string | null; // CSV "1,2,3,4,5" (1=Lun..7=Dom)
   // Modo default de venta para mobile. "Preventa" | "VentaDirecta" | "Preguntar".
   modoVentaDefault?: string | null;
+  // PR 6 plan gating cobros: true si plan.permitir_anticipos_en_campo.
+  // Gateia el boton "Anticipo" del selector de modos en cobranza/page.tsx.
+  // Default false (fail-closed) si el backend omite el campo o el tenant esta
+  // en free trial sin plan asignado.
+  permitirAnticiposEnCampo?: boolean;
 }
 
 export interface UpdateGlobalSettingsRequest {

--- a/libs/HandySuites.Application/Cobranza/Interfaces/ICobroFifoAplicadorService.cs
+++ b/libs/HandySuites.Application/Cobranza/Interfaces/ICobroFifoAplicadorService.cs
@@ -31,6 +31,21 @@ public interface ICobroFifoAplicadorService
         DateTime? fechaCobro,
         string? referencia,
         string? notas);
+
+    /// <summary>
+    /// 2026-06-09 PR 6 plan eager-drifting cobros (FIFO preview).
+    /// Calcula la distribución FIFO SIN persistir en DB. Solo aplica la
+    /// lógica de cálculo + validación para que la UI pueda mostrar un
+    /// preview ("Aplicará $X a PED-001, $Y a PED-002 …") antes del submit.
+    ///
+    /// Throws si:
+    /// - Cliente no existe en el tenant actual.
+    /// - Cliente sin pedidos abiertos.
+    /// - Monto &gt; suma de saldos pendientes.
+    ///
+    /// Retorna lista con CobroId=0 (el preview no genera cobros).
+    /// </summary>
+    Task<List<FifoAplicacionDto>> CalcularSinPersistirAsync(int clienteId, decimal monto);
 }
 
 /// <summary>

--- a/libs/HandySuites.Application/Cobranza/Services/CobroFifoAplicadorService.cs
+++ b/libs/HandySuites.Application/Cobranza/Services/CobroFifoAplicadorService.cs
@@ -51,13 +51,47 @@ public class CobroFifoAplicadorService : ICobroFifoAplicadorService
         string? referencia,
         string? notas)
     {
+        // 2026-06-09 PR 6: la lógica de cálculo FIFO se extrajo a
+        // CalcularSinPersistirAsync para reuso del endpoint /cobros/fifo-preview.
+        // Aquí solo persistimos cada aplicación via _repo.CrearAsync.
+        var planeadas = await CalcularSinPersistirAsync(clienteId, monto);
+
+        var userId = int.Parse(_tenant.UserId);
+        var aplicaciones = new List<FifoAplicacionDto>(planeadas.Count);
+
+        foreach (var planeada in planeadas)
+        {
+            // Crea un cobro per-pedido con PedidoId asignado. El repo aplica
+            // advisory lock + overpayment guard. Modo=PorPedido (default OK).
+            var dto = new CobroCreateDto(
+                PedidoId: planeada.PedidoId,
+                ClienteId: clienteId,
+                Monto: planeada.MontoAplicado,
+                MetodoPago: metodoPago,
+                FechaCobro: fechaCobro,
+                Referencia: referencia,
+                Notas: notas != null ? $"{notas} (FIFO aplicacion)" : "Aplicacion FIFO");
+
+            var cobroId = await _repo.CrearAsync(dto, _tenant.TenantId, userId);
+            aplicaciones.Add(new FifoAplicacionDto(cobroId, planeada.PedidoId, planeada.NumeroPedido, planeada.MontoAplicado));
+
+            _logger.LogInformation(
+                "CobroFifoAplicador: aplicado {Aplicar} a pedido {PedidoId} ({Numero}) cliente {ClienteId}. CobroId={CobroId}.",
+                planeada.MontoAplicado, planeada.PedidoId, planeada.NumeroPedido, clienteId, cobroId);
+        }
+
+        return aplicaciones;
+    }
+
+    public async Task<List<FifoAplicacionDto>> CalcularSinPersistirAsync(int clienteId, decimal monto)
+    {
         if (monto <= 0)
             throw new InvalidOperationException("El monto debe ser mayor a cero.");
 
         var estadoCuenta = await _repo.ObtenerEstadoCuentaAsync(clienteId, _tenant.TenantId, historico: false);
         if (estadoCuenta == null)
         {
-            _logger.LogWarning("CobroFifoAplicador.DistribuirAsync: cliente {ClienteId} no existe en tenant {TenantId}", clienteId, _tenant.TenantId);
+            _logger.LogWarning("CobroFifoAplicador.CalcularSinPersistirAsync: cliente {ClienteId} no existe en tenant {TenantId}", clienteId, _tenant.TenantId);
             throw new InvalidOperationException("El cliente no existe o no pertenece a tu empresa.");
         }
 
@@ -70,7 +104,7 @@ public class CobroFifoAplicadorService : ICobroFifoAplicadorService
         if (pedidosAbiertos.Count == 0)
         {
             _logger.LogInformation(
-                "CobroFifoAplicador.DistribuirAsync: cliente {ClienteId} no tiene pedidos abiertos. Sugiere modo Anticipo.",
+                "CobroFifoAplicador.CalcularSinPersistirAsync: cliente {ClienteId} no tiene pedidos abiertos. Sugiere modo Anticipo.",
                 clienteId);
             throw new InvalidOperationException(
                 "El cliente no tiene pedidos pendientes para aplicar. Usa el modo 'Anticipo' si quieres registrar el cobro como saldo a favor.");
@@ -80,14 +114,14 @@ public class CobroFifoAplicadorService : ICobroFifoAplicadorService
         if (monto > saldoTotalCliente)
         {
             _logger.LogWarning(
-                "CobroFifoAplicador.DistribuirAsync: monto={Monto} excede saldo total cliente={Saldo} (cliente {ClienteId})",
+                "CobroFifoAplicador.CalcularSinPersistirAsync: monto={Monto} excede saldo total cliente={Saldo} (cliente {ClienteId})",
                 monto, saldoTotalCliente, clienteId);
             throw new InvalidOperationException(
                 $"El monto ({monto:C}) excede el saldo total pendiente del cliente ({saldoTotalCliente:C}). " +
                 $"Reduce el monto o usa el modo 'Anticipo' para la diferencia.");
         }
 
-        var userId = int.Parse(_tenant.UserId);
+        // Calcula la distribución FIFO sin tocar DB. CobroId=0 en preview.
         var aplicaciones = new List<FifoAplicacionDto>();
         var restante = monto;
 
@@ -96,25 +130,8 @@ public class CobroFifoAplicadorService : ICobroFifoAplicadorService
             if (restante <= 0) break;
 
             var aplicar = Math.Min(restante, pedido.Saldo);
-
-            // Crea un cobro per-pedido con PedidoId asignado. El repo aplica
-            // advisory lock + overpayment guard. Modo=PorPedido (default OK).
-            var dto = new CobroCreateDto(
-                PedidoId: pedido.PedidoId,
-                ClienteId: clienteId,
-                Monto: aplicar,
-                MetodoPago: metodoPago,
-                FechaCobro: fechaCobro,
-                Referencia: referencia,
-                Notas: notas != null ? $"{notas} (FIFO aplicacion)" : "Aplicacion FIFO");
-
-            var cobroId = await _repo.CrearAsync(dto, _tenant.TenantId, userId);
-            aplicaciones.Add(new FifoAplicacionDto(cobroId, pedido.PedidoId, pedido.NumeroPedido, aplicar));
+            aplicaciones.Add(new FifoAplicacionDto(0, pedido.PedidoId, pedido.NumeroPedido, aplicar));
             restante -= aplicar;
-
-            _logger.LogInformation(
-                "CobroFifoAplicador: aplicado {Aplicar} a pedido {PedidoId} ({Numero}) cliente {ClienteId}. CobroId={CobroId}. Restante={Restante}",
-                aplicar, pedido.PedidoId, pedido.NumeroPedido, clienteId, cobroId, restante);
         }
 
         return aplicaciones;

--- a/libs/HandySuites.Application/CompanySettings/DTOs/CompanySettingsDto.cs
+++ b/libs/HandySuites.Application/CompanySettings/DTOs/CompanySettingsDto.cs
@@ -82,6 +82,13 @@ namespace HandySuites.Application.CompanySettings.DTOs
         // Modo default de venta para mobile. "Preventa" | "VentaDirecta" | "Preguntar".
         [JsonPropertyName("modoVentaDefault")]
         public string ModoVentaDefault { get; set; } = "Preguntar";
+
+        // PR 6 plan gating cobros 3 modos (web): true si plan.permitir_anticipos_en_campo.
+        // Gateia el boton "Anticipo" del selector de modos en cobranza/page.tsx
+        // espejo del flag mobile en useEmpresa.ts. Default false (fail-closed)
+        // si el tenant esta en free trial sin plan o el endpoint omite el campo.
+        [JsonPropertyName("permitirAnticiposEnCampo")]
+        public bool PermitirAnticiposEnCampo { get; set; } = false;
     }
 
     public class UpdateCompanySettingsRequest


### PR DESCRIPTION
## Summary
Merge a `main` (production) los cambios del sprint cobros 3 modos validados en staging.

### Mobile (PR 5c)
- **registrar.tsx pedido picker**: tras elegir cliente en modo PorPedido, picker carga estado de cuenta y lista facturas con saldo>0. Empty state guia a Anticipo/FIFO si no hay pedidos. testIDs `cobro-pedido-picker-*` para Maestro.

### Backend (PR 6 FIFO preview + gating)
- `CobroFifoAplicadorService.CalcularSinPersistirAsync` extraido del Distribuir puro (sin DB writes).
- `POST /cobros/fifo-preview` con auth.
- `CompanySettingsDto.PermitirAnticiposEnCampo` (default false fail-closed) via `ISubscriptionFeatureGuard.HasFeatureAsync(tenantId, "anticipos_en_campo")`.

### Web (PR 6 + i18n)
- `cobranza/page.tsx` modo AbonoFifo dispara debounce 300ms a /cobros/fifo-preview y muestra distribucion.
- Anticipo button deshabilitado cuando `permitirAnticiposEnCampo!==true` + tooltip "Disponible en plan PRO".
- `messages es.json/en.json`: collections.modes.{fifo,advance}.* keys.

### Fix Vercel build
- `cobranza/page.tsx:329` catch `error: any` -> `error: unknown` + `instanceof Error` narrowing (resolvio ESLint @typescript-eslint/no-explicit-any que rompia npm run build).

## Test plan
- [x] **CI staging verde**: 6/6 checks (Backend Tests, Migrations, Vercel, Gitleaks, etc.) en merge commit 599350ed.
- [x] **Staging web Playwright vs `staging.handysuites.com`**:
  - login admin@jeyma.com -> dashboard 200
  - `/api/company/settings` retorna `permitirAnticiposEnCampo:true` (Jeyma PRO)
  - Selector 3 modos visible
  - Anticipo button enabled (PRO + flag)
  - FIFO preview: `VD-20260420-0001: $37.12 + VD-20260420-0004: $62.88 = $100`
  - POST `/cobros/fifo-preview` -> 200 body correcto
  - Anticipo modo warning visible
- [x] **APK staging (EAS build 04aa814a) en emulator**:
  - PR 5 selector 3 modos visible
  - PR 5c pedido picker lista 6+ pedidos abiertos con saldos correctos (mismos que staging web)
  - Cobro $50 a Esquina pedido VD-20260420-0004 registrado
  - Sync mobile->backend OK -> historial web staging muestra fila `09 jun 2026 | Abarrotes La Esquina | VD-20260420-0004 | $50`
- [ ] **Post-merge prod**: ejecutar SQL gating prod (ver Op note abajo)
- [ ] **Post-merge prod**: smoke test handysuites.com/cobranza

## Op note post-merge a main
Tras merge a `main` (Railway prod auto-deploy desde main), ejecutar contra Railway PG production (`trolley.proxy.rlwy.net:58561`):

```sql
UPDATE subscription_plans SET permitir_anticipos_en_campo = true WHERE codigo IN ('PRO','BUSINESS');
```

Sin esto, planes PRO en prod no podran usar modo Anticipo (backend 403 FeatureNotInPlanException). En staging ya esta aplicado (verificado: Jeyma PRO retorna flag true).

Backfill de cobros legacy NO se ejecuta (decision original: cobros pre-migration quedan modo=0 PorPedido por retrocompat).