### PR TITLE
chore(seed): incluir permitir_anticipos_en_campo en seed subscription_plans

### DIFF
--- a/infra/database/schema/seed_production.sql
+++ b/infra/database/schema/seed_production.sql
@@ -31,10 +31,10 @@ BEGIN;
 -- SECTION 1: SUBSCRIPTION PLANS
 -- =====================================================
 
-INSERT INTO subscription_plans (nombre, codigo, precio_mensual, precio_anual, max_usuarios, max_productos, max_clientes_por_mes, incluye_reportes, incluye_soporte_prioritario, caracteristicas, activo, orden) VALUES
-('Gratis', 'FREE', 0, 0, 2, 50, 20, false, false, '["Hasta 2 usuarios","50 productos","20 clientes"]'::jsonb, true, 1),
-('Basico', 'BASIC', 499, 4990, 5, 500, 100, true, false, '["Hasta 5 usuarios","500 productos","100 clientes","Reportes","25 timbres CFDI"]'::jsonb, true, 2),
-('Profesional', 'PRO', 999, 9990, 20, 5000, 500, true, true, '["Hasta 20 usuarios","5000 productos","500 clientes","Reportes avanzados","100 timbres CFDI","Asistente IA","Soporte prioritario"]'::jsonb, true, 3)
+INSERT INTO subscription_plans (nombre, codigo, precio_mensual, precio_anual, max_usuarios, max_productos, max_clientes_por_mes, incluye_reportes, incluye_soporte_prioritario, permitir_anticipos_en_campo, caracteristicas, activo, orden) VALUES
+('Gratis', 'FREE', 0, 0, 2, 50, 20, false, false, false, '["Hasta 2 usuarios","50 productos","20 clientes"]'::jsonb, true, 1),
+('Basico', 'BASIC', 499, 4990, 5, 500, 100, true, false, false, '["Hasta 5 usuarios","500 productos","100 clientes","Reportes","25 timbres CFDI"]'::jsonb, true, 2),
+('Profesional', 'PRO', 999, 9990, 20, 5000, 500, true, true, true, '["Hasta 20 usuarios","5000 productos","500 clientes","Reportes avanzados","100 timbres CFDI","Asistente IA","Soporte prioritario","Cobros en campo: Anticipo + FIFO"]'::jsonb, true, 3)
 ON CONFLICT DO NOTHING;
 
 -- =====================================================


### PR DESCRIPTION
## Summary
Fresh installs heredaban `permitir_anticipos_en_campo=false` por default porque la columna no estaba en el INSERT del seed. Un tenant nuevo en plan PRO no podria usar Anticipo hasta UPDATE manual.

**Cambio**:
- FREE / BASIC: `false` explicito (no incluye Anticipo)
- PRO: `true` + agregado "Cobros en campo: Anticipo + FIFO" al array `caracteristicas`

## Test plan
- [x] Verificado vs prod actual: PRO ya tiene flag=true (idempotent vs seed cambio, no impacta running instances)
- [ ] CI: detect-changed-services + tests (sin cambios de codigo, solo SQL seed)
- [ ] Cualquier instalacion clean futura recibira el flag correcto sin intervencion manual

## Out of scope
No toca: prod actual (idempotent), staging (mismo idempotent), ninguna migration.

Aplica solo a `infra/database/schema/seed_production.sql` que se ejecuta una vez al levantar instancia clean.
